### PR TITLE
Removed duplicate status throttling used by `pwnlib.log.waitfor`.

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -431,7 +431,6 @@ class TermHandler(logging.Handler):
         self.spinner.daemon = True
         self.spinner.start()
         self._handle = term.output('')
-        self.last    = 0
 
     def emit(self, record):
         final = getattr(record, 'pwnlib_stop', False)
@@ -440,12 +439,8 @@ class TermHandler(logging.Handler):
             self.stop.set()
             self.spinner.join()
 
-        now = time.time()
-
-        if final or (now - self.last > 0.1):
-            msg = self.format(record)
-            self._handle.update(msg + '\n')
-            self.last = now
+        msg = self.format(record)
+        self._handle.update(msg + '\n')
 
     def spin(self, handle):
         state  = 0


### PR DESCRIPTION
In order not to stress the term module / terminal we throttle status updates on `progress` loggers.  There wre two throttling mechanisms: one in `Logger.status` and one in `TermHandler.emit`.  This PR removes the check in `TermHandler.emit`.  This fixes at least one bug:

Run this with nc listening:

```
from pwn import *
sock = remote('localhost', 1337)
sock.recvall()
```

Notice that the status line reads `[>] Recieving all data:`, i.e. without `0B` as expected.  Notice that this PR does not fix this example due to another bug in `pwnlib.tubes.tube.recvall()`; see PR #269.
