### PR TITLE
now only install a log handler when not in lib-mode

### DIFF
--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -3,8 +3,8 @@
    from pwn import *
 
    # redirect logging to `sys.stdout`
-   import pwnlib.log
-   pwnlib.log._console.stream = sys.stdout
+   import logging
+   logging.getLogger('pwnlib').handlers[0].stream = sys.stdout
 
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -108,6 +108,7 @@ def closure():
         term.init()
     # install a log handler and turn logging all the way up
     import pwnlib.log as log
+    import logging
     log.rootlogger.setLevel(logging.DEBUG)
     handler = log.Handler()
     formatter = log.Formatter()

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -106,6 +106,14 @@ def closure():
     # put the terminal in rawmode unless NOTERM was specified
     if term_mode:
         term.init()
+    # install a log handler and turn logging all the way up
+    import pwnlib.log as log
+    log.rootlogger.setLevel(logging.DEBUG)
+    handler = log.Handler()
+    formatter = log.Formatter()
+    handler.setFormatter(formatter)
+    log.rootlogger.addHandler(handler)
+
 closure()
 del closure
 

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -558,7 +558,8 @@ def getLogger(name):
     return _loggers[name]
 
 #
-# By default, everything will log to the console.
+# The root 'pwnlib' logger is declared here.  To change the target of all
+# 'pwntools'-specific logging, only this logger needs to be changed.
 #
 # Logging cascades upward through the heirarchy,
 # so the only point that should ever need to be
@@ -568,23 +569,5 @@ def getLogger(name):
 #     map(rootlogger.removeHandler, rootlogger.handlers)
 #     logger.addHandler(myCoolPitchingHandler)
 #
-#
-_console = Handler()
-_console.setFormatter(Formatter())
 
-#
-# The root 'pwnlib' logger is declared here, and attached to the
-# console.  To change the target of all 'pwntools'-specific
-# logging, only this logger needs to be changed.
-#
-# As explained at the top of this file we monkey patch the logger such that its
-# log level will be `logging.DEBUG` or `logging.INFO` depending on
-# `context.log_level`, if not set explicitly.
-#
-# Since properties are looked up on an instance's class we need to monkey patch
-# the whole class...
-rootlogger = logging.getLogger('pwnlib')
-rootlogger.setLevel(logging.DEBUG)
-rootlogger.addHandler(_console)
-rootlogger = Logger(rootlogger)
-_loggers['pwnlib'] = rootlogger
+rootlogger = getLogger('pwnlib')

--- a/pwnlib/term/__init__.py
+++ b/pwnlib/term/__init__.py
@@ -71,8 +71,4 @@ def init():
     term.on_winch.append(update_geometry)
     readline.init()
 
-    # the logging module has an old reference to sys.stderr, so lets update that
-    from ..log import _console
-    _console.stream = sys.stderr
-
     term_mode = True


### PR DESCRIPTION
Fixes #392.

The level of the `'pwnlib'` logger is not set explicitly in non-lib mode either.
