### PR TITLE
Attempt at improving logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
   - python -c 'from pwn import *; print pwnlib.term.term_mode' NOTERM
 
-script: make -C docs doctest
+script: PWNLIB_NOTERM=1 make -C docs doctest

--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -2,6 +2,10 @@
 
    from pwn import *
 
+   # redirect logging to `sys.stdout`
+   import pwnlib.log
+   pwnlib.log._console.stream = sys.stdout
+
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================
 

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -71,4 +71,4 @@ def closure():
 closure()
 del closure
 
-log = logging.getLogger('pwnlib.exploit')
+log = getLogger('pwnlib.exploit')

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -7,6 +7,7 @@ from pwnlib.context          import context, Thread
 from pwnlib.dynelf           import DynELF
 from pwnlib.elf              import ELF, load
 from pwnlib.exception        import PwnlibException
+from pwnlib.log              import getLogger
 from pwnlib.memleak          import MemLeak
 from pwnlib.replacements     import *
 from pwnlib.rop              import ROP

--- a/pwnlib/__init__.py
+++ b/pwnlib/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     'tubes'       , 'ui'          , 'useragents'  , 'util'
 ]
 
-
 from . import \
     atexception   , atexit        , asm           , constants     , \
                     dynelf        , elf           , exception     , \

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -39,13 +39,13 @@ Disassembly
     '   0:   b8 0b 00 00 00          mov    eax,0xb'
 
 """
-import tempfile, subprocess, shutil, tempfile, errno, logging, platform
+import tempfile, subprocess, shutil, tempfile, errno, platform
 from os import path, environ
 from glob import glob
-from . import log
+from .log import getLogger
 from .context import context
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 __all__ = ['asm', 'cpp', 'disasm', 'which_binutils']
 
@@ -449,4 +449,3 @@ def disasm(data, vma = 0, **kwargs):
         else:
             shutil.rmtree(tmpdir)
             return result
-

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -51,12 +51,13 @@ from . import elf
 from .elf     import ELF, constants
 from .memleak import MemLeak
 from .context import context
+from .log     import getLogger
 
 from elftools.elf.enums import ENUM_D_TAG
 
-import logging, ctypes
+import ctypes
 
-log    = logging.getLogger(__name__)
+log    = getLogger(__name__)
 sizeof = ctypes.sizeof
 
 def sysv_hash(symbol):

--- a/pwnlib/elf/__init__.py
+++ b/pwnlib/elf/__init__.py
@@ -4,14 +4,15 @@ from ..term import text
 from .datatypes import *
 from ..asm import asm, disasm
 from ..util import misc
+from ..log import getLogger
 
-import mmap, subprocess, os, logging
+import mmap, subprocess, os
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from elftools.elf.descriptions import describe_e_type
 from elftools.elf.constants import P_FLAGS, SHN_INDICES
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 __all__ = ['load', 'ELF'] + sorted(filter(lambda x: not x.startswith('_'), datatypes.__dict__.keys()))
 
@@ -604,4 +605,3 @@ class ELF(ELFFile):
             res.append('Packer:'.ljust(15) + red("Packed with UPX"))
 
         return '\n'.join(res)
-

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -1,8 +1,9 @@
-import os, tempfile, re, shlex, logging
+import os, tempfile, re, shlex
 from .util import misc, proc
 from . import tubes, elf
+from .log import getLogger
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 def debug(args, exe=None, execute=None, ssh=None):
     """debug(args) -> tube

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -110,7 +110,7 @@ from .term      import spinners, text
 from .          import term
 
 # list of prefixes to use for the different message types.  note that the `text`
-# module won't add any escape codes if `sys.stdout.isatty()` is `False`
+# module won't add any escape codes if `sys.stderr.isatty()` is `False`
 _msgtype_prefixes = {
     'status'       : text.magenta('x'),
     'success'      : text.bold_green('+'),

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -262,7 +262,7 @@ class Logger(object):
                     time.sleep(0.5)
                 x = 1/0
         """
-        level = kwargs.get('level', logging.INFO)
+        level = kwargs.pop('level', logging.INFO)
         return Progress(self, message, status, level, args, kwargs)
     waitfor = progress
 
@@ -275,7 +275,7 @@ class Logger(object):
             level(int): Alternate log level at which to set the indented
                         message.  Defaults to `logging.INFO`.
         """
-        level = kwargs.get('level', logging.INFO)
+        level = kwargs.pop('level', logging.INFO)
         self._log(level, message, args, kwargs, 'indented')
 
     def success(self, message, *args, **kwargs):

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -381,6 +381,27 @@ class Logger(object):
         """
         return self._logger.isEnabledFor(level)
 
+    def setLevel(self, level):
+        """setLevel(level)
+
+        Set the logging level for the underlying logger.
+        """
+        self._logger.setLevel(level)
+
+    def addHandler(self, handler):
+        """addHandler(handler)
+
+        Add the specified handler to the underlying logger.
+        """
+        self._logger.addHandler(handler)
+
+    def removeHandler(self, handler):
+        """removeHandler(handler)
+
+        Remove the specified handler from the underlying logger.
+        """
+        self._logger.removeHandler(handler)
+
 class Handler(logging.StreamHandler):
     """
     A custom handler class.  This class will report whatever `context.log_level`

--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -1,6 +1,6 @@
-import logging
 from .util.packing import pack, unpack
-log = logging.getLogger(__name__)
+from .log import getLogger
+log = getLogger(__name__)
 
 class MemLeak(object):
     """MemLeak is a caching and heuristic tool for exploiting memory leaks.

--- a/pwnlib/rop.py
+++ b/pwnlib/rop.py
@@ -1,12 +1,12 @@
 """Return Oriented Programming
 """
 import hashlib, os, sys, tempfile, re
-import logging
 
 from .elf     import ELF
 from .util    import packing
+from .log     import getLogger
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class ROP(object):
     """Class which simplifies the generation of ROP-chains.

--- a/pwnlib/shellcraft/templates/amd64/mov.asm
+++ b/pwnlib/shellcraft/templates/amd64/mov.asm
@@ -1,7 +1,7 @@
 <% from pwnlib.util import lists, packing, fiddling, misc %>\
 <%
-import logging
-log = logging.getLogger('pwnlib.shellcraft')
+from pwnlib.log import getLogger
+log = getLogger('pwnlib.shellcraft')
 %>\
 <%page args="dest, src, stack_allowed = True"/>
 <%docstring>

--- a/pwnlib/shellcraft/templates/i386/mov.asm
+++ b/pwnlib/shellcraft/templates/i386/mov.asm
@@ -1,7 +1,7 @@
 <% from pwnlib.util import lists, packing, fiddling, misc %>\
 <%
-import logging
-log = logging.getLogger('pwnlib.shellcraft')
+from pwnlib.log import getLogger
+log = getLogger('pwnlib.shellcraft')
 %>\
 <%page args="dest, src, stack_allowed = True"/>
 <%docstring>

--- a/pwnlib/term/__init__.py
+++ b/pwnlib/term/__init__.py
@@ -12,10 +12,12 @@ Keymap = keymap.Keymap
 term_mode = False
 
 def can_init():
-    """This function returns True iff stdout is a tty and we are not inside a
-    REPL."""
+    """This function returns True iff stderr is a TTY and we are not inside a
+    REPL.  Iff this function returns `True`, a call to :meth:`init` will let
+    ``pwnlib`` manage the terminal.
+    """
 
-    if not sys.stdout.isatty():
+    if not sys.stderr.isatty():
         return False
 
     # Check for python -i
@@ -45,11 +47,12 @@ def can_init():
 
 
 def init():
-    """Calling this function will take over the terminal (if :func:`can_init`
+    """Calling this function will take over the terminal (iff :func:`can_init`
     returns True) until the current python interpreter is closed.
 
     It is on our TODO, to create a function to "give back" the terminal without
-    closing the interpreter."""
+    closing the interpreter.
+    """
 
     global term_mode
 

--- a/pwnlib/term/__init__.py
+++ b/pwnlib/term/__init__.py
@@ -67,4 +67,9 @@ def init():
     update_geometry()
     term.on_winch.append(update_geometry)
     readline.init()
+
+    # the logging module has an old reference to sys.stderr, so lets update that
+    from ..log import _console
+    _console.stream = sys.stderr
+
     term_mode = True

--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -15,7 +15,7 @@ from . import termcap
 settings = None
 _graphics_mode = False
 
-fd = sys.stdout
+fd = sys.stderr
 
 def show_cursor():
     do('cnorm')

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -9,7 +9,7 @@ def eval_when(when):
         elif when == 'never':
             return False
         elif when == 'auto':
-            return sys.stdout.isatty()
+            return sys.stderr.isatty()
         else:
             return when.isatty()
     else:

--- a/pwnlib/timeout.py
+++ b/pwnlib/timeout.py
@@ -3,10 +3,8 @@
 """
 Timeout encapsulation, complete with countdowns and scope managers.
 """
-import time, logging
+import time
 import pwnlib
-
-log = logging.getLogger(__name__)
 
 class _DummyContextClass(object):
     def __enter__(self):   pass
@@ -153,7 +151,7 @@ class Timeout(object):
             value = float(value)
 
             if value is value < 0:
-                log.error("Timeout cannot be negative")
+                raise AttributeError("timeout: Timeout cannot be negative")
 
             if value > self.maximum:
                 value = self.maximum

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -1,9 +1,10 @@
 from .sock     import sock
 from ..timeout import Timeout
 from ..context import context
-import socket, errno, logging
+from ..log     import getLogger
+import socket, errno
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class listen(sock):
     """Creates an TCP or UDP-socket to receive data on. It supports

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -2,9 +2,10 @@ from .tube import tube
 from ..timeout import Timeout
 from ..util.misc import which
 from ..context import context
-import subprocess, fcntl, os, select, logging
+from ..log import getLogger
+import subprocess, fcntl, os, select
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class process(tube):
     r"""

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -1,9 +1,10 @@
 from .sock import sock
 from ..timeout import Timeout
-import socket, logging
+from ..log import getLogger
+import socket
 import ssl as _ssl
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class remote(sock):
     r"""Creates a TCP or UDP-connection to a remote host. It supports

--- a/pwnlib/tubes/serialtube.py
+++ b/pwnlib/tubes/serialtube.py
@@ -104,8 +104,8 @@ class serialtube(tube.tube):
                     elif cur == '\a':
                         # Ugly hack until term unstands bell characters
                         continue
-                    sys.stdout.write(cur)
-                    sys.stdout.flush()
+                    sys.stderr.write(cur)
+                    sys.stderr.flush()
                 except EOFError:
                     log.info('Got EOF while reading in interactive')
                     go[0] = False

--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -1,7 +1,8 @@
-import socket, errno, select, logging
+import socket, errno, select
 from .tube import tube
+from ..log import getLogger
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class sock(tube):
     """Methods available exclusively to sockets."""

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -151,8 +151,8 @@ class ssh_channel(sock):
                     elif cur == '\a':
                         # Ugly hack until term unstands bell characters
                         continue
-                    sys.stdout.write(cur)
-                    sys.stdout.flush()
+                    sys.stderr.write(cur)
+                    sys.stderr.flush()
                 except EOFError:
                     log.info('Got EOF while reading in interactive')
                     event.set()

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -6,8 +6,9 @@ from ..util import hashes, misc
 from .sock import sock
 from .process import process
 from ..timeout import Timeout
+from ..log import getLogger
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 # Kill the warning line:
 # No handlers could be found for logger "paramiko.transport"

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -3,9 +3,10 @@ from .buffer import Buffer
 from ..timeout import Timeout
 from .. import context, term, atexit
 from ..util import misc, fiddling
+from ..log import getLogger
 import re, threading, sys, time, subprocess, logging, string
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class tube(Timeout):
     """

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -770,8 +770,8 @@ class tube(Timeout):
                 try:
                     cur = self.recv(timeout = 0.05)
                     if cur:
-                        sys.stdout.write(cur)
-                        sys.stdout.flush()
+                        sys.stderr.write(cur)
+                        sys.stderr.flush()
                 except EOFError:
                     log.info('Got EOF while reading in interactive')
                     break

--- a/pwnlib/ui.py
+++ b/pwnlib/ui.py
@@ -1,7 +1,8 @@
 from . import term
-import time, types, logging
+from .log import getLogger
+import time, types
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 def options(prompt, opts, default = None):
     """Presents the user with a prompt (typically in the

--- a/pwnlib/util/iters.py
+++ b/pwnlib/util/iters.py
@@ -53,8 +53,9 @@ __all__ = [
 ]
 
 from itertools import *
-import collections, operator, random, copy, logging
-log = logging.getLogger(__name__)
+from ..log import getLogger
+import collections, operator, random, copy
+log = getLogger(__name__)
 
 def take(n, iterable):
     """take(n, iterable) -> list

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -1,6 +1,7 @@
-import socket, re, os, stat, errno, string, base64, logging
+import socket, re, os, stat, errno, string, base64
 from . import lists
-log = logging.getLogger(__name__)
+from ..log import getLogger
+log = getLogger(__name__)
 
 def align(alignment, x):
     """align(alignment, x) -> int
@@ -82,7 +83,7 @@ def read(path):
 
     Examples:
         >>> read('pwnlib/util/misc.py').split('\\n')[0]
-        'import socket, re, os, stat, errno, string, base64, logging'
+        'import socket, re, os, stat, errno, string, base64'
     """
     path = os.path.expanduser(os.path.expandvars(path))
     with open(path) as fd:

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -1,5 +1,6 @@
-import time, errno, logging
+import time, errno
 from .. import tubes
+from ..log import getLogger
 
 try:
     import psutil
@@ -7,7 +8,7 @@ try:
 except ImportError:
     _ok_import = False
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 if _ok_import:
     all_pids = psutil.pids

--- a/pwnlib/util/web.py
+++ b/pwnlib/util/web.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-import os, tempfile, logging
+import os, tempfile
 from .misc import size
-log = logging.getLogger(__name__)
+from ..log import getLogger
+log = getLogger(__name__)
 
 def wget(url, save=None, timeout=5, **kwargs):
     """wget(url, save=None, timeout=5) -> str


### PR DESCRIPTION
The logging subsystem was rewritten to use the `logging` module.  I think this is a good idea and I think we can do it better.  This PR is an attempt at that.

The current logging subsystem has some issues:
* It installs a new default `Logger` class.  This means that if someone imports `pwnlib` and then uses the `logging` module they will get our overloaded `Logger`'s.  While this may not cause any problems (our `Logger` works just like `logging.Logger` in most regards) it is still bad;  `import pwnlib` should have no side-effects.
* We generate different log records for the same program depending on the value of `term.term_mode`.  If I install a file logger, I shouldn't see any difference.
* Spinners generate log levels originating from loggers names `'pwnlib.spinner.x'`.  This makes it hard to filter messages from a single submodule.

Lets begin with the latter issue.  If I run this:
```
from pwn import *
import logging
logger = logging.getLogger('pwnlib.tubes.listen')
logger.setLevel(logging.WARNING)
sock = listen(1337).wait_for_connection()
```
I expect the spinners to not show.  But they do.  Instead I have to write:
```
from pwn import *
import logging
logger = logging.getLogger('pwnlib.spinner')
logger.setLevel(logging.WARNING)
sock = listen(1337).wait_for_connection()
```
But then I can't have any spinners at all :(.

Next issue;  If I run this:
```
from pwn import *
sock = listen(1337)
sock.recvall()
```
And the send 10MB, I see this in my terminal:
```
[+] Trying to bind to 0.0.0.0 on port 1337: Done
[+] Waiting for connections on 0.0.0.0:1337: Got connection from 127.0.0.1 on port 35277
[+] Recieving all data: Done (10.00MB)
[*] Closed connection to 127.0.0.1 port 35277
```
Which is fine.  But if I then also log to a file:
```
from pwn import *
import logging
logging.basicConfig(filename = 'test.log')
sock = listen(1337)
sock.recvall()
```
Then the file contains:
```
INFO:pwnlib.tubes.sock:Closed connection to 127.0.0.1 port 35279
```
But if I instead pipe the output from python into cat (thus setting `term.term_mode` to false) I see this in my terminal:
```
[*] Trying to bind to 0.0.0.0 on port 1337: 
[*] Trying to bind to 0.0.0.0 on port 1337: Trying 0.0.0.0
[+] Trying to bind to 0.0.0.0 on port 1337: Done
[*] Waiting for connections on 0.0.0.0:1337: 
[*] Recieving all data: 
[+] Waiting for connections on 0.0.0.0:1337: Got connection from 127.0.0.1 on port 35282
[*] Recieving all data: 0B
[*] Recieving all data: 1.69MB
[*] Recieving all data: 3.47MB
[*] Recieving all data: 5.24MB
[*] Recieving all data: 7.08MB
[*] Recieving all data: 8.92MB
[+] Recieving all data: Done (10.00MB)
[*] Closed connection to 127.0.0.1 port 35282
```
And this in `test.log`:
```
INFO:pwnlib.spinner.0:Trying to bind to 0.0.0.0 on port 1337: 
INFO:pwnlib.spinner.0:Trying to bind to 0.0.0.0 on port 1337: Trying 0.0.0.0
INFO:pwnlib.spinner.0:Trying to bind to 0.0.0.0 on port 1337: Done
INFO:pwnlib.spinner.1:Waiting for connections on 0.0.0.0:1337: 
INFO:pwnlib.spinner.2:Recieving all data: 
INFO:pwnlib.spinner.1:Waiting for connections on 0.0.0.0:1337: Got connection from 127.0.0.1 on port 35282
INFO:pwnlib.spinner.2:Recieving all data: 0B
INFO:pwnlib.spinner.2:Recieving all data: 1.69MB
INFO:pwnlib.spinner.2:Recieving all data: 3.47MB
INFO:pwnlib.spinner.2:Recieving all data: 5.24MB
INFO:pwnlib.spinner.2:Recieving all data: 7.08MB
INFO:pwnlib.spinner.2:Recieving all data: 8.92MB
INFO:pwnlib.spinner.2:Recieving all data: Done (10.00MB)
INFO:pwnlib.tubes.sock:Closed connection to 127.0.0.1 port 35282
```

All three issues are resolved in this PR.