### PR TITLE
Bugfix: ssh.run(tuple) => error

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -14,7 +14,7 @@ class ssh_channel(sock.sock):
 
         env = env or {}
 
-        h = log.waitfor('Opening new channel: %r' % (process or 'shell'), log_level = self.log_level)
+        h = log.waitfor('Opening new channel: %r' % ((process,) or 'shell'), log_level = self.log_level)
 
         if isinstance(process, (list, tuple)):
             process = ' '.join(misc.sh_string(s) for s in process)


### PR DESCRIPTION
Otherwise throws this

```
  File "/home/user/pwntools/pwnlib/tubes/ssh.py", line 17, in __init__
    h = log.waitfor('Opening new channel: %r' % (process or 'shell'), log_level = self.log_level)
TypeError: not all arguments converted during string formatting
```
