### PR TITLE
elf.asm now uses "org" directive for correct relative jumps

### DIFF
--- a/pwnlib/elf.py
+++ b/pwnlib/elf.py
@@ -428,7 +428,8 @@ class ELF(ELFFile):
 
         The resulting binary can be saved with ELF.save()
         """
-        self.write(address, asm.asm(assembly))
+        binary = asm.asm(('org %#x\n' % address) + assembly)
+        self.write(address, binary)
 
     def bss(self, offset):
         """Returns an index into the .bss segment"""


### PR DESCRIPTION
```
In [5]: asm('''
   ...: org 0x1000
   ...: call 0x1005
   ...: ''')
Out[5]: '\xe8\x00\x00\x00\x00'
```
