### PR TITLE
Catch invalid characters early in cyclic_find()

### DIFF
--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -96,8 +96,8 @@ def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = None):
       >>> cyclic_find(cyclic(1000)[514:518])
       514
     """
-    if not all(map(alphabet.__contains__, subseq)):
-      return -1
+    if any(c not in alphabet for c in subseq):
+        return -1
 
     if isinstance(subseq, (int, long)):
         width = n * 8 or 'all'


### PR DESCRIPTION
Catch invalid characters early in cyclic_find().  Sometimes I forget to `unhex()` the data, and it searches forever for eight bytes of irrelevant data.

Without this patch, the following will hang ~forever.

``` python
not_in_alphabet = '61616161'
cyclic_find(not_in_alphabet)
```
