### PR TITLE
Remove references to "init" as PID 1

### DIFF
--- a/docs/source/util/proc.rst
+++ b/docs/source/util/proc.rst
@@ -1,7 +1,7 @@
 .. testsetup:: *
 
    from pwnlib.util.proc import *
-   import os
+   import os, sys
 
 
 :mod:`pwnlib.util.proc` --- Working with ``/proc/``

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -56,8 +56,6 @@ def pid_by_name(name):
         List of PIDs matching `name` sorted by lifetime, youngest to oldest.
 
     Example:
-        >>> 1 in pid_by_name('init')
-        True
         >>> os.getpid() in pid_by_name(name(os.getpid()))
         True
     """
@@ -83,8 +81,8 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
-        >>> name(1)
-        'init'
+        >>> name(os.getpid()) == os.path.basename(sys.argv[0])
+        True
     """
     return psutil.Process(pid).name()
 


### PR DESCRIPTION
Remove references to "init" as PID 1 which is not accurate for Debian after switching to systemd.

Fixes #250