### PR TITLE
Clean up the implementation of 'sock', 'remote', and 'listen'

### DIFF
--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -1,10 +1,6 @@
 .. testsetup:: *
 
-   from pwnlib.tubes.tube import tube
-   from pwnlib.tubes.ssh import *
-   from pwnlib.tubes.remote import remote
-   from pwnlib.util.misc import which
-   from pwnlib.context import context
+    from pwn import *
 
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -15,6 +15,7 @@ from pwnlib.tubes.listen     import listen
 from pwnlib.tubes.process    import process
 from pwnlib.tubes.remote     import remote
 from pwnlib.tubes.serialtube import serialtube
+from pwnlib.tubes.sock       import sock
 from pwnlib.tubes.ssh        import ssh
 from pwnlib.tubes.tube       import tube
 from pwnlib.ui               import *

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -6,97 +6,139 @@ import socket, errno, logging
 log = logging.getLogger(__name__)
 
 class listen(sock):
-    """Creates an TCP or UDP-socket to receive data on. It supports
-    both IPv4 and IPv6.
-
-    The returned object supports all the methods from
-    :class:`pwnlib.tubes.sock` and :class:`pwnlib.tubes.tube`.
+    r"""Listens on a socket for exactly one incoming connection.
 
     Args:
         port(int): The port to connect to.
         bindaddr(str): The address to bind to.
-        fam: The string "any", "ipv4" or "ipv6" or an integer to pass to :func:`socket.getaddrinfo`.
-        typ: The string "tcp" or "udp" or an integer to pass to :func:`socket.getaddrinfo`.
+        family: The string "any", "ipv4" or "ipv6" or an integer to pass to :func:`socket.getaddrinfo`.
+        type: The string "tcp" or "udp" or an integer to pass to :func:`socket.getaddrinfo`.
         timeout: A positive number, None
+
+    Examples:
+
+        >>> import socket
+        >>> l = listen(0)
+        >>> s = socket.create_connection(('localhost', l.lport))
+        >>> _ = l.wait_for_connection()
+        >>> s.send('hello')
+        5
+        >>> l.recv()
+        'hello'
+
+        Only one connection is accepted.
+
+        >>> socket.create_connection(('localhost', l.lport))
+        Traceback (most recent call last):
+        ...
+        error: [Errno 61] Connection refused
+
+        UDP works in a similar fashion, and binds to the first host
+        that data is received from.
+
+        >>> l = listen(type='udp')
+        >>> s = socket.socket(type=socket.SOCK_DGRAM)
+        >>> s.sendto('hello', ('localhost', l.lport))
+        5
+        >>> l.recv()
+        'hello'
+
+        IPv6 also works by default
+
+        >>> l = listen(0, '::')
+        >>> s = socket.create_connection(('::1', l.lport))
+        >>> _ = l.wait_for_connection()
+        >>> s.send('hello')
+        5
+        >>> l.recv()
+        'hello'
+        >>> l = listen(0, family='ipv6')
+        >>> s = socket.create_connection(('::1', l.lport))
+        >>> _ = l.wait_for_connection()
+        >>> s.send('hello')
+        5
+        >>> l.recv()
+        'hello'
+
+        You can also replicate the functionality of 'nc -e' to create
+        a socket server that automatically launches a binary.
+
+        >>> l = listen()
+        >>> l.spawn_process('sh')
+        >>> s = socket.create_connection(('localhost', l.lport))
+        >>> s.send('echo hello; exit;\n')
+        18
+        >>> s.recv(1024)
+        'hello\n'
+
     """
 
-    def __init__(self, port=0, bindaddr = "0.0.0.0",
-                 fam = "any", typ = "tcp",
-                 timeout = Timeout.default):
-        super(listen, self).__init__(timeout)
+    def __init__(self,
+                 port     = 0,
+                 bindaddr = "0.0.0.0",
+                 family   = sock.default_family,
+                 type     = sock.default_type,
+                 timeout  = Timeout.default,
+                 ssl      = sock.default_ssl):
 
-        port = int(port)
+        port   = int(port)
+        family = self.get_family(family)
+        type   = self.get_type(type)
 
-        if fam == 'any':
-            fam = socket.AF_UNSPEC
-        elif fam == 4 or fam.lower() in ['ipv4', 'ip4', 'v4', '4']:
-            fam = socket.AF_INET
-        elif fam == 6 or fam.lower() in ['ipv6', 'ip6', 'v6', '6']:
-            fam = socket.AF_INET6
-        elif isinstance(fam, (int, long)):
-            pass
-        else:
-            log.error("remote(): family %r is not supported" % fam)
+        msg = 'Trying to bind to %s on port %d' % (bindaddr, port)
+        with log.waitfor(msg) as h:
 
-        if typ == "tcp":
-            typ = socket.SOCK_STREAM
-        elif typ == "udp":
-            typ = socket.SOCK_DGRAM
-        elif isinstance(typ, (int, long)):
-            pass
-        else:
-            log.error("remote(): type %r is not supported" % typ)
+            for res in socket.getaddrinfo(bindaddr, port, family, type, 0, socket.AI_PASSIVE):
+                f, t, p, _canonname, sockaddr = res
 
-        h = log.waitfor('Trying to bind to %s on port %d' % (bindaddr, port))
+                if t not in [socket.SOCK_STREAM, socket.SOCK_DGRAM]:
+                    continue
 
-        for res in socket.getaddrinfo(bindaddr, port, fam, typ, 0, socket.AI_PASSIVE):
-            self.family, self.type, self.proto, self.canonname, self.sockaddr = res
+                h.status("Trying %s" % sockaddr[0])
+                listen_sock = socket.socket(f, t, p)
+                listen_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                listen_sock.bind(sockaddr)
 
-            if self.type not in [socket.SOCK_STREAM, socket.SOCK_DGRAM]:
-                continue
+                if t == socket.SOCK_STREAM:
+                    listen_sock.listen(1)
+                break
+            else:
+                log.error("Could not bind to %s on port %d" % (bindaddr, port))
 
-            h.status("Trying %s" % self.sockaddr[0])
-            listen_sock = socket.socket(self.family, self.type, self.proto)
-            listen_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            listen_sock.bind(self.sockaddr)
-            self.lhost, self.lport = listen_sock.getsockname()[:2]
-            if self.type == socket.SOCK_STREAM:
-                listen_sock.listen(1)
-            break
-        else:
-            h.failure()
-            log.error("Could not bind to %s on port %d" % (bindaddr, port))
+        # We now have a socket to initialize, pass it to the sock constructor
+        super(listen, self).__init__(socket=listen_sock, timeout=timeout, ssl=ssl)
 
-        h.success()
+        self._accepter = context.Thread(target = self._accepter_thread)
+        self._accepter.daemon = True
+        self._accepter.start()
 
-        h = log.waitfor('Waiting for connections on %s:%s' % (self.lhost, self.lport))
-
-        def accepter():
+    def _accepter_thread(self):
+        msg = 'Waiting for connections on %s:%s' % (self.lhost, self.lport)
+        with log.waitfor(msg) as h:
             while True:
                 try:
                     if self.type == socket.SOCK_STREAM:
-                        self.sock, rhost = listen_sock.accept()
-                        listen_sock.close()
+                        client, rhost = self.sock.accept()
+                        self.sock.close()
+
+                        self.sock = client
                     else:
-                        self.buffer, rhost = listen_sock.recvfrom(4096)
-                        listen_sock.connect(rhost)
-                        self.sock = listen_sock
+                        data, rhost = self.sock.recvfrom(4096)
+                        self.sock.connect(rhost)
+                        self.unrecv(data)
                     self.settimeout(self.timeout)
                     break
                 except socket.error as e:
                     if e.errno == errno.EINTR:
                         continue
-                    h.failure()
                     log.exception("Socket failure while waiting for connection")
                     self.sock = None
                     return
 
             self.rhost, self.rport = rhost[:2]
+
             h.success('Got connection from %s on port %d' % (self.rhost, self.rport))
 
-        self._accepter = context.Thread(target = accepter)
-        self._accepter.daemon = True
-        self._accepter.start()
 
     def spawn_process(self, *args, **kwargs):
         def accepter():
@@ -104,25 +146,26 @@ class listen(sock):
             p = super(listen, self).spawn_process(*args, **kwargs)
             p.wait()
             self.close()
+
         t = context.Thread(target = accepter)
         t.daemon = True
         t.start()
 
-    def wait_for_connection(self):
-        """Blocks until a connection has been established."""
-        self.sock
+
+    def wait_for_connection(self, timeout=Timeout.default):
+        """Blocks until a connection has been established.
+
+        Arguments:
+            timeout(int): Maximum time to wait for a connection
+        """
+        with self.countdown(timeout):
+            while self.countdown_active() and self._accepter.is_alive():
+                self._accepter.join(timeout = 0.1)
+
         return self
 
-    def __getattr__(self, key):
-        if key == 'sock':
-            while self._accepter.is_alive():
-                self._accepter.join(timeout = 0.1)
-            if 'sock' in self.__dict__:
-                return self.sock
-            else:
-                return None
-        else:
-            return getattr(super(listen, self), key)
+    #: Alias for :meth:`wait_for_connection`
+    accept = wait_for_connection
 
     def close(self):
         # since `close` is scheduled to run on exit we must check that we got

--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -1,14 +1,82 @@
 import socket, errno, select, logging
+from ssl import wrap_socket, SSLSocket
 from .tube import tube
+from ..timeout import Timeout
 
 log = logging.getLogger(__name__)
 
 class sock(tube):
-    """Methods available exclusively to sockets."""
+    r"""Encapsulates a standard socket-like object with a tube interface.
 
-    def __init__(self, timeout):
+    Examples:
+
+        >>> import socket
+        >>> s = socket.create_connection(('google.com', 80))
+        >>> s.send('GET /' + '\r\n'*2)
+        9
+        >>> tubesock = sock(s)
+        >>> tubesock.recvline(4)
+        'HTTP/1.0 200 OK\r\n'
+    """
+
+    default_family = 'any'
+    default_type   = 'tcp'
+    default_ssl    = False
+
+    def __init__(self,
+                 socket  = None,
+                 timeout = Timeout.default,
+                 ssl     = default_ssl):
+
         super(sock, self).__init__(timeout)
+
         self.closed = {"recv": False, "send": False}
+
+        self.sock              = socket
+        self.lhost, self.lport = self.sock.getsockname()[:2]
+        self.type              = self.sock.type
+        self.proto             = self.sock.proto
+        self.family            = self.sock.family
+
+        try:
+            self.rhost, self.rport = self.sock.getpeername()[:2]
+        except:
+            self.rhost = self.rport = None
+
+        if ssl:
+            self.sock = wrap_socket(self.sock)
+
+        self.settimeout(timeout)
+
+    @staticmethod
+    def get_family(fam):
+
+        if isinstance(fam, (int, long)):
+            pass
+        elif fam == 'any':
+            fam = socket.AF_UNSPEC
+        elif fam.lower() in ['ipv4', 'ip4', 'v4', '4']:
+            fam = socket.AF_INET
+        elif fam.lower() in ['ipv6', 'ip6', 'v6', '6']:
+            fam = socket.AF_INET6
+        else:
+            log.error("remote(): family %r is not supported" % fam)
+
+        return fam
+
+    @staticmethod
+    def get_type(typ):
+
+        if isinstance(typ, (int, long)):
+            pass
+        elif typ == "tcp":
+            typ = socket.SOCK_STREAM
+        elif typ == "udp":
+            typ = socket.SOCK_DGRAM
+        else:
+            log.error("remote(): type %r is not supported" % typ)
+
+        return typ
 
     # Overwritten for better usability
     def recvall(self):
@@ -22,8 +90,16 @@ class sock(tube):
         else:
             return super(sock, self).recvall()
 
+    _eof_exception_errors = [
+        errno.EPIPE,
+        errno.ECONNRESET,
+        errno.ECONNREFUSED
+    ]
+    def _is_eof_exception(self, e):
+        return e.errno in self._eof_exception_errors or e.message == 'Socket is closed'
+
     def recv_raw(self, numb):
-        if self.closed["recv"]:
+        if not self.connected("recv"):
             raise EOFError
 
         while True:
@@ -35,7 +111,7 @@ class sock(tube):
             except IOError as e:
                 if e.errno == errno.EAGAIN:
                     return None
-                elif e.errno in [errno.ECONNREFUSED, errno.ECONNRESET]:
+                elif self._is_eof_exception(e):
                     self.shutdown("recv")
                     raise EOFError
                 elif e.errno == errno.EINTR:
@@ -50,14 +126,13 @@ class sock(tube):
         return data
 
     def send_raw(self, data):
-        if self.closed["send"]:
+        if not self.connected("send"):
             raise EOFError
 
         try:
             self.sock.sendall(data)
         except IOError as e:
-            eof_numbers = [errno.EPIPE, errno.ECONNRESET, errno.ECONNREFUSED]
-            if e.message == 'Socket is closed' or e.errno in eof_numbers:
+            if self._is_eof_exception(e):
                 self.shutdown("send")
                 raise EOFError
             else:
@@ -68,32 +143,49 @@ class sock(tube):
             self.sock.settimeout(timeout)
 
     def can_recv_raw(self, timeout):
-        if not self.sock or self.closed["recv"]:
+        if not self.connected_raw('recv'):
             return False
 
         return select.select([self.sock], [], [], timeout) == ([self.sock], [], [])
 
     def connected_raw(self, direction):
-        if not self.sock:
+        # The connection is closed via .close()
+        if not getattr(self, 'sock', None):
             return False
 
-        if direction == 'any':
-            return True
-        elif direction == 'recv':
-            return not self.closed['recv']
-        elif direction == 'send':
-            return not self.closed['send']
+        # The connection is closed in that direction via .shutdown()
+        if self.closed.get(direction, False):
+            return False
+
+        # If the socket is wrapped with SSL, we can't call peek directly on it.
+        peek_socket = self.sock
+
+        if isinstance(self.sock, SSLSocket):
+            peek_socket = self.sock._sock
+
+        try:
+            # Don't block
+            with self.local(0):
+                # Return value of '' implies the connection is closed
+                if peek_socket.recv(1, socket.MSG_PEEK | socket.MSG_DONTWAIT):
+                    return True
+        except IOError as e:
+            # Still connected
+            if e.errno == errno.EAGAIN:   return True
+            # Connection has closed unexpectedly
+            if self._is_eof_exception(e): return False
+            # Bad things happened
+            raise
+
+        return False
 
     def close(self):
         if not getattr(self, 'sock', None):
             return
 
         # Call shutdown without triggering another call to close
-        self.closed['hack'] = False
-        self.shutdown('recv')
-        self.shutdown('send')
-        del self.closed['hack']
-
+        self._shutdown_raw_inner(socket.SHUT_RDWR)
+        self.closed = {'send': True, 'recv': True}
         self.sock.close()
         self.sock = None
         self._close_msg()
@@ -102,34 +194,30 @@ class sock(tube):
         log.info('Closed connection to %s port %d' % (self.rhost, self.rport))
 
     def fileno(self):
-        if not self.sock:
+        if not getattr(self, 'sock', None):
             log.error("A closed socket does not have a file number")
 
         return self.sock.fileno()
 
+    def _shutdown_raw_inner(self, flag):
+        try:
+            self.sock.shutdown(flag)
+        except IOError as e:
+            if e.errno in [errno.ENOTCONN, errno.EBADF]:
+                pass
+            else:
+                raise
+
     def shutdown_raw(self, direction):
-        if self.closed[direction]:
+        if not self.connected(direction):
             return
 
+        flag = {'send': socket.SHUT_WR,
+                'recv': socket.SHUT_RD}[direction]
+
+        self._shutdown_raw_inner(flag)
+
         self.closed[direction] = True
-
-        if direction == "send":
-            try:
-                self.sock.shutdown(socket.SHUT_WR)
-            except IOError as e:
-                if e.errno == errno.ENOTCONN:
-                    pass
-                else:
-                    raise
-
-        if direction == "recv":
-            try:
-                self.sock.shutdown(socket.SHUT_RD)
-            except IOError as e:
-                if e.errno == errno.ENOTCONN:
-                    pass
-                else:
-                    raise
 
         if False not in self.closed.values():
             self.close()

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -663,7 +663,7 @@ class tube(Timeout):
                 except EOFError:
                     pass
             h.success("Done (%s)" % l)
-        self.close()
+        self.wait_for_close()
 
         return self.buffer.get()
 


### PR DESCRIPTION
- All three now have doctests
- Promoted 'sock' to the toplevel
- As much functionality as possible is implemented in the base 'sock' class
- Arguments 'typ' and 'fam' renamed to follow the standard library socket.socket() argument names
- Added alias listen.accept for listen.wait_for_connection
- Added connection closure detection.  sock.wait_for_close() now returns upon an unexpected connection termination.  Fixes #344.