### PR TITLE
Clean up tubes on process exit

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -18,11 +18,12 @@ def _fix_timeout(timeout, default):
 class tube(object):
     """Container of all the tube functions common to both sockets, TTYs and SSH connetions."""
 
-    def __init__(self, timeout):
+    def __init__(self, timeout, auto_close=True):
         self.buffer          = []
         self.timeout         = _fix_timeout(timeout, context.timeout)
 
-        atexit.register(self.close)
+        if auto_close:
+            atexit.register(self.close)
 
     # Functions based on functions from subclasses
     def recv(self, numb = 4096, timeout = 'default'):


### PR DESCRIPTION
Very frequently, I'll take a look at `ps`/`top`/`htop` and see a billion shells and various `stdin`-driven binaries still running in the background.

This happens because they're spawned, and I don't bother to call `close()` on them when I'm done.  While this can be taken care of in a `with` block, it's a bit cumbersome to always remember to do (and in my opinion, messes up an otherwise pretty exploit).

This patch automatically closes all tubes when the process exits for any reason.  While this will have little to no effect on some tubes (e.g. `sock`, `ssh`, `listen`) it is useful for `process` and may as well be the default behavior for all tubes.

```
$ python -c 'from pwn import *; process("/bin/sh");'
[+] Started program '/bin/sh'
[*] Stopped program '/bin/sh'
```

```
$ python -c 'from pwn import *; process("/bin/sh"); exit();'
[+] Started program '/bin/sh'
[*] Stopped program '/bin/sh'
```

```
python -c 'from pwn import *; process("/bin/sh"); time.sleep(10);'
[+] Started program '/bin/sh'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
KeyboardInterrupt
[*] Program '/bin/sh' stopped with exit code -2
```

```
$ python -c 'from pwn import *; process("/bin/sh"); raise Exception;'
[+] Started program '/bin/sh'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
Exception
[*] Stopped program '/bin/sh'
```
