### PR TITLE
Filter a few things which should not spawn SSH commands

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -378,14 +378,13 @@ class ssh(object):
         """
         bad_attrs = [
             'trait_names',          # ipython tab-complete
-            '_getAttributeNames',   # ipython tab-complete
             'download',             # frequent typo
             'upload',               # frequent typo
         ]
 
         if attr in self.__dict__ \
         or attr in bad_attrs \
-        or attr.startswith('__'):
+        or attr.startswith('_'):
             raise AttributeError
 
         def runner(*args):


### PR DESCRIPTION
When working in IPython interactively, attempting to tab-complete on a `ssh` object causes several sessions to kick off.  Additionally, I keep typo'ing `upload` and `download` (vs. the `_file` variants).

Filter out these few specific things.
