### PR TITLE
pwnlib root logger now reports parents level if more verbose

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -569,7 +569,8 @@ def closure():
     def setter(self, level):
         self._level = level
     def getter(self):
-        return self._level or min(context.log_level, logging.INFO)
+        return self._level or min(context.log_level, logging.INFO,
+                                  self.parent.getEffectiveLevel())
     prop = property(
         getter,
         setter,


### PR DESCRIPTION
If the log level for the pwnlib root logger (named 'pwnlib') is not set and its parents level is more verbose than `context.log_level` then return the parents level.

This is needed if e.g. a catch-all handler is installed for `logging.root` and the level for `logging.root` is set to `logging.DEBUG`.