### PR TITLE
ssh.foo and ssh['foo'] were accidentally silcening output from commands

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -385,7 +385,7 @@ class ssh(object):
             else:
                 command = ' '.join((attr,) + args)
 
-            return self.run_to_end(command)[0].strip()
+            return self.run(command, log_level=self.log_level).recvall().strip()
         return runner
 
     def connected(self):


### PR DESCRIPTION
`ssh.foo` and `ssh['foo']` were accidentally silcening output from commands (e.g. 'opening new channel', 'receiving all data')

```
[+] Connecting to bandit.labs.overthewire.org on port 22: OK
[+] Opening new channel: 'whoami': OK
[+] Recieving all data: OK
[*] username: bandit0
```

vs.

```
[+] Connecting to bandit.labs.overthewire.org on port 22: OK
[*] username: bandit0
```
