### PR TITLE
Enable collapsing contiguous cyclic patterns

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -465,7 +465,7 @@ if 1 or not sys.stdout.isatty():
 
 
 def sequential_lines(a,b):
-    if len(a) != len(b):
+    if len(a) != len(b) or len(a) < 4:
         return False
 
     all_chars = sorted(set(a+b))


### PR DESCRIPTION
Normally we collapse repeating bytes with hexdump.

```
>>> print hexdump('A'*100)
00000000  41 41 41 41  41 41 41 41  41 41 41 41  41 41 41 41  │AAAA│AAAA│AAAA│AAAA│
*
00000060  41 41 41 41                                         │AAAA││
00000064
```

Now we can collapse cyclic patterns.

```
>>> print hexdump(cyclic(100))
00000000  61 61 61 61  62 61 61 61  63 61 61 61  64 61 61 61  │aaaa│baaa│caaa│daaa│
*
00000060  79 61 61 61                                         │yaaa││
00000064
>>> print hexdump(cyclic(410, alphabet=string.uppercase))
00000000  41 41 41 41  42 41 41 41  43 41 41 41  44 41 41 41  │AAAA│BAAA│CAAA│DAAA│
*
00000190  5a 41 41 45  42 41 41 45  43 41                     │ZAAE│BAAE│CA│
0000019a
>>> print hexdump(cyclic(410, alphabet=string.uppercase), width=4)
00000000  41 41 41 41    │AAAA│
*
00000198  43 41          │CA│
0000019a
```
