### PR TITLE
GDB resolution for modules

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -209,15 +209,15 @@ def find_module_addresses(binary, ssh=None, ulimit=False):
         0xf7e26f10  0xf7f5b51c  Yes (*)     /lib32/libc.so.6
         (*): Shared library is missing debugging information.
 
-    However, do not that these are the addresses of the '.text' segments.
-    You need to adjust for the base of the image.
+    Note that the raw addresses provided by ``info sharedlibrary`` are actually
+    the address of the ``.text`` segment, not the image base address.
 
     This routine automates the entire process of:
 
     1. Downloading the binaries from the remote server
     2. Scraping GDB for the information
     3. Loading each library into an ELF
-    4. Fixing up the base address
+    4. Fixing up the base address vs. the ``.text`` segment address
 
     Args:
         binary(str): Path to the binary on the remote server


### PR DESCRIPTION
So the general criticism for the "ldd" approach is that it's inaccurate, and doesn't give us real base addresses.  I agree, and generally resort to pulling things manually out of GDB.

This PR automates the process.

_N.B._: This PR requires #59.

```
from pwn import *
shell = ssh(host='bandit.labs.overthewire.org',user='bandit0',password='bandit0')
libs = gdb.find_module_addresses(shell, '/bin/bash')
hex(libs[0].symbols['mmap'])
# '0x7ffff76df7a0'
```

Compare to:

```
(gdb) p/x &mmap
$2 = 0x7ffff76df7a0
```
