### PR TITLE
command line flag NOTERM no longer turns text decoration off

### DIFF
--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -106,8 +106,6 @@ def closure():
     # put the terminal in rawmode unless NOTERM was specified
     if term_mode:
         term.init()
-    else:
-        term.text.when = 'never'
 closure()
 del closure
 


### PR DESCRIPTION
text decoration is turned on for TTYs and off otherwise; `NOTERM` only instructs `pwnlib` not to control the terminal