### PR TITLE
Fix stackhunter and pushstr

### DIFF
--- a/pwnlib/shellcraft/templates/i386/pushstr.asm
+++ b/pwnlib/shellcraft/templates/i386/pushstr.asm
@@ -7,6 +7,22 @@ null bytes or newline characters.
 Args:
   string (str): The string to push.
   append_null (bool): Whether to append a single NULL-byte before pushing.
+
+Examples:
+
+    >>> with context.local():
+    ...    context.arch = 'i386'
+    ...    print enhex(asm(shellcraft.pushstr("/bin/sh")))
+    68010101018134242e726901682f62696e
+    >>> with context.local():
+    ...    context.arch = 'i386'
+    ...    print enhex(asm(shellcraft.pushstr("")))
+    6a01fe0c24
+    >>> with context.local():
+    ...    context.arch = 'i386'
+    ...    print enhex(asm(shellcraft.pushstr("\x00", False)))
+    6a01fe0c24
+
 </%docstring>
 <%
     if append_null:

--- a/pwnlib/shellcraft/templates/i386/stackhunter.asm
+++ b/pwnlib/shellcraft/templates/i386/stackhunter.asm
@@ -10,6 +10,17 @@
 
     The default cookie has been chosen, because it makes it possible
     to shave a single byte, but other cookies can be used too.
+
+Example:
+
+    >>> with context.local():
+    ...    context.arch = 'i386'
+    ...    print enhex(asm(shellcraft.stackhunter()))
+    3d58ebfc7a75faffe4
+    >>> with context.local():
+    ...    context.arch = 'i386'
+    ...    print enhex(asm(shellcraft.stackhunter(0xdeadbeef)))
+    583defbeadde75f8ffe4
 </%docstring>
 <% stackhunter = common.label("stackhunter") %>
 %if (cookie & 0xffffff) == 0xfceb58:

--- a/pwnlib/shellcraft/templates/i386/stackhunter.asm
+++ b/pwnlib/shellcraft/templates/i386/stackhunter.asm
@@ -14,13 +14,13 @@
 <% stackhunter = common.label("stackhunter") %>
 %if (cookie & 0xffffff) == 0xfceb58:
 ${stackhunter}:
-    cmp dword eax, ${hex(cookie)}
+    cmp eax, ${hex(cookie)}
     jne ${stackhunter}+1
     jmp esp
 %else:
 ${stackhunter}:
     pop eax
-    cmp dword eax, ${hex(cookie)}
+    cmp eax, ${hex(cookie)}
     jne ${stackhunter}
     jmp esp
 %endif


### PR DESCRIPTION
Resolves two remaining issues in #263.  Checked the other shellcrafts have the same issue (`pushb` or `cmp dword REG`).  Fixes #263.