### PR TITLE
Add plt.XXXX and got.XXXX symbols so that rop.dump() output is better

### DIFF
--- a/pwnlib/elf.py
+++ b/pwnlib/elf.py
@@ -189,6 +189,17 @@ class ELF(ELFFile):
 
                 self.symbols[symbol.name] = symbol.entry.st_value
 
+        # Add 'plt.foo' and 'got.foo' to the symbols for entries,
+        # iff there is no symbol for that address
+        for sym, addr in self.plt.items():
+            if addr not in self.symbols.values():
+                self.symbols['plt.%s' % sym] = addr
+
+        for sym, addr in self.got.items():
+            if addr not in self.symbols.values():
+                self.symbols['got.%s' % sym] = addr
+
+
     def _populate_got_plt(self):
         """Loads the GOT and the PLT symbols and addresses.
 


### PR DESCRIPTION
Specifically this is to enhance `ROP.dump`.  `got.read` is not printed in the example below without this.

```
>>> rop1 = ROP(rex)
>>> rop1.call(rex.plt['write'], [1, rex.got['read'], 4])
>>> rop1.call(0x80483F4)
>>> print '\n'.join(rop1.dump())
    0x0000:        0x80482f4 (write)
    0x0004:        0x80483f4
    0x0008:              0x1
    0x000c:        0x804961c (got.read)
    0x0010:              0x4
```
