### PR TITLE
Add better documentation for installation.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,19 +11,21 @@ Prerequisites
 In order to get the most out of ``pwntools``, you should have the
 following system libraries installed.
 
--  binutils for your target architecture (`Ubuntu`_)
--  `libcapstone 2.1`_ (Ubuntu `i386`_ `amd64`_)
-- Python development headers (``python-dev``)
+.. toctree::
+   :maxdepth: 3
+   :glob:
+
+   install/*
 
 Released Version
 -----------------
 
 Pwntools is available as a ``pip`` package.
 
-.. code:: sh
+.. code-block:: bash
 
-    apt-get install python2.7 python2.7-dev python-pip
-    pip install pwntools
+    $ apt-get install python2.7 python2.7-dev python-pip
+    $ pip install pwntools
 
 Latest Version
 --------------
@@ -31,27 +33,14 @@ Latest Version
 Alternatively if you prefer to use the latest version from the
 repository:
 
-.. code:: sh
+.. code-block:: bash
 
-    git clone https://github.com/Gallopsled/pwntools
-    PWN=$(realpath pwntools)
-    cd $PWN
-    pip2 install -r requirements.txt
-    export PATH="$PWN/bin:$PATH"
-    export PYTHONPATH="$PWN:$PYTHONPATH"
-
-If you want to make these settings permanent:
-
-.. code:: sh
-
-    >>~/.bashrc cat <<EOF
-    # Set up path for Pwntools
-    export PATH="$PWN/bin:\$PATH"
-    export PYTHONPATH="$PWN:\$PYTHONPATH"
-    EOF
+    $ git clone https://github.com/Gallopsled/pwntools
+    $ cd pwntools
+    $ pip install -e .
 
 .. _Ubuntu: https://launchpad.net/~pwntools/+archive/ubuntu/binutils
 .. _libcapstone 2.1: http://www.capstone-engine.org
 .. _i386: http://www.capstone-engine.org/download/2.1.2/capstone-2.1.2_i386.deb
 .. _amd64: http://www.capstone-engine.org/download/2.1.2/capstone-2.1.2_amd64.deb
-```
+

--- a/docs/source/install/binutils.rst
+++ b/docs/source/install/binutils.rst
@@ -1,0 +1,82 @@
+Binutils
+-------------
+
+Assembly of foreign architectures (e.g. assembling Sparc shellcode on
+Mac OS X) requires cross-compiled versions of ``binutils`` to be
+installed. We've made this process as smooth as we can.
+
+In these examples, replace ``$ARCH`` with your target architecture (e.g., arm, mips64, vax, etc.).
+
+Ubuntu
+^^^^^^^^^^^^^^^^
+First, add our `Personal Package Archive repository <http://binutils.pwntools.com>`__.
+
+.. code-block:: bash
+
+    $ apt-get install software-properties-common
+    $ apt-add-repository ppa:pwntools/binutils
+    $ apt-get updatez
+
+Then, install the binutils for your architecture.
+
+.. code-block:: bash
+
+    $ apt-get install binutils-$ARCH-linux-gnu
+
+Mac OS X
+^^^^^^^^^^^^^^^^
+
+Mac OS X is just as easy, but requires building binutils from source.
+However, we've made ``homebrew`` recipes to make this a single command.
+After installing `brew <http://brew.sh>`__, grab the appropriate
+recipe from our `binutils
+repo <https://github.com/Gallopsled/pwntools-binutils/>`__.
+
+.. code-block:: bash
+
+    $ brew install https://raw.githubusercontent.com/Gallopsled/pwntools-binutils/master/osx/binutils-$ARCH.rb
+
+Alternate OSes
+^^^^^^^^^^^^^^^^
+
+If you want to build everything by hand, or don't use any of the above
+OSes, ``binutils`` is simple to build by hand.
+
+.. code-block:: bash
+
+    #!/usr/bin/env bash
+
+    V=2.25   # Binutils Version
+    ARCH=arm # Target architecture
+
+    cd /tmp
+    wget -nc http://ftp.gnu.org/gnu/binutils/binutils-$V.tar.gz
+    wget -nc http://ftp.gnu.org/gnu/binutils/binutils-$V.tar.gz.sig
+
+    gpg --keyserver keys.gnupg.net --recv-keys 4AE55E93
+    gpg --verify binutils-$V.tar.gz.sig
+
+    rm -rf binutils-*
+
+    tar xf binutils-$V.tar.gz
+
+    mkdir binutils-build
+    cd binutils-build
+
+    export AR=ar
+    export AS=as
+
+    ../binutils-$V/configure \
+        --prefix=/usr/local \
+        --target=$ARCH-unknown-linux-gnu \
+        --disable-static \
+        --disable-multilib \
+        --disable-werror \
+        --disable-nls
+
+    MAKE=gmake
+    hash gmake || MAKE=make
+
+    $MAKE -j
+    sudo $MAKE install
+

--- a/docs/source/install/capstone.rst
+++ b/docs/source/install/capstone.rst
@@ -1,0 +1,27 @@
+Capstone
+-------------
+
+Capstone is a disassembly library required for gathering ROP gadgets
+and ROP chain generation.
+
+It's a separate requirement from ``binutils`` because it's used by
+Jon Salwan's ``ROPgadget`` tool which we use under the covers.
+
+In particular, version ``2.1.2`` should be used.  Capstone can be downloaded here_, or installed with the steps below.
+
+Ubuntu
+^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    $ wget -nc http://www.capstone-engine.org/download/2.1.2/capstone-2.1.2_amd64.deb
+    $ apt-get install capstone-2.1.2_amd64.deb
+
+Mac OS X
+^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    $ brew install capstone
+
+.. _here:  http://www.capstone-engine.org/download.html

--- a/docs/source/install/headers.rst
+++ b/docs/source/install/headers.rst
@@ -1,0 +1,18 @@
+Python Development Headers
+-------------
+
+Some of pwntools' Python dependencies require native extensions (for example, Paramiko requires PyCrypto).
+
+In order to build these native extensions, the development headers for Python must be installed.
+
+Ubuntu
+^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    $ apt-get install python-dev
+
+Mac OS X
+^^^^^^^^^^^^^^^^
+
+No action needed.


### PR DESCRIPTION
Specifically, use "pip install -e" isntead of environment paths.
Give instructions for installing binutils.

Fixes #272, #273, #274 