### PR TITLE
Add elf-dump utility

### DIFF
--- a/bin/elfdump
+++ b/bin/elfdump
@@ -1,0 +1,1 @@
+../elfpatch/elfdump

--- a/elfpatch/elfdump
+++ b/elfpatch/elfdump
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import pwn, sys, argparse, string
+from subprocess import check_output
+p = argparse.ArgumentParser(description="ELF disassembly dumper")
+p.add_argument('file',
+               metavar = '<file>',
+               help = 'ELF file to patch',
+               )
+args = p.parse_args()
+elf  = pwn.ELF(args.file, silent=True)
+
+for name, data in elf.sections.items():
+  if 'X' not in data['flags']: continue
+
+  file_off = data['offset']
+  mem_off  = data['addr']
+  print check_output(['objdump',
+                      '--file-offsets',
+                      '--disassemble',
+                      '--demangle',
+                      '--section', name,
+                      '--wide',
+                      '--adjust-vma', str(file_off - mem_off),
+                      args.file])

--- a/pwn/elf.py
+++ b/pwn/elf.py
@@ -33,13 +33,14 @@ class ELF:
     '''A parsed ELF file'''
 
     __cache = {}
-    def __init__(self, path):
+    def __init__(self, path, silent=False):
         import os, re
         path = os.path.realpath(path)
         if path in ELF.__cache:
             pwn.log.warning('Loaded "%s" again; use "elf.load(...)" to avoid this' \
                             % os.path.basename(path))
-        pwn.log.waitfor('Loading ELF file `%s\'' % os.path.basename(path))
+        if not silent:
+            pwn.log.waitfor('Loading ELF file `%s\'' % os.path.basename(path))
         self.segments = []
         self.sections = {}
         self.symbols = {}


### PR DESCRIPTION
Adds an `elf-dump` utility that basically wraps `objdump` to print out file offsets for disassembled instructions.  Makes patching with things other than `elf-patch` easier.

```
$ objdump -d lateot | grep fork
080489ac <fork@plt>:
 80496a9:       e8 fe f2 ff ff          call   80489ac <fork@plt>
$ elfdump lateot | grep fork
000009ac <fork@plt> (File Offset: 0x9ac):
    16a9:       e8 fe f2 ff ff          call   9ac <fork@plt> (File Offset: 0x9ac)
$ xxd  -l5 -s $((0x16a9)) lateot
00016a9: e8fe f2ff ff                             .....
```
