### PR TITLE
Stopped using amd64.syscall and i386.syscall, as they will not work without a set context

### DIFF
--- a/pwnlib/shellcraft/templates/amd64/linux/dup.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/dup.asm
@@ -21,7 +21,7 @@ ${looplabel}:
     js ${after}
     push rsi
 
-    ${amd64.syscall('SYS_dup2', 'rbp', 'rsi')}
+    ${amd64.linux.syscall('SYS_dup2', 'rbp', 'rsi')}
 
     jmp ${looplabel}
 ${after}:

--- a/pwnlib/shellcraft/templates/amd64/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/echo.asm
@@ -4,4 +4,4 @@
 <%docstring>Writes a string to a file descriptor</%docstring>
 
 ${amd64.pushstr(string, append_null = False)}
-${amd64.syscall('SYS_write', sock, 'rsp', len(string))}
+${amd64.linux.syscall('SYS_write', sock, 'rsp', len(string))}

--- a/pwnlib/shellcraft/templates/amd64/linux/setregid.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/setregid.asm
@@ -7,10 +7,10 @@ Args: [gid (imm/reg) = egid]
 
 % if gid == 'egid':
     /*  getegid */
-    ${amd64.syscall('SYS_getegid')}
+    ${amd64.linux.syscall('SYS_getegid')}
     ${amd64.mov('rdi', 'rax')}
 % else:
     ${amd64.mov('rdi', gid)}
 % endif
 
-    ${amd64.syscall('SYS_setregid', 'rdi', 'rdi')}
+    ${amd64.linux.syscall('SYS_setregid', 'rdi', 'rdi')}

--- a/pwnlib/shellcraft/templates/amd64/linux/setreuid.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/setreuid.asm
@@ -7,10 +7,10 @@ Args: [uid (imm/reg) = euid]
 
 % if uid == 'euid':
     /*  geteuid */
-    ${amd64.syscall('SYS_geteuid')}
+    ${amd64.linux.syscall('SYS_geteuid')}
     ${amd64.mov('rdi', 'rax')}
 % else:
     ${amd64.mov('rdi', uid)}
 % endif
 
-    ${amd64.syscall('SYS_setreuid', 'rdi', 'rdi')}
+    ${amd64.linux.syscall('SYS_setreuid', 'rdi', 'rdi')}

--- a/pwnlib/shellcraft/templates/amd64/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/sh.asm
@@ -12,4 +12,4 @@
     push rax
 
     /*  Call execve("/bin//sh", 0, 0) */
-    ${amd64.syscall('SYS_execve', 'rsp', 0, 'rdx')}
+    ${amd64.linux.syscall('SYS_execve', 'rsp', 0, 'rdx')}

--- a/pwnlib/shellcraft/templates/i386/linux/setregid.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/setregid.asm
@@ -13,4 +13,4 @@ Args: [gid (imm/reg) = egid]
 % endif
 
     /*  setregid(eax, eax) */
-    ${i386.syscall('SYS_setregid', 'ebx', 'ebx')}
+    ${i386.linux.syscall('SYS_setregid', 'ebx', 'ebx')}


### PR DESCRIPTION
We should instead use amd64.linux.syscall and i386.linux.syscall. Note that I left a single syscall inplace without fixing it, as it is fixed in #326 and would create a merge conflict.