### PR TITLE
Changed the behavior of `log.Logger.getEffectiveLevel`

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -97,8 +97,17 @@ class Logger(logging.getLoggerClass()):
         self.status_last = 0
 
     def getEffectiveLevel(self):
-        normLevel = super(Logger, self).getEffectiveLevel()
-        return min(normLevel, context.log_level)
+        # this is a copy of the `logging` modules `getEffectiveLevel` except
+        # that if we are the pwnlib root logger (named 'pwnlib') we return the
+        # log-level set in the current context
+        logger = self
+        while logger:
+            if logger.name == 'pwnlib':
+                return context.log_level
+            if logger.level:
+                return logger.level
+            logger = logger.parent
+        return logging.NOTSET
 
     def __log(self, level, msg, args, kwargs, symbol='', stop=False):
         """


### PR DESCRIPTION
Before `log.Logger.getEffectiveLevel` would return the log level of the current context or the parent logger depending on which was more verbose.  This lead to some surprising behavior.  Example:
```
from pwn import *
context(log_level = 'DEBUG')

log.setLevel(logging.WARNING)
log.debug('debug')
log.info('info')
log.warning('warning')
```

We would expect to see only a warning, but since `context.log_level` is a more verbose level we will see all three messages.

This PR changes `log.Logger.getEffectiveLevel` to work exactly as `logging.Logger.getEffectiveLevel` except if the current logger is named 'pwnlib', in which case the log level of the current context is returned.