### PR TITLE
Check that a connection was actually established before calling `close` in `pwnlib.tubes.listen`.

### DIFF
--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -123,3 +123,10 @@ class listen(sock):
                 return None
         else:
             return getattr(super(listen, self), key)
+
+    def close(self):
+        # since `close` is scheduled to run on exit we must check that we got
+        # a connection or the program will hang in the `join` call above
+        if self._accepter.is_alive():
+            return
+        super(listen, self).close()


### PR DESCRIPTION
Since `close` is scheduled to run on exit a program listening for a connection but not receiving one will hang on exit.  Fixed by this PR.

To see the bug run `python -c "from pwn import * ; listen(1337).wait_for_connection()"` and kill with ^C.