### PR TITLE
Enable configurable avoidance patterns for pushstr

### DIFF
--- a/pwnlib/shellcraft/templates/amd64/pushstr.asm
+++ b/pwnlib/shellcraft/templates/amd64/pushstr.asm
@@ -1,6 +1,5 @@
 <% from pwnlib.util import lists, packing, fiddling %>
-<% import sys %>
-<%page args="string, append_null = True"/>
+<%page args="string, append_null = True, avoid='\x00\n'"/>
 <%docstring>
 Pushes a string onto the stack without using
 null bytes or newline characters.
@@ -8,6 +7,7 @@ null bytes or newline characters.
 Args:
   string (str): The string to push.
   append_null (bool): Whether to append a single NULL-byte before pushing.
+  avoid (str): Bytes to avoid
 </%docstring>
 
 <%
@@ -17,7 +17,7 @@ Args:
         return
 
     def okay(s):
-        return '\n' not in s and '\0' not in s
+        return not any(bad in s for bad in avoid)
 
     if ord(string[-1]) >= 128:
         extend = '\xff'
@@ -42,7 +42,7 @@ Args:
     push rax
 % else:
 <%
-    a,b = fiddling.xor_pair(word, avoid = '\x00\n')
+    a,b = fiddling.xor_pair(word, avoid = avoid)
     a   = packing.u64(a, 'little', 'unsigned')
     b   = packing.u64(b, 'little', 'unsigned')
 %>

--- a/pwnlib/shellcraft/templates/i386/pushstr.asm
+++ b/pwnlib/shellcraft/templates/i386/pushstr.asm
@@ -1,5 +1,5 @@
 <% from pwnlib.util import lists, packing, fiddling %>
-<%page args="string, append_null = True"/>
+<%page args="string, append_null = True, avoid='\x00\n'"/>
 <%docstring>
 Pushes a string onto the stack without using
 null bytes or newline characters.
@@ -7,6 +7,7 @@ null bytes or newline characters.
 Args:
   string (str): The string to push.
   append_null (bool): Whether to append a single NULL-byte before pushing.
+  avoid (str): Bytes to avoid
 </%docstring>
 
 <%
@@ -28,11 +29,11 @@ Args:
 % if sign == 0:
     push 1
     dec byte ptr [esp] /*  ${repr(word)} */
-% elif '\x00' not in word and '\n' not in word:
+% elif not any(b in word for b in avoid):
     push ${hex(sign)} /*  ${repr(word)} */
 % else:
 <%
-    a,b = fiddling.xor_pair(word, avoid = '\x00\n')
+    a,b = fiddling.xor_pair(word, avoid = avoid)
     a   = packing.u32(a, 'little', False)
     b   = packing.u32(b, 'little', False)
 %>


### PR DESCRIPTION
Sometimes you don't care:

```py
>>> from pwn import *
>>> print shellcraft.pushstr('Hello, world!', avoid='')
    push 0x21 /*  '!\x00\x00\x00' */
    push 0x646c726f /*  'orld' */
    push 0x77202c6f /*  'o, w' */
    push 0x6c6c6548 /*  'Hell' */
```

And sometimes you need to be special:

```py
>>> from pwn import *
>>> print shellcraft.pushstr('Hello, world!', avoid='\x00' + string.whitespace)
    /* push '!\x00\x00\x00' */
    push 0x1010102
    xor dword ptr [esp], 0x1010123

    push 0x646c726f /*  'orld' */

    /* push 'o, w' */
    push 0x1010101
    xor dword ptr [esp], 0x76212d6e

    push 0x6c6c6548 /*  'Hell' */
```