### PR TITLE
acceptor => accepter

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -240,7 +240,7 @@ class ssh_listener(sock.sock):
 
     def __getattr__(self, key):
         if key == 'sock':
-            while self._acceptor.is_alive():
+            while self._accepter.is_alive():
                 self._accepter.join(timeout = 0.1)
             return self.sock
         else:


### PR DESCRIPTION
There's a typo that currently breaks `ssh.listen_remote(12345).wait_for_connection()`
