### PR TITLE
If not explicitly set, spinners are marked as succeeded unless an exception was raised in which case they are marked as failed.

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -518,9 +518,12 @@ def waitfor(msg, status = '', log_level = logging.INFO):
         l.addHandler(h)
         l.propagate = False
 
-        def stop(*a):
+        def stop(exc_typ, exc_val, exc_tb):
             if not h.stop.isSet():
-                l.failure('Done, did not provide status')
+                if exc_typ is None:
+                    l.success()
+                else:
+                    l.failure()
                 h.stop.set()
         _monkeypatch(l, lambda *a: l, stop)
     else:


### PR DESCRIPTION
This change makes it possible to use anonymous spinners that succeed by default, which is usually what you want when writing exploits.
