### PR TITLE
Shellcraft tests

### DIFF
--- a/docs/source/shellcraft/amd64.rst
+++ b/docs/source/shellcraft/amd64.rst
@@ -1,3 +1,7 @@
+.. testsetup:: *
+
+   from pwn import *
+
 :mod:`pwnlib.shellcraft.amd64` --- Shellcode for AMD64
 ===========================================================
 

--- a/docs/source/shellcraft/arm.rst
+++ b/docs/source/shellcraft/arm.rst
@@ -1,3 +1,7 @@
+.. testsetup:: *
+
+   from pwn import *
+
 :mod:`pwnlib.shellcraft.arm` --- Shellcode for ARM
 ===========================================================
 

--- a/docs/source/shellcraft/i386.rst
+++ b/docs/source/shellcraft/i386.rst
@@ -1,3 +1,7 @@
+.. testsetup:: *
+
+   from pwn import *
+
 :mod:`pwnlib.shellcraft.i386` --- Shellcode for Intel 80386
 ===========================================================
 

--- a/docs/source/shellcraft/thumb.rst
+++ b/docs/source/shellcraft/thumb.rst
@@ -1,3 +1,7 @@
+.. testsetup:: *
+
+   from pwn import *
+
 :mod:`pwnlib.shellcraft.thumb` --- Shellcode for Thumb Mode
 ===========================================================
 

--- a/pwnlib/shellcraft/templates/arm/ret.asm
+++ b/pwnlib/shellcraft/templates/arm/ret.asm
@@ -3,6 +3,15 @@
 
 Args:
     return_value: Value to return
+
+Examples:
+    >>> with context.local(arch='arm'):
+    ...     print enhex(asm(shellcraft.ret()))
+    ...     print enhex(asm(shellcraft.ret(0)))
+    ...     print enhex(asm(shellcraft.ret(0xdeadbeef)))
+    1eff2fe1
+    000020e01eff2fe1
+    ef0e0be3ad0e4de31eff2fe1
 </%docstring>
 <%page args="return_value = None"/>
 


### PR DESCRIPTION
Enable doctests for shellcode.

Even with a lack of more robust testing mechanisms, we can at least make sure that things don't stop working.

Includes parts of #318, so it should be merged first.