### PR TITLE
easy rop gadget notation

### DIFF
--- a/pwnlib/rop.py
+++ b/pwnlib/rop.py
@@ -118,7 +118,10 @@ class ROP(object):
         """Clear the ROP chain"""
         self._chain = []
 
-    flush = clear # alias
+    def flush(self):
+        f = self.chain()
+        self.clear()
+        return f
 
     def dump(self):
         """Dump the ROP chain in an easy-to-read manner"""


### PR DESCRIPTION
Sometimes you just need that one specific ROP gadget.  It's a pain to insert hardcoded addresses, and a list comprehension/`filter` to search for it on `rop.gadgets` is aslo a pain.

You can do this now:

``` py
from pwn import *
>>> bash = ELF('/bin/bash')
>>> rop  = ROP([bash])
>>> rop.ret
(4195235L, {'insns': ['ret'], 'move': 8, 'regs': []})
>>> rop.rdi
(4319593L, {'insns': ['pop rdi', 'ret'], 'move': 16, 'regs': ['rdi']})
>>> rop.ret_24
(4383087L, {'insns': ['add rsp, 0x18', 'ret'], 'move': 32, 'regs': []})
>>> rop.r13_r14_r15_rbp
(4511728L,
 {'insns': ['pop r13', 'pop r14', 'pop r15', 'pop rbp', 'ret'],
  'move': 40,
  'regs': ['r13', 'r14', 'r15', 'rbp']})
```
