### PR TITLE
Enable flat() for bytearray().  Pass argument given to hexdump() to flat() first.

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -580,4 +580,5 @@ def hexdump_iter(s, width = 16, skip = True, hexii = False, begin = 0,
 
 def hexdump(s, width = 16, skip = True, hexii = False, begin = 0,
             style = None, highlight = None):
+    s = packing.flat(s)
     return '\n'.join(hexdump_iter(s, width, skip, hexii, begin, style, highlight))

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -480,6 +480,8 @@ def _flat(args, preprocessor, packer):
             out.append(arg.encode('utf8'))
         elif isinstance(arg, (int, long)):
             out.append(packer(arg))
+        elif isinstance(arg, bytearray):
+            out.append(str(arg))
         else:
             raise ValueError("flat(): Flat does not support values of type %s" % type(arg))
     return ''.join(out)


### PR DESCRIPTION
```py
>>> print hexdump(bytearray('Hello'))
00000000  48 65 6c 6c  6f                                     │Hell│o│
00000005
```