### PR TITLE
Include documentation for alternate architectures

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ import pwnlib
 pwnlib.context.context.reset_local()
 pwnlib.context.ContextType.defaults['log_level'] = 'ERROR'
 pwnlib.term.text.when = 'never'
+
 '''
 
 autodoc_member_order = 'alphabetical'
@@ -311,3 +312,12 @@ def linkcode_resolve(domain, info):
                 pass
 
     return "https://github.com/Gallopsled/pwntools/blob/%s/%s" % (branch, filename)
+
+
+#
+# Work around #317
+#
+import pwnlib
+pwnlib.shellcraft.arm
+pwnlib.shellcraft.thumb
+pwnlib.shellcraft.amd64

--- a/docs/source/shellcraft/amd64.rst
+++ b/docs/source/shellcraft/amd64.rst
@@ -1,0 +1,14 @@
+:mod:`pwnlib.shellcraft.amd64` --- Shellcode for AMD64
+===========================================================
+
+:mod:`pwnlib.shellcraft.amd64`
+---------------------------------------
+
+.. automodule:: pwnlib.shellcraft.amd64
+   :members:
+
+:mod:`pwnlib.shellcraft.amd64.linux`
+---------------------------------------
+
+.. automodule:: pwnlib.shellcraft.amd64.linux
+   :members:

--- a/docs/source/shellcraft/arm.rst
+++ b/docs/source/shellcraft/arm.rst
@@ -1,0 +1,14 @@
+:mod:`pwnlib.shellcraft.arm` --- Shellcode for ARM
+===========================================================
+
+:mod:`pwnlib.shellcraft.arm`
+-----------------------------
+
+.. automodule:: pwnlib.shellcraft.arm
+   :members:
+
+:mod:`pwnlib.shellcraft.arm.linux`
+-----------------------------------
+
+.. automodule:: pwnlib.shellcraft.arm.linux
+   :members:

--- a/docs/source/shellcraft/thumb.rst
+++ b/docs/source/shellcraft/thumb.rst
@@ -1,0 +1,14 @@
+:mod:`pwnlib.shellcraft.thumb` --- Shellcode for Thumb Mode
+===========================================================
+
+:mod:`pwnlib.shellcraft.thumb`
+-------------------------------
+
+.. automodule:: pwnlib.shellcraft.thumb
+   :members:
+
+:mod:`pwnlib.shellcraft.thumb.linux`
+---------------------------------------
+
+.. automodule:: pwnlib.shellcraft.thumb.linux
+   :members:


### PR DESCRIPTION
This throws some warnings when generating documentation.  See #317.

I think it's worth having the documentation, even in spite of the warnings.