### PR TITLE
Cyclic should only emit a newline when writing to a TTY

### DIFF
--- a/bin/cyclic
+++ b/bin/cyclic
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-import argparse, string
+import argparse, string, sys
 from pwnlib.util import cyclic, packing
 from pwnlib import log
 
@@ -67,4 +67,8 @@ else:
     got    = len(result)
     if got < want:
         log.failure("Alphabet too small (max length = %i)" % got)
-    print result
+
+    sys.stdout.write(result)
+
+    if sys.stdout.isatty():
+        sys.stdout.write('\n')


### PR DESCRIPTION
Otherwise this messes up prototyping on the command line.
## New

```
$ cyclic 10
aaaabaaaca
$ cyclic 10 | phd
00000000  61 61 61 61  62 61 61 61  63 61                     │aaaa│baaa│ca│
0000000a
```
## Old

```
$ cyclic 10 | phd
00000000  61 61 61 61  62 61 61 61  63 61 0a                  │aaaa│baaa│ca⋅│
0000000b
```
