### PR TITLE
elfdiff

### DIFF
--- a/bin/elfdiff
+++ b/bin/elfdiff
@@ -1,0 +1,24 @@
+#!/usr/bin/env python2
+from argparse import ArgumentParser
+from subprocess import check_output, CalledProcessError
+from tempfile import NamedTemporaryFile
+
+def dump(x):
+	n = NamedTemporaryFile(delete=False)
+	o = check_output(['objdump','-d','-x','-s',x])
+	n.write(o)
+	n.flush()
+	return n.name
+
+def diff(a,b):
+	try: return check_output(['diff',a,b])
+	except CalledProcessError as e:
+		return e.output
+
+
+p = ArgumentParser()
+p.add_argument('a')
+p.add_argument('b')
+a = p.parse_args()
+
+print diff(dump(a.a), dump(a.b))


### PR DESCRIPTION
After patching some NOPs into `/bin/bash`

```
$ elfdiff /bin/bash mybash
2,3c2,3
< /bin/bash:     file format elf64-x86-64
< /bin/bash

---
> mybash:     file format elf64-x86-64
> mybash
7702c7702
<  41dac0 ff251a18 2d006859 000000e9 50faffff  .%..-.hY....P...

---
>  41dac0 90909090 90006859 000000e9 50faffff  ......hY....P...
63991,63993c63991,64002
<   41dac0:     ff 25 1a 18 2d 00       jmpq   *0x2d181a(%rip)        # 6ef2e0 <_rl_possible_control_prefixes+0x21c9c0>
<   41dac6:     68 59 00 00 00          pushq  $0x59
<   41dacb:     e9 50 fa ff ff          jmpq   41d520 <_init+0x20>

---
>   41dac0:     90                      nop
>   41dac1:     90                      nop
>   41dac2:     90                      nop
>   41dac3:     90                      nop
>   41dac4:     90                      nop
>   41dac5:     00 68 59                add    %ch,0x59(%rax)
>   41dac8:     00 00                   add    %al,(%rax)
>   41daca:     00 e9                   add    %ch,%cl
>   41dacc:     50                      push   %rax
>   41dacd:     fa                      cli    
>   41dace:     ff                      (bad)  
>   41dacf:     ff                      (bad)  
```
