### PR TITLE
Disable memoizing asm output

### DIFF
--- a/pwn/asm.py
+++ b/pwn/asm.py
@@ -66,7 +66,6 @@ def _run(cmd):
             err += 'It had this on stdout:\n%s\n' % stderr
         raise Exception(err)
 
-@pwn.memoize
 def _asm(target_arch, target_os, code_blocks, emit_asm = 0, keep_tmp = False):
     import pwn.internal.shellcode_helper as H
     import os.path, tempfile, subprocess, string, shutil


### PR DESCRIPTION
Disable memoizing `asm` output. Not sure why this was done, doesn't seem like it would be a huge performance hit/saver vs. a headache for those who don't expect it when making development changes.
