### PR TITLE
FreeBSD .so are not recognized as shared objects, so ldd throws an error...

### DIFF
--- a/pwnlib/elf.py
+++ b/pwnlib/elf.py
@@ -157,10 +157,10 @@ class ELF(ELFFile):
         >>> any(map(lambda x: 'libc' in x, bash.libs.keys()))
         True
         """
-        if self.elftype != 'DYN':
+        try:
             data = subprocess.check_output('ulimit -s unlimited; ldd ' + misc.sh_string(self.path), shell = True)
             self.libs = misc.parse_ldd_output(data)
-        else:
+        except:
             self.libs = {}
 
     def _populate_symbols(self):


### PR DESCRIPTION
Since there's not really a need to check the dependencies of an .so (use-case is we loaded all the deps from an exe via ldd), don't do it.
