### PR TITLE
Permit chaining of `shellcraft`

### DIFF
--- a/bin/shellcraft
+++ b/bin/shellcraft
@@ -84,12 +84,19 @@ p.add_argument(
                'h', 'hex',
                'a', 'asm', 'assembly',
                'p',
-               'i', 'hexii'],
-    default = 'hex',
+               'i', 'hexii',
+               'default'],
+    default = 'default',
     help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code',
 )
 
 args = p.parse_args()
+
+if args.format == 'default':
+    if sys.stdout.isatty():
+        args.format = 'hex'
+    else:
+        args.format = 'raw'
 
 def get_tree(path, val, result):
     if path:


### PR DESCRIPTION
Auto-detect output format based on whether the output fd is tty or not.

If stdin is not a tty, prepend all data from stdin.

```
$ shellcraft i386.linux.setreuid | shellcraft i386.linux.dup 4 | shellcraft i386.linux.sh | phd                                              
00000000  6a 31 58 cd  80 89 c3 89  c1 6a 46 58  cd 80 bb 04  │j1X⋅│⋅⋅⋅⋅│⋅jFX│⋅⋅⋅⋅│
00000010  00 00 00 6a  03 59 49 6a  3f 58 cd 80  75 f8 31 c9  │⋅⋅⋅j│⋅YIj│?X⋅⋅│u⋅1⋅│
00000020  f7 e9 6a 01  fe 0c 24 68  2f 2f 73 68  68 2f 62 69  │⋅⋅j⋅│⋅⋅$h│//sh│h/bi│
00000030  6e b0 0b 89  e3 cd 80                               │n⋅⋅⋅│⋅⋅⋅│
00000037
```

```
$ shellcraft i386.linux.setreuid | shellcraft i386.linux.dup 4 | shellcraft i386.linux.sh | disasm
   0:   6a 31                   push   0x31
   2:   58                      pop    eax
   3:   cd 80                   int    0x80
   5:   89 c3                   mov    ebx,eax
   7:   89 c1                   mov    ecx,eax
   9:   6a 46                   push   0x46
   b:   58                      pop    eax
   c:   cd 80                   int    0x80
   e:   bb 04 00 00 00          mov    ebx,0x4
  13:   6a 03                   push   0x3
  15:   59                      pop    ecx
  16:   49                      dec    ecx
  17:   6a 3f                   push   0x3f
  19:   58                      pop    eax
  1a:   cd 80                   int    0x80
  1c:   75 f8                   jne    0x16
  1e:   31 c9                   xor    ecx,ecx
  20:   f7 e9                   imul   ecx
  22:   6a 01                   push   0x1
  24:   fe 0c 24                dec    BYTE PTR [esp]
  27:   68 2f 2f 73 68          push   0x68732f2f
  2c:   68 2f 62 69 6e          push   0x6e69622f
  31:   b0 0b                   mov    al,0xb
  33:   89 e3                   mov    ebx,esp
  35:   cd 80                   int    0x80
```
