### PR TITLE
Split Travis installation steps into its own script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,10 @@ branches:
   only:
     - master
 install:
-  - sudo apt-get update
-  - sudo apt-get install software-properties-common
-  - sudo apt-add-repository --yes ppa:pwntools/binutils
-  - sudo apt-get update
-  - sudo apt-get install binutils-arm-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu
-  - wget -nc http://www.capstone-engine.org/download/2.1.2/capstone-2.1.2_amd64.deb
-  - sudo dpkg -i *.deb
-  - pip install -r requirements.txt
-  - pip install -r docs/requirements.txt
-  - pip install .
+  - source .travis_install.sh
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
+
 script: make -C docs doctest

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+setup_linux()
+{
+    sudo apt-get update
+    sudo apt-get install software-properties-common pwgen
+    sudo apt-add-repository --yes ppa:pwntools/binutils
+    sudo apt-get update
+    sudo apt-get install binutils-arm-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+    wget -nc http://www.capstone-engine.org/download/2.1.2/capstone-2.1.2_amd64.deb
+    (echo "a30bcb58fd82d32b135eec978eaa22230c44e722 *capstone-2.1.2_amd64.deb" | sha1sum -c) || exit
+    sudo dpkg -i *.deb
+}
+
+setup_osx()
+{
+    brew update
+    brew install binutils
+    brew install capstone
+}
+
+case $(uname) in
+Darwin) setup_osx   ;;
+Linux)  setup_linux ;;
+esac
+
+pip install -r requirements.txt
+pip install -r docs/requirements.txt
+pip install .


### PR DESCRIPTION
Split Travis installation steps into its own script so we can check the OS

Also add a sha1sum check to the downloaded `deb` file.