### PR TITLE
added command line option "LOG_FILE"

### DIFF
--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -36,22 +36,22 @@ def closure():
         k = k[7:]
         if   k == 'DEBUG':
             if asbool(v):
-                context.log_level = 'debug'
+                context.log_level = 'DEBUG'
         elif k == 'SILENT':
             if asbool(v):
                 context.log_level = 'ERROR'
         elif k == 'NOTERM':
             if asbool(v):
                 term_mode = False
-        elif k == 'LOG_LEVEL':
-            context.log_level = v
         elif isident(k):
             args[k] = v
     # parse command line
-    for arg in sys.argv[:]:
+    # save a copy of argv for the log file header (see below)
+    argv = sys.argv[:]
+    for arg in argv:
         if   arg == 'DEBUG':
             sys.argv.remove(arg)
-            context.log_level = 'debug'
+            context.log_level = 'DEBUG'
         elif arg == 'SILENT':
             sys.argv.remove(arg)
             context.log_level = 'ERROR'
@@ -63,6 +63,47 @@ def closure():
                 continue
             sys.argv.remove(arg)
             args[k] = v
+    if 'LOG_LEVEL' in args:
+        context.log_level = args['LOG_LEVEL']
+    if 'LOG_FILE' in args:
+        # install a file logger
+        import logging, time
+        modes = ('w', 'wb', 'a', 'ab')
+        filename = args['LOG_FILE']
+        mode = 'a'
+        # check if mode was specified as "[filename],[mode]"
+        if ',' in filename:
+            filename_, mode_ = filename.rsplit(',', 1)
+            if mode in modes:
+                filename = filename_
+                mode = mode_
+        # ISO 8601
+        dfmt = '%Y-%m-%dT%H:%M:%S'
+        # write a "header" to the file, which makes it easier to find the start
+        # of a session
+        with open(filename, mode) as fd:
+            lines = [
+                '=' * 78,
+                ' Started at %s ' % time.strftime(dfmt),
+                ' sys.argv = [',
+                ]
+            for arg in argv:
+                lines.append('   %r,' % arg)
+            lines.append(' ]')
+            lines.append('=' * 78)
+            for line in lines:
+                fd.write('=%s=\n' % line.ljust(78))
+        # if the mode was 'w' or 'wb' we need to change it to 'a'/'ab' now so
+        # the logging module wont overwrite the header
+        mode = mode.replace('w', 'a')
+        # create a formatter and a handler and install them for the pwnlib root
+        # logger (i.e. 'pwnlib')
+        handler = logging.FileHandler(filename, mode)
+        fmt = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
+        formatter = logging.Formatter(fmt, dfmt)
+        handler.setFormatter(formatter)
+        logger = logging.getLogger('pwnlib')
+        logger.addHandler(handler)
     # put the terminal in rawmode unless NOTERM was specified
     if term_mode:
         term.init()

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -102,8 +102,7 @@ def closure():
         fmt = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
         formatter = logging.Formatter(fmt, dfmt)
         handler.setFormatter(formatter)
-        logger = logging.getLogger('pwnlib')
-        logger.addHandler(handler)
+        logging.root.addHandler(handler)
     # put the terminal in rawmode unless NOTERM was specified
     if term_mode:
         term.init()


### PR DESCRIPTION
When importing `pwn`, `LOG_FILE=[filename]` can now be given on the command line (or `PWNLIB_LOG_FILE=[filename]` in the environment) to install a file logger.

Also, `LOG_LEVEL` can now be given both on the command line or in the environment (as `PWNLIB_LOG_LEVEL` of course).

PS. I now have this in my `.bashrc`:
```bash
function python () {
  if [[ "$1" == "doit.py" ]] ; then
    command python "$@" LOG_FILE=doit.log
  else
    command python "$@"
  fi
}
```