### PR TITLE
Add pwnlib.elf.ELF.bss()

### DIFF
--- a/pwnlib/elf.py
+++ b/pwnlib/elf.py
@@ -421,3 +421,9 @@ class ELF(ELFFile):
         The resulting binary can be saved with ELF.save()
         """
         self.write(address, asm.asm(assembly))
+
+    def bss(self, offset):
+        """Returns an index into the .bss segment"""
+        orig_bss = self.get_section_by_name('.bss').header.sh_addr
+        curr_bss = orig_bss - self.load_addr + self.address
+        return curr_bss + offset


### PR DESCRIPTION
```
In [1]: from pwn import *

In [2]: bash = ELF('/bin/bash')

In [3]: print hex(bash.bss(0))
0x6f7cc0
```

IDA says:

```
.bss:00000000006F7CC0                         _bss            segment para public 'BSS' use64
```
