### PR TITLE
Use -o switch for cpp output

### DIFF
--- a/pwn/asm.py
+++ b/pwn/asm.py
@@ -149,7 +149,7 @@ def _asm(target_arch, target_os, code_blocks, emit_asm = 0, keep_tmp = False):
             return '\n'.join(output)
 
         pwn.write(path('step1'), code)
-        _run(cpp + [path('step1'), path('step2')])
+        _run(cpp + [path('step1'), '-o', path('step2')])
         code = pwn.read(path('step2'))
 
         _code = code.split('\n' + magic + '\n')


### PR DESCRIPTION
Use -o switch for cpp output. Clang `cpp` doesn't default to using second argument as output.

This is compatible with gcc `cpp`.
