### PR TITLE
"shellcraft -?" now removes any doctests from the docstring

### DIFF
--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -198,7 +198,7 @@ def main():
 
             if not in_doctest:
                 doc.append(line)
-        print '\n'.join(doc)
+        print '\n'.join(doc).rstrip()
         exit()
 
     defargs = len(func.func_defaults or ())

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -164,7 +164,41 @@ def main():
         func = vals[0][1]
 
     if args.show:
-        print func.__doc__
+        # remove doctests
+        doc = []
+        in_doctest = False
+        block_indent = None
+        caption = None
+        for i, line in enumerate(func.__doc__.splitlines()):
+            if line.lstrip().startswith('>>>'):
+                # this line starts a doctest
+                in_doctest = True
+                if caption:
+                    # delete back up to the caption
+                    doc = doc[:caption - i]
+                    caption = None
+            elif line == '':
+                # skip blank lines
+                pass
+            elif in_doctest:
+                # indentation marks the end of a doctest
+                indent = len(line) - len(line.lstrip())
+                if block_indent is None:
+                    block_indent = indent
+                elif indent < block_indent:
+                    in_doctest = False
+                    block_indent = None
+            elif line.endswith(':'):
+                # save index of caption
+                caption = i
+            else:
+                # this is not blank space and we're not in a doctest, so the
+                # previous caption (if any) was not for a doctest
+                caption = None
+
+            if not in_doctest:
+                doc.append(line)
+        print '\n'.join(doc)
         exit()
 
     defargs = len(func.func_defaults or ())


### PR DESCRIPTION
Fixes #362.

Without this PR:
```
$ shellcraft i386.stackhunter -?
    stackhunter(cookie = 0x7afceb58)

    Returns an an egghunter, which searches from esp and upwards
    for a cookie. However to save bytes, it only looks at a single
    4-byte alignment. Use the function stackhunter_helper to
    generate a suitable cookie prefix for you.

    The default cookie has been chosen, because it makes it possible
    to shave a single byte, but other cookies can be used too.

Example:

    >>> with context.local():
    ...    context.arch = 'i386'
    ...    print enhex(asm(shellcraft.stackhunter()))
    3d58ebfc7a75faffe4
    >>> with context.local():
    ...    context.arch = 'i386'
    ...    print enhex(asm(shellcraft.stackhunter(0xdeadbeef)))
    583defbeadde75f8ffe4
```
and with it:
```
$ shellcraft i386.stackhunter -?
    stackhunter(cookie = 0x7afceb58)

    Returns an an egghunter, which searches from esp and upwards
    for a cookie. However to save bytes, it only looks at a single
    4-byte alignment. Use the function stackhunter_helper to
    generate a suitable cookie prefix for you.

    The default cookie has been chosen, because it makes it possible
    to shave a single byte, but other cookies can be used too.
```