### PR TITLE
Add ${push} for i386 and amd64 that just uses the pushstr code

### DIFF
--- a/pwnlib/shellcraft/templates/amd64/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/push.asm
@@ -1,0 +1,12 @@
+<% from pwnlib.util import packing %>
+<% from pwnlib.shellcraft import amd64 %>
+<%page args="value, append_null = True"/>
+<%docstring>
+Pushes a value onto the stack without using
+null bytes or newline characters.
+
+Args:
+  value (int): The string to push.
+</%docstring>
+
+${amd64.pushstr(packing.pack(value, 'all'), False)}

--- a/pwnlib/shellcraft/templates/amd64/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/push.asm
@@ -1,5 +1,6 @@
 <% from pwnlib.util import packing %>
 <% from pwnlib.shellcraft import amd64 %>
+<% import re %>
 <%page args="value"/>
 <%docstring>
 Pushes a value onto the stack without using
@@ -10,8 +11,8 @@ Args:
 </%docstring>
 
 % if isinstance(value, (int,long)):
-${amd64.pushstr(packing.pack(value, 64, 'little', True), False)}
+    /* push ${repr(value)} */
+    ${re.sub(r'^\s*/.*\n', '', amd64.pushstr(packing.pack(value, 64, 'little', True), False), 1)}
 % else:
-push ${value}
+    push ${value}
 % endif
-

--- a/pwnlib/shellcraft/templates/amd64/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/push.asm
@@ -10,7 +10,7 @@ Args:
 </%docstring>
 
 % if isinstance(value, (int,long)):
-${amd64.pushstr(packing.pack(value, 'all'), False)}
+${amd64.pushstr(packing.pack(value, 64), False)}
 % else:
 push ${value}
 % endif

--- a/pwnlib/shellcraft/templates/amd64/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/push.asm
@@ -1,6 +1,6 @@
 <% from pwnlib.util import packing %>
 <% from pwnlib.shellcraft import amd64 %>
-<%page args="value, append_null = True"/>
+<%page args="value"/>
 <%docstring>
 Pushes a value onto the stack without using
 null bytes or newline characters.
@@ -10,7 +10,7 @@ Args:
 </%docstring>
 
 % if isinstance(value, (int,long)):
-${amd64.pushstr(packing.pack(value, 64), False)}
+${amd64.pushstr(packing.pack(value, 64, 'little', True), False)}
 % else:
 push ${value}
 % endif

--- a/pwnlib/shellcraft/templates/amd64/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/push.asm
@@ -6,7 +6,12 @@ Pushes a value onto the stack without using
 null bytes or newline characters.
 
 Args:
-  value (int): The string to push.
+  value (int,str): The value or register to push
 </%docstring>
 
+% if isinstance(value, (int,long)):
 ${amd64.pushstr(packing.pack(value, 'all'), False)}
+% else:
+push ${value}
+% endif
+

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -1,5 +1,6 @@
 <% from pwnlib.util import packing %>
 <% from pwnlib.shellcraft import i386 %>
+<% import re %>
 <%page args="value"/>
 <%docstring>
 Pushes a value onto the stack without using
@@ -10,7 +11,8 @@ Args:
 </%docstring>
 
 % if isinstance(value, (int,long)):
-${i386.pushstr(packing.pack(value, 32, 'little', True), False)}
+    /* push ${repr(value)} */
+    ${re.sub(r'^\s*/.*\n', '', i386.pushstr(packing.pack(value, 32, 'little', True), False), 1)}
 % else:
-push ${value}
+    push ${value}
 % endif

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -1,0 +1,12 @@
+<% from pwnlib.util import packing %>
+<% from pwnlib.shellcraft import i386 %>
+<%page args="value, append_null = True"/>
+<%docstring>
+Pushes a value onto the stack without using
+null bytes or newline characters.
+
+Args:
+  value (int): The string to push.
+</%docstring>
+
+${i386.pushstr(packing.pack(value, 'all'), False)}

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -6,7 +6,11 @@ Pushes a value onto the stack without using
 null bytes or newline characters.
 
 Args:
-  value (int): The string to push.
+  value (int,str): The value or register to push
 </%docstring>
 
+% if isinstance(value, (int,long)):
 ${i386.pushstr(packing.pack(value, 'all'), False)}
+% else:
+push ${value}
+% endif

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -1,6 +1,6 @@
 <% from pwnlib.util import packing %>
 <% from pwnlib.shellcraft import i386 %>
-<%page args="value, append_null = True"/>
+<%page args="value"/>
 <%docstring>
 Pushes a value onto the stack without using
 null bytes or newline characters.
@@ -10,7 +10,7 @@ Args:
 </%docstring>
 
 % if isinstance(value, (int,long)):
-${i386.pushstr(packing.pack(value, 32), False)}
+${i386.pushstr(packing.pack(value, 32, 'little', True), False)}
 % else:
 push ${value}
 % endif

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -10,7 +10,7 @@ Args:
 </%docstring>
 
 % if isinstance(value, (int,long)):
-${i386.pushstr(packing.pack(value, 'all'), False)}
+${i386.pushstr(packing.pack(value, 32), False)}
 % else:
 push ${value}
 % endif


### PR DESCRIPTION
Useful for pushing constants.

```
$ shellcraft amd64.push 0 | disasm
   0:   6a 01                   push   0x1
   2:   fe 0c 24                dec    BYTE PTR [esp]
$ shellcraft amd64.push 33 | disasm
   0:   6a 21                   push   0x21
$ shellcraft i386.push 0 | disasm
   0:   6a 01                   push   0x1
   2:   fe 0c 24                dec    BYTE PTR [esp]
$ shellcraft i386.push 0xdeadbeef | disasm
   0:   68 ef be ad de          push   0xdeadbeef
$ shellcraft i386.push 0xdeadbe00 | disasm
   0:   68 01 01 01 01          push   0x1010101
   5:   81 34 24 01 bf ac df    xor    DWORD PTR [esp],0xdfacbf01
```