### PR TITLE
Single point for ldd, make ELF.libs and SSH.libs return consistent output

### DIFF
--- a/pwnlib/elf.py
+++ b/pwnlib/elf.py
@@ -1,6 +1,7 @@
 """Exposes functionality for manipulating ELF files
 """
 from . import log
+from .util.misc import ldd
 import mmap, subprocess
 from os.path import abspath
 from elftools.elf.elffile import ELFFile
@@ -389,31 +390,3 @@ class ELF(ELFFile):
         data = self.stream.read(self.stream.size())
         self.stream.seek(old)
         return data
-
-
-
-def ldd(path):
-    """Effectively runs 'ldd' on the specified binary, captures the output,
-    and parses it.  Returns a dictionary of {path: address} for
-    each library required by the specified binary.
-
-    Args:
-      path(str): Path to the binary
-
-    Example:
-        >>> ldd('/bin/bash').keys()
-        ['/lib/x86_64-linux-gnu/libc.so.6', '/lib/x86_64-linux-gnu/libtinfo.so.5', '/lib/x86_64-linux-gnu/libdl.so.2']
-    """
-    import re
-    expr = re.compile(r'\s(\S?/\S+)\s+\((0x.+)\)')
-    libs = {}
-
-    output = subprocess.check_output([path], env={'LD_TRACE_LOADED_OBJECTS':'1'}).strip().splitlines()
-    output = map(str.strip, output)
-    output = map(expr.search, output)
-
-    for match in filter(None, output):
-        lib, addr = match.groups()
-        libs[lib] = int(addr,16)
-
-    return libs


### PR DESCRIPTION
Single point of code for `ldd`, make ELF.libs and SSH.libs return consistent output of `{full local path: ldd address}`

Moved `pwn.elf.ldd` to `pwn.utils.misc` to replace `pwn.utils.misc.parse_ldd_output`.

This is a diversion from the legacy output of `ssh.libs`, which returned a dict of `{soname: full local path}`.

``` python
>>> from pwn import *

>>> ELF('/bin/bash').libs
{'/lib/x86_64-linux-gnu/libc.so.6': 140737345654784,
 '/lib/x86_64-linux-gnu/libdl.so.2': 140737349615616,
 '/lib/x86_64-linux-gnu/libtinfo.so.5': 140737351729152}

>>> ssh(host='vortex.labs.overthewire.org',user='vortex1',password='Gq#qu3bF3').libs('/bin/bash')
{'/home/user/pwntools/vortex.labs.overthewire.org/lib/x86_64-linux-gnu/libc.so.6': 140737345781760,
 '/home/user/pwntools/vortex.labs.overthewire.org/lib/x86_64-linux-gnu/libdl.so.2': 140737349718016,
 '/home/user/pwntools/vortex.labs.overthewire.org/lib/x86_64-linux-gnu/libtinfo.so.5': 140737351831552}
```

It also works for BSD without warnings (I'd previously contributed a [work-around](https://github.com/Gallopsled/pwntools/pull/32/files#diff-1) for `parse_ldd_output`).

``` py
>>> from pwn import *
>>> shell=ssh(host='bsd.binjit.su',user='user')
>>> shell.run_to_end('uname -a')
('FreeBSD bsd.binjit.su 10.0-RELEASE FreeBSD 10.0-RELEASE #0 r260789: Fri Jan 17 01:46:25 UTC 2014     root@snap.freebsd.org:/usr/obj/usr/src/sys/GENERIC  i386\n', 0)
>>> shell.libs('/usr/local/bin/bash')
{'/home/user/pwntools/bsd.binjit.su/usr/local/lib/libintl.so.9': 672493568,
 '/home/user/pwntools/bsd.binjit.su/lib/libncurses.so.8': 672247808,
 '/home/user/pwntools/bsd.binjit.su/lib/libc.so.7': 672530432}
```
