### PR TITLE
Use https instead of http wherever possible.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Github has a great guide for contributing to open source projects:
 
 ## Pwntools Specifics
 
-In general, we like to keep things documented.  You should add documentation to any new functionality, and update it for any changed functionality.  Our docstrings use the [Google Style Python Docstrings](http://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_google.html#example-google).
+In general, we like to keep things documented.  You should add documentation to any new functionality, and update it for any changed functionality.  Our docstrings use the [Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_google.html#example-google).
 
 After you have documentation, you should add a [doctest](https://docs.python.org/2/library/doctest.html).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pwntools - CTF toolkit
-[![Docs latest](https://readthedocs.org/projects/pwntools/badge/)](http://pwntools.readthedocs.org/en/latest)
-[![Docs 2.1.3](https://readthedocs.org/projects/pwntools/badge/?version=2.1.3)](http://pwntools.readthedocs.org/en/2.1.3)
-[![PyPI](http://img.shields.io/pypi/v/pwntools.svg)](https://pypi.python.org/pypi/pwntools/)
-[![Gittip](http://img.shields.io/gittip/gallopsled.svg)](https://www.gittip.com/gallopsled/)
+[![Docs latest](https://readthedocs.org/projects/pwntools/badge/)](https://pwntools.readthedocs.org/en/latest)
+[![Docs 2.1.3](https://readthedocs.org/projects/pwntools/badge/?version=2.1.3)](https://pwntools.readthedocs.org/en/2.1.3)
+[![PyPI](https://img.shields.io/pypi/v/pwntools.svg)](https://pypi.python.org/pypi/pwntools/)
+[![Gittip](https://img.shields.io/gittip/gallopsled.svg)](https://www.gittip.com/gallopsled/)
 [![Travis](https://travis-ci.org/Gallopsled/pwntools.svg)](https://travis-ci.org/Gallopsled/pwntools)
 
 This is the CTF framework used by Gallopsled in every CTF.
@@ -28,7 +28,7 @@ in `pwnlib`. These are:
 * `phd`: Replacement for `hexdump` with colors.
 
 # Documentation
-Our documentation is available at [docs.pwntools.com](http://docs.pwntools.com/en/latest/)
+Our documentation is available at [pwntools.readthedocs.org](https://pwntools.readthedocs.org/en/latest/)
 
 To get you started, we've provided some example solutions for past CTF challenges in our [write-ups repository](https://github.com/Gallopsled/pwntools-write-ups).
 
@@ -42,7 +42,7 @@ Most of the functionality of pwntools is self-contained and Python-only.  You sh
 pip install pwntools
 ```
 
-However, some of the features (ROP generation and assembling/disassembling foreign architectures) require non-Python dependencies.  For more information, see the [complete installation instructions here](http://docs.pwntools.com/en/latest/install.html).
+However, some of the features (ROP generation and assembling/disassembling foreign architectures) require non-Python dependencies.  For more information, see the [complete installation instructions here](https://pwntools.readthedocs.org/en/latest/install.html).
 
 
 # Contribution

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,8 +210,8 @@ latex_documents = [
    u'Gallopsled et al', 'manual'),
 ]
 
-intersphinx_mapping = {'python': ('http://docs.python.org/2.7', None),
-                       'paramiko': ('http://paramiko-docs.readthedocs.org/en/1.15/', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/2.7', None),
+                       'paramiko': ('https://paramiko-docs.readthedocs.org/en/1.15/', None)}
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.

--- a/docs/source/install/binutils.rst
+++ b/docs/source/install/binutils.rst
@@ -50,8 +50,8 @@ OSes, ``binutils`` is simple to build by hand.
     ARCH=arm # Target architecture
 
     cd /tmp
-    wget -nc http://ftp.gnu.org/gnu/binutils/binutils-$V.tar.gz
-    wget -nc http://ftp.gnu.org/gnu/binutils/binutils-$V.tar.gz.sig
+    wget -nc https://ftp.gnu.org/gnu/binutils/binutils-$V.tar.gz
+    wget -nc https://ftp.gnu.org/gnu/binutils/binutils-$V.tar.gz.sig
 
     gpg --keyserver keys.gnupg.net --recv-keys 4AE55E93
     gpg --verify binutils-$V.tar.gz.sig

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ the pwntools project.
 
 We have a plan to create a separate repository with examples, primarily
 exploits. Until we do so, we recommend new users to look at
-http://pwntools.readthedocs.org, as this is a better overview of our features.
+https://pwntools.readthedocs.org, as this is a better overview of our features.
 
 In no particular order the docstrings for each example:
 

--- a/examples/gen-README.py
+++ b/examples/gen-README.py
@@ -10,7 +10,7 @@ the pwntools project.
 
 We have a plan to create a separate repository with examples, primarily
 exploits. Until we do so, we recommend new users to look at
-http://pwntools.readthedocs.org, as this is a better overview of our features.
+https://pwntools.readthedocs.org, as this is a better overview of our features.
 
 In no particular order the docstrings for each example:
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -112,7 +112,7 @@ def which_binutils(util, **kwargs):
         log.warning("""
 Could not find %(util)r installed for %(context)s
 Try installing binutils for this architecture:
-    http://docs.pwntools.com/en/latest/install/binutils.html
+    https://pwntools.readthedocs.org/en/latest/install/binutils.html
 """.strip() % locals())
         raise Exception('Could not find %(util)r installed for %(context)s' % locals())
 

--- a/pwnlib/data/includes/LICENSE.txt
+++ b/pwnlib/data/includes/LICENSE.txt
@@ -7,14 +7,14 @@ This directory, the directory pwnlib/constants/ and subdirectories contains:
 - the result of that transformation
 
 
-The header files can be retrieved from http://www.freebsd.org and
+The header files can be retrieved from https://www.freebsd.org and
 http://www.fefe.de/dietlibc/ respectively.
 
 
 The header files from the FreeBSD project are to the best of our
 knowledge available under a BSD 2-clause license available here:
 
-http://www.freebsd.org/copyright/freebsd-license.html
+https://www.freebsd.org/copyright/freebsd-license.html
 
 
 The header files from dietlibc are to the best of our knowledge

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -128,9 +128,9 @@ class DynELF(object):
 
     .. _symtab:    https://refspecs.linuxbase.org/elf/gabi4+/ch4.symtab.html
     .. _strtab:    https://refspecs.linuxbase.org/elf/gabi4+/ch4.strtab.html
-    .. _.got.plt:  http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/specialsections.html
+    .. _.got.plt:  https://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/specialsections.html
     .. _DYNAMIC:   http://www.sco.com/developers/gabi/latest/ch5.dynamic.html#dynamic_section
-    .. _SYSV:      http://refspecs.linuxbase.org/elf/gabi4+/ch5.dynamic.html#hash
+    .. _SYSV:      https://refspecs.linuxbase.org/elf/gabi4+/ch5.dynamic.html#hash
     .. _GNU:       https://blogs.oracle.com/ali/entry/gnu_hash_elf_sections
     .. _DT_DEBUG:  https://reverseengineering.stackexchange.com/questions/6525/elf-link-map-when-linked-as-relro
     .. _link map:  https://google.com
@@ -573,7 +573,7 @@ class DynELF(object):
         Internal Documentation:
             See the ELF manual for more information.  Search for the phrase
             "A hash table of Elf32_Word objects supports symbol table access", or see:
-            http://docs.oracle.com/cd/E19504-01/802-6319/6ia12qkfo/index.html#chapter6-48031
+            https://docs.oracle.com/cd/E19504-01/802-6319/6ia12qkfo/index.html#chapter6-48031
 
             struct Elf_Hash {
                 uint32_t nbucket;

--- a/pwnlib/elf/datatypes.py
+++ b/pwnlib/elf/datatypes.py
@@ -274,8 +274,8 @@ class Elf64_Link_Map(ctypes.Structure):
 #
 # https://chromium.googlesource.com/chromiumos/third_party/glibc/+/master/sysdeps/x86/dl-machine.h
 # https://chromium.googlesource.com/chromiumos/third_party/glibc/+/master/sysdeps/x86_64/dl-machine.h
-# http://fossies.org/dox/glibc-2.20/aarch64_2dl-machine_8h_source.html#l00074
-# http://fossies.org/dox/glibc-2.20/powerpc32_2dl-machine_8c_source.html#l00203
+# https://fossies.org/dox/glibc-2.20/aarch64_2dl-machine_8h_source.html#l00074
+# https://fossies.org/dox/glibc-2.20/powerpc32_2dl-machine_8c_source.html#l00203
 #
 # For now, these are defined for x86 and x64
 #

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -87,7 +87,7 @@ def attach(target, execute = None, exe = None, arch = None):
         ptrace_scope = open('/proc/sys/kernel/yama/ptrace_scope').read().strip()
         if ptrace_scope != '0' and os.geteuid() != 0:
             msg =  'Disable ptrace_scope to attach to running processes.\n'
-            msg += 'More info: http://askubuntu.com/q/41629'
+            msg += 'More info: https://askubuntu.com/q/41629'
             log.warning(msg)
     except IOError:
         pass

--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -131,8 +131,7 @@ def init():
         else:
             traceback.print_exception(*args)
         # this is a bit esoteric
-        # look here for details: http://stackoverflow.com/questions
-        # /12790328/how-to-silence-sys-excepthook-is-missing-error
+        # look here for details: https://stackoverflow.com/questions/12790328/how-to-silence-sys-excepthook-is-missing-error
         if fd.fileno() == 2:
             os.close(fd.fileno())
     sys.excepthook = hook
@@ -255,7 +254,7 @@ def parse(s):
                 #  here is supporting setting the terminal title and updating
                 #  the color map.  we promise to do it properly in the next
                 #  iteration of this terminal emulation/compatibility layer
-                #  related: http://unix.stackexchange.com/questions/5936/can-i-set-my-local-machines-terminal-colors-to-use-those-of-the-machine-i-ssh-i
+                #  related: https://unix.stackexchange.com/questions/5936/can-i-set-my-local-machines-terminal-colors-to-use-those-of-the-machine-i-ssh-i
                 try:
                     j = s.index('\x07', i)
                 except:

--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -1,7 +1,7 @@
 import string
 from . import packing
 
-# Taken from http://en.wikipedia.org/wiki/De_Bruijn_sequence but changed to a generator
+# Taken from https://en.wikipedia.org/wiki/De_Bruijn_sequence but changed to a generator
 def de_bruijn(alphabet = string.ascii_lowercase, n = 4):
     """de_bruijn(alphabet = string.ascii_lowercase, n = 4) -> generator
 
@@ -81,7 +81,7 @@ def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = None):
        There exists better algorithms for this, but they depend on generating
        the De Bruijn sequence in another fashion. Somebody should look at it:
 
-       http://www.sciencedirect.com/science/article/pii/S0012365X00001175
+       https://www.sciencedirect.com/science/article/pii/S0012365X00001175
 
     Args:
       subseq: The subsequence to look for. This can either be a string, a list

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -131,7 +131,7 @@ def which(name, all = False):
             st = os.stat(p)
             if not stat.S_ISREG(st.st_mode):
                 continue
-            # work around this issue: http://bugs.python.org/issue9311
+            # work around this issue: https://bugs.python.org/issue9311
             if isroot and not \
               st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
                 continue

--- a/pwnlib/util/web.py
+++ b/pwnlib/util/web.py
@@ -16,7 +16,7 @@ def wget(url, save=None, timeout=5, **kwargs):
 
     Example:
 
-      >>> url    = 'http://httpbin.org/robots.txt'
+      >>> url    = 'https://httpbin.org/robots.txt'
       >>> with context.local(log_level='ERROR'):
       ...     result = wget(url)
       >>> result


### PR DESCRIPTION
Note that this means that I changed a few of the links from 
http://docs.pwntools.com to https://pwntools.readthedocs.org as we do not
currently have https on pwntools.com