### PR TITLE
If no base is given, read it from the LOAD segment

### DIFF
--- a/pwn/dynelf.py
+++ b/pwn/dynelf.py
@@ -23,6 +23,11 @@ class DynELF:
             self.elf = path
         else:
             self.elf = pwn.elf.load(path)
+        if base == None and not PIE:
+            for segment in self.elf.segments:
+                if segment['type'] == 'LOAD' and segment['offset'] == 0:
+                    base = segment['virtaddr']
+                    break
         self.leak = leak
         self.base = base
         self.PIE = PIE


### PR DESCRIPTION
The DynELF class can't leak anything without a base.
But if the executable is no PIE, we can just read the base address from the LOAD segment with offset 0.
