### PR TITLE
Fix shebang

### DIFF
--- a/asm/asm
+++ b/asm/asm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import argparse, tempfile, sys, subprocess, os, pwn
 
 default_context = ['linux', 'i386']

--- a/asm/disasm
+++ b/asm/disasm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse, sys, readline, pwn, re
 

--- a/clookup/clookup
+++ b/clookup/clookup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import argparse, pwn, string
 
 default_context = ['linux', 'i386']

--- a/cyclic/cyclic
+++ b/cyclic/cyclic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import pwn, sys, argparse, string
 from pwn import de_bruijn, de_bruijn_find
 

--- a/dictgen/dictgen
+++ b/dictgen/dictgen
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os, warnings
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 

--- a/elfpatch/elfpatch
+++ b/elfpatch/elfpatch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import pwn, sys, argparse, string
 
 if __name__ == "__main__":

--- a/hex/hex
+++ b/hex/hex
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from binascii import hexlify
 import sys
 

--- a/hex/unhex
+++ b/hex/unhex
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from binascii import unhexlify
 import sys, re
 

--- a/nops/nops
+++ b/nops/nops
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import pwn
 

--- a/pbpoke/pbpeek.py
+++ b/pbpoke/pbpeek.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from pwn import b64d, write
 import json, sys
 

--- a/pbpoke/pbpoke.py
+++ b/pbpoke/pbpoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from pwn import b64, read, unhex
 import json, sys
 

--- a/pltfixup/pltfixup
+++ b/pltfixup/pltfixup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import pwn, sys, os, argparse
 
 default = [

--- a/pltlist/pltlist
+++ b/pltlist/pltlist
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import pwn, sys
 
 if __name__ == "__main__":

--- a/poke/peek
+++ b/poke/peek
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import pwn, sys, hashlib
 import pwn.log as log
 

--- a/poke/poke
+++ b/poke/poke
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import pwn, sys, hashlib, os, socket, errno
 import pwn.log as log
 

--- a/pwn/test/attach/demo.py
+++ b/pwn/test/attach/demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Pwnies workshop server level 1
 

--- a/pwn/test/bin300/doit_aeropics.py
+++ b/pwn/test/bin300/doit_aeropics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from pwn import *
 context('i386', 'linux', 'ipv4')
 

--- a/pwn/test/demo.py
+++ b/pwn/test/demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Pwnies workshop server level 1
 

--- a/pwn/test/demo_findpeer.py
+++ b/pwn/test/demo_findpeer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Pwnies workshop server level 1
 

--- a/pwn/test/demo_findtag.py
+++ b/pwn/test/demo_findtag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Pwnies workshop server level 1
 

--- a/pwn/test/leaky/resolve.py
+++ b/pwn/test/leaky/resolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import pwn
 import sys

--- a/randomua/randomua
+++ b/randomua/randomua
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 from pwn.useragents import randomua
 

--- a/scramble/scramble
+++ b/scramble/scramble
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import pwn
 pwn.context('i386')

--- a/shellcraft/shellcraft
+++ b/shellcraft/shellcraft
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import argparse, sys, pwn, os
 from pwn.internal.shellcode_helper import registered as shellcodes
 default_context = ['linux', 'i386', 'ipv4']

--- a/shoehorn/shoehorn
+++ b/shoehorn/shoehorn
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os, re, tempfile, subprocess
 
 READELF = '/usr/bin/readelf'


### PR DESCRIPTION
Fixes the shebang on a few files.  If no system Python is installed (e.g. only with `pyenv`), or it's installed in `/usr/local`, these scripts don't work.
