### PR TITLE
no longer creates an "a.out" when using `pwnlib.asm`

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -152,7 +152,7 @@ def _assembler():
 
     if not checked_assembler_version[gas]:
         checked_assembler_version[gas] = True
-        result = subprocess.check_output([gas, '-v','/dev/null'],
+        result = subprocess.check_output([gas, '--version','/dev/null'],
                                          stderr=subprocess.STDOUT)
         version = re.search(r' (\d\.\d+)', result).group(1)
         if version < '2.19':


### PR DESCRIPTION
Fixes #395.

The problem was introduced in #374;  the problem was that `gas` was called with `-v` instead of `--version`.