### PR TITLE
Fix i386_to_amd64 and pushstr against GNU GAS syntax

### DIFF
--- a/pwnlib/shellcraft/templates/i386/freebsd/i386_to_amd64.asm
+++ b/pwnlib/shellcraft/templates/i386/freebsd/i386_to_amd64.asm
@@ -1,12 +1,12 @@
 <% from pwnlib.shellcraft import common %>
 <%docstring>Returns code to switch from i386 to amd64 mode.</%docstring>
 <% helper, end = common.label("helper"), common.label("end") %>
-[bits 32]
+.code32
     push 0x43 /*  This is the segment we want to go to */
     call $+4
 ${helper}:
-    db 0xc0
-    add dword [esp], ${end} - ${helper}
+    .byte 0xc0
+    add dword ptr [esp], ${end} - ${helper}
     jmp far [esp]
 ${end}:
-[bits 64]
+.code64

--- a/pwnlib/shellcraft/templates/i386/linux/i386_to_amd64.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/i386_to_amd64.asm
@@ -1,12 +1,12 @@
 <% from pwnlib.shellcraft import common %>
 <%docstring>Returns code to switch from i386 to amd64 mode.</%docstring>
 <% helper, end = common.label("helper"), common.label("end") %>
-[bits 32]
+.code32
     push 0x33 /*  This is the segment we want to go to */
     call $+4
 ${helper}:
-    db 0xc0
-    add dword [esp], ${end} - ${helper}
+    .byte 0xc0
+    add dword ptr [esp], ${end} - ${helper}
     jmp far [esp]
 ${end}:
-[bits 64]
+.code64

--- a/pwnlib/shellcraft/templates/i386/pushstr.asm
+++ b/pwnlib/shellcraft/templates/i386/pushstr.asm
@@ -33,8 +33,13 @@ Args:
 % elif '\x00' not in word and '\n' not in word:
     push ${hex(sign)} /*  ${repr(word)} */
 % else:
-<% a,b = fiddling.xor_pair(word, avoid = '\x00\n') %>
-    push '${repr(a)[1:-1]}'
-    xor dword [esp], `${repr(b)[1:-1]}` /*  ${repr(word)} */
+<%
+    a,b = fiddling.xor_pair(word, avoid = '\x00\n')
+    a   = packing.u32(a, 'little', False)
+    b   = packing.u32(b, 'little', False)
+%>
+    /* push ${repr(word)} */
+    push ${hex(a)}
+    xor dword ptr [esp], ${hex(b)}
 % endif
 % endfor


### PR DESCRIPTION
Fixes #263 