### PR TITLE
Add log.exception to be able to print out an error message *with* an exception.

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -375,7 +375,7 @@ def asm(shellcode, vma = 0, **kwargs):
                 result = fd.read()
 
         except:
-            log.error("An error occurred while assembling:\n%s" % code)
+            log.exception("An error occurred while assembling:\n%s" % code)
         else:
             shutil.rmtree(tmpdir)
             return result
@@ -456,7 +456,7 @@ def disasm(data, vma = 0, **kwargs):
 
             result = output1[1].strip('\n').rstrip().expandtabs()
         except:
-            log.error("An error occurred while disassembling:\n%s" % data)
+            log.exception("An error occurred while disassembling:\n%s" % data)
         else:
             shutil.rmtree(tmpdir)
             return result

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -125,12 +125,20 @@ class Logger(logging.getLoggerClass()):
         """
         return self.__log(level, m, a, kw)
 
+    def exception(self, m, e=None, *a, **kw):
+        """exception(exception, message)
+
+        Log an exception with additional error message.
+        """
+        self.__log(logging.ERROR, m, a, kw, text.on_red('ERROR'), True)
+        raise e or sys.exc_info()[1]
+
     def error(self, m, *a, **kw):
         """error(message)
 
         Logs an error message, and raises an ``Exception``.
         """
-        self.__log(logging.ERROR, m, a, kw, text.on_red('ERROR'))
+        self.__log(logging.ERROR, m, a, kw, text.on_red('ERROR'), True)
         raise Exception(m)
 
     def warn(self, m, *a, **kw):


### PR DESCRIPTION
Add log.exception to be able to print out an error message _with_ an exception.

Update log.error (and log.exception) to stop the active progress item.
