### PR TITLE
SSH Tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
     - master
 install:
   - source .travis_install.sh
+  - source .travis_ssh_setup.sh
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -27,3 +27,22 @@ esac
 pip install -r requirements.txt
 pip install -r docs/requirements.txt
 pip install .
+
+
+#
+# Install a demo user for SSH purposes
+#
+U=demouser
+H=/home/$U
+
+sudo useradd -m $U
+ssh-keygen -t rsa -f /tmp/$U -N ''
+
+eval $(ssh-agent -s)
+ssh-add    /tmp/$U
+
+sudo -u $U mkdir $H/.ssh
+sudo -u $U cp    /tmp/$U.pub $H/.ssh/authorized_keys
+sudo chmod -R 700 $H
+
+(echo -n "$U:"; pwgen 100 1) | sudo chpasswd

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -27,22 +27,3 @@ esac
 pip install -r requirements.txt
 pip install -r docs/requirements.txt
 pip install .
-
-
-#
-# Install a demo user for SSH purposes
-#
-U=demouser
-H=/home/$U
-
-sudo useradd -m $U
-ssh-keygen -t rsa -f /tmp/$U -N ''
-
-eval $(ssh-agent -s)
-ssh-add    /tmp/$U
-
-sudo -u $U mkdir $H/.ssh
-sudo -u $U cp    /tmp/$U.pub $H/.ssh/authorized_keys
-sudo chmod -R 700 $H
-
-(echo -n "$U:"; pwgen 100 1) | sudo chpasswd

--- a/.travis_ssh_setup.sh
+++ b/.travis_ssh_setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Install a demo user for SSH purposes
+#
+U=demouser
+H=/home/$U
+
+sudo useradd -m $U
+ssh-keygen -t rsa -f /tmp/$U -N ''
+
+eval $(ssh-agent -s)
+ssh-add    /tmp/$U
+
+sudo -u $U mkdir $H/.ssh
+sudo -u $U cp    /tmp/$U.pub $H/.ssh/authorized_keys
+sudo chmod -R 700 $H
+
+(echo -n "$U:"; pwgen 100 1) | sudo chpasswd

--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -15,13 +15,13 @@
 
    .. automodule:: pwnlib.tubes.remote
 
-      .. autoclass:: pwnlib.tubes.remote.remote(host, port, fam = None, typ = None, proto = 0, timeout = 'default', log_level = INFO)
+      .. autoclass:: pwnlib.tubes.remote.remote
          :members:
          :show-inheritance:
 
    .. automodule:: pwnlib.tubes.listen
 
-      .. autoclass:: pwnlib.tubes.listen.listen(port, bindaddr = "0.0.0.0", fam = "any", typ = "tcp", timeout = 'default', log_level = INFO)
+      .. autoclass:: pwnlib.tubes.listen.listen
          :members:
          :show-inheritance:
 
@@ -35,7 +35,7 @@
 
    .. automodule:: pwnlib.tubes.process
 
-      .. autoclass:: pwnlib.tubes.process.process(args, shell = False, executable = None, env = None, timeout = 'default', log_level = INFO)
+      .. autoclass:: pwnlib.tubes.process.process
          :members: kill, poll, communicate
          :show-inheritance:
 
@@ -44,7 +44,7 @@
 
    .. automodule:: pwnlib.tubes.ssh
 
-      .. autoclass:: pwnlib.tubes.ssh.ssh(user, host, port = 22, password = None, key = None, keyfile = None, proxy_command = None, proxy_sock = None, timeout = 'default', log_level = INFO)
+      .. autoclass:: pwnlib.tubes.ssh.ssh
          :members:
 
       .. autoclass:: pwnlib.tubes.ssh.ssh_channel()


### PR DESCRIPTION
Create a new SSH user on Travis CI, and use this for testing SSH functionality.

We can also test this locally in a secure-enough manner.  It requires a dummy user account and uses SSH pubkey authentication.