### PR TITLE
Add <> for tubes, fix typo

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -373,9 +373,12 @@ class tube(object):
         self.connect_input(other)
         return other
 
-    def __rshift(self, other):
+    def __rshift__(self, other):
         self.connect_output(other)
         return other
+
+    def __ne__(self, other):
+        self << other << self
 
     def wait(self):
         """Waits until the socket is closed."""


### PR DESCRIPTION
``` python
from pwn import *
shell  = ssh(host='vortex.labs.overthewire.org',user='vortex1',password='Gq#qu3bF3')
bash   = shell.shell()
client = listen(1337)
client <> bash
```

``` shell
$ nc localhost 1337
vortex1@melinda:~$ 
```
