### PR TITLE
Restore logging functionality

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -437,17 +437,6 @@ class Handler(logging.StreamHandler):
 
     An instance of this handler is added to the ``'pwnlib'`` logger.
     """
-    @property
-    def level(self):
-        """
-        The current log level; always equal to :data:`context.log_level`.
-        Setting this property is a no-op.
-        """
-        return context.log_level
-
-    @level.setter
-    def level(self, _):
-        pass
 
     def emit(self, record):
         """
@@ -605,8 +594,7 @@ def closure():
     def setter(self, level):
         self._level = level
     def getter(self):
-        return self._level or min(context.log_level, logging.INFO,
-                                  self.parent.getEffectiveLevel())
+        return context.log_level
     prop = property(
         getter,
         setter,

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -542,7 +542,7 @@ class Formatter(logging.Formatter):
 
         msg = prefix + msg
         msg = self.nlindent.join(msg.splitlines())
-        return msg
+        return msg % record.__dict__
 
 # we keep a dictionary of loggers such that multiple calls to `getLogger` with
 # the same name will return the same logger

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -589,25 +589,13 @@ _console.setFormatter(Formatter())
 # Since properties are looked up on an instance's class we need to monkey patch
 # the whole class...
 rootlogger = logging.getLogger('pwnlib')
-def closure():
-    import types
-    def setter(self, level):
-        self._level = level
-    def getter(self):
-        return context.log_level
-    prop = property(
-        getter,
-        setter,
-        None,
-        None
-    )
-    cls = rootlogger.__class__
-    cls = type(cls.__name__, (cls,), {})
-    cls.level = prop
-    rootlogger.__class__ = cls
-closure()
-del closure
-rootlogger.level = logging.NOTSET
+
+class RootLogger(rootlogger.__class__):
+    @property
+    def level(self):
+        return min(context.log_level, self.parent.getEffectiveLevel())
+
+rootlogger.__class__ = RootLogger
 rootlogger.addHandler(_console)
 rootlogger = Logger(rootlogger)
 _loggers['pwnlib'] = rootlogger


### PR DESCRIPTION

- Enable correct cascading of logging output per the logging heirarchy the functionality of [getEffectiveLevel](https://docs.python.org/2/library/logging.html#logging.Logger.getEffectiveLevel)
    - This is achieved by removing filtering inside the `Handler`.  
        - This doesn't need to be done, it's effectively already done by the `logging` subsystem.
- Since we implement a custom `Handler`, we must also perform formatting of the `LogRecord` fields
- Remove (erroneous?) limitation of `rootlogger.level` which meant it could never be set to less-verbose than `info`.

Fixes #380 

### Example Program

```
from pwn import *
from pwnlib.log import getLogger
import logging

a = getLogger('pwnlib.a')
aa = getLogger('pwnlib.a.a')
ab = getLogger('pwnlib.a.b')
abx = getLogger('pwnlib.a.b.x')
aby = getLogger('pwnlib.a.b.y')

a.setLevel(logging.WARNING)
ab.setLevel(logging.INFO)
abx.setLevel(logging.DEBUG)

for logger in [a, aa, ab, abx, aby]:
    for meth in [logger.warning, logger.info, logger.debug]:
        meth('%(name)s %(levelname)s')

log.debug('NOT OK')
log.info('1')
with context.local(log_level='WARN'):
    assert context.log_level == logging.WARNING
    log.info('NOT OK')
    log.warn('2')
    a.warn('3')
    ab.info('4')
    abx.debug('5')
    aby.debug('NOT OK')

log.info('6')
```

### Output

```
[!] pwnlib.a WARNING
[!] pwnlib.a.a WARNING
[!] pwnlib.a.b WARNING
[*] pwnlib.a.b INFO
[!] pwnlib.a.b.x WARNING
[*] pwnlib.a.b.x INFO
[DEBUG] pwnlib.a.b.x DEBUG
[!] pwnlib.a.b.y WARNING
[*] pwnlib.a.b.y INFO
[*] 1
[!] 2
[!] 3
[*] 4
[DEBUG] 5
[*] 6
```

### Current `master` output

```
[!] %(name)s %(levelname)s
[!] %(name)s %(levelname)s
[!] %(name)s %(levelname)s
[*] %(name)s %(levelname)s
[!] %(name)s %(levelname)s
[*] %(name)s %(levelname)s
[!] %(name)s %(levelname)s
[*] %(name)s %(levelname)s
[*] 1
[!] 2
[!] 3
[*] 6
```