### PR TITLE
Change tube.recvall behavior to use .wait_for_close instead of forcing .close

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -77,23 +77,9 @@ class ssh_channel(sock):
 
         self.close()
 
-    def recvall(self):
-        # We subclass tubes.sock which sets self.sock to None.
-        #
-        # However, we need to wait for the return value to propagate,
-        # which may not happen by the time .close() is called by tube.recvall()
-        tmp_sock = self.sock
-
-        data = super(ssh_channel, self).recvall()
-
-        # Restore self.sock to be able to call wait()
-        self.sock = tmp_sock
+    def wait_for_close(self):
         self.wait()
-
-        # Again set self.sock to None
-        self.sock = None
-
-        return data
+        super(ssh_channel, self).wait_for_close()
 
     def wait(self):
         return self.poll(block=True)

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -663,7 +663,7 @@ class tube(Timeout):
                 except EOFError:
                     pass
             h.success("Done (%s)" % l)
-        self.close()
+        self.wait_for_close()
 
         return self.buffer.get()
 


### PR DESCRIPTION
This is a second attempt to resolve the issues seen by SSH, which I can only assume are due to weird timing issues related to `.recvall()` the the lifetime of the socket.

This cannot be merged until #344 is fixed.