### PR TITLE
Remove all special handling for OSX binutils, since it is broken

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -124,11 +124,9 @@ def _assembler():
         'little': '-EL'
     }[context.endianness]
 
-    osx = (platform.system() == 'Darwin')
-
     assemblers = {
-        'i386'   : [gas, '--32'] if not osx else [gas, '-arch', 'i386'],
-        'amd64'  : [gas, '--64'] if not osx else [gas, '-arch', 'x86_64'],
+        'i386'   : [gas, '--32'],
+        'amd64'  : [gas, '--64'],
 
         # Most architectures accept -EL or -EB
         'thumb'  : [gas, '-mthumb', E],
@@ -148,7 +146,6 @@ def _assembler():
     }
 
     return assemblers.get(context.arch, [gas])
-
 
 def _objcopy():
     return [which_binutils('objcopy')]
@@ -335,10 +332,8 @@ def asm(shellcode, vma = 0, **kwargs):
     result = ''
 
     with context.local(**kwargs):
-        osx = (platform.system() == 'Darwin')
-
         assembler = _assembler()
-        objcopy   = _objcopy() + ['-j', '.shellcode' if not osx else '*.shellcode*', '-Obinary']
+        objcopy   = _objcopy() + ['-j', '.shellcode', '-Obinary']
         code      = '.org %#x\n' % vma
         code      += _arch_header()
         code      += cpp(shellcode)


### PR DESCRIPTION
Fixes #347  by completely removing support for the default OS X assembler, which is based on version 1.4X (we require 2.19+).