### PR TITLE
ELF PLT Symbol Fix

### DIFF
--- a/pwnlib/elf.py
+++ b/pwnlib/elf.py
@@ -243,7 +243,7 @@ class ELF(ELFFile):
         multiplier = None
 
         # Map architecture: offset, multiplier
-        offset, multiplier = {
+        header_size, entry_size = {
             'x86':   (0x10, 0x10),
             'amd64': (0x10, 0x10),
             'arm':   (0x14, 0xC)
@@ -252,7 +252,7 @@ class ELF(ELFFile):
 
         # Based on the ordering of the GOT symbols, populate the PLT
         for i,(addr,name) in enumerate(sorted((addr,name) for name, addr in self.got.items())):
-            self.plt[name] = plt.header.sh_addr + offset +  i*multiplier
+            self.plt[name] = plt.header.sh_addr + header_size + i*entry_size
 
     def search(self, needle, writable = False):
         """search(needle, writable = False) -> str generator


### PR DESCRIPTION
This fixes some issues encountered by the PLT parsing in the past.  It is by no means foolproof, and there are probably lots of examples this doesn't work for.  However, it works for more binaries than it used to.

All of the binaries I've tested this against which used to work, still work.

All of the binaries I've tested this against which did not work, were used as guidelines for this, and now work correctly.
