### PR TITLE
Add status message for "listening" to expressly print out port

### DIFF
--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -66,7 +66,7 @@ class listen(sock.sock):
 
         h.success()
 
-        h = log.waitfor('Waiting')
+        h = log.waitfor('Waiting for connections on %s:%s' % (self.lhost, self.lport))
 
         def accepter():
             while True:


### PR DESCRIPTION
### Old:

```
[*] Trying to bind to 0.0.0.0 on port 0...
[*] Trying to bind to 0.0.0.0 on port 0: Trying 0.0.0.0
[+] Trying to bind to 0.0.0.0 on port 0: OK
[*] Waiting
```
### New

```
[*] Trying to bind to 0.0.0.0 on port 0...
[*] Trying to bind to 0.0.0.0 on port 0: Trying 0.0.0.0
[+] Trying to bind to 0.0.0.0 on port 0: OK
[*] Waiting for connections on 0.0.0.0:35224...
```
