### PR TITLE
bugfix: command line tools now installs a log handler

### DIFF
--- a/docs/source/log.rst
+++ b/docs/source/log.rst
@@ -2,7 +2,7 @@
 ===================================
 
 .. automodule:: pwnlib.log
-   :members: getLogger
+   :members: getLogger, install_default_handler, rootlogger
 
 .. autoclass:: pwnlib.log.Progress
    :members:

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -110,10 +110,7 @@ def closure():
     import pwnlib.log as log
     import logging
     log.rootlogger.setLevel(logging.DEBUG)
-    handler = log.Handler()
-    formatter = log.Formatter()
-    handler.setFormatter(formatter)
-    log.rootlogger.addHandler(handler)
+    log.install_default_handler()
 
 closure()
 del closure

--- a/pwnlib/commandline/asm.py
+++ b/pwnlib/commandline/asm.py
@@ -5,6 +5,9 @@ from pwnlib.asm           import asm
 from pwnlib.context       import context
 from pwnlib.util.fiddling import enhex
 
+import pwnlib.log
+pwnlib.log.install_default_handler()
+
 parser = argparse.ArgumentParser(
     description = 'Assemble shellcode into bytes'
 )

--- a/pwnlib/commandline/constgrep.py
+++ b/pwnlib/commandline/constgrep.py
@@ -3,8 +3,10 @@
 import argparse, os, re
 from pwnlib import asm, constants
 from pwnlib.util import safeeval
-# from pwnlib.context import __possible__ as contexts
 from pwnlib.context import context
+
+import pwnlib.log
+pwnlib.log.install_default_handler()
 
 p = argparse.ArgumentParser(
     description = "Looking up constants from header files.\n\nExample: constgrep -c freebsd -m  ^PROT_ '3 + 4'",

--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python2
 import argparse, string, sys
 from pwnlib.util import cyclic, packing
-from pwnlib.log import getLogger
+from pwnlib.log import getLogger, install_default_handler
+install_default_handler()
 
 log = getLogger('pwnlib.commandline.cyclic')
 

--- a/pwnlib/commandline/disasm.py
+++ b/pwnlib/commandline/disasm.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python2
-
 import argparse, sys
 from pwnlib import asm
 from pwnlib.context import context
 from string import whitespace, hexdigits
+
+import pwnlib.log
+pwnlib.log.install_default_handler()
 
 parser = argparse.ArgumentParser(
     description = 'Disassemble bytes into text format'

--- a/pwnlib/commandline/elfpatch.py
+++ b/pwnlib/commandline/elfpatch.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python2
-
 import argparse, sys
 from pwnlib.elf import ELF
 from pwnlib.util.fiddling import unhex
+
+import pwnlib.log
+pwnlib.log.install_default_handler()
+
 p = argparse.ArgumentParser()
 p.add_argument('elf',help="File to patch")
 p.add_argument('offset',help="Offset to patch in virtual address (hex encoded)")

--- a/pwnlib/commandline/phd.py
+++ b/pwnlib/commandline/phd.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python2
-
 import argparse, sys, os
 import pwnlib.term.text as text
 from pwnlib.util.fiddling import hexdump_iter
+
+import pwnlib.log
+pwnlib.log.install_default_handler()
 
 parser = argparse.ArgumentParser(
     description = 'Pwnlib HexDump'

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -4,7 +4,9 @@ import pwnlib
 from pwnlib import util
 import pwnlib.term.text as text
 from pwnlib.context import context
-from pwnlib.log import getLogger
+from pwnlib.log import getLogger, install_default_handler
+install_default_handler()
+
 log = getLogger('pwnlib.commandline.shellcraft')
 
 r = text.red

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -93,7 +93,7 @@ logger.
 """
 
 __all__ = [
-    'getLogger', 'rootlogger'
+    'getLogger', 'install_default_handler', 'rootlogger'
 ]
 
 import logging, re, threading, sys, random, time
@@ -571,3 +571,15 @@ def getLogger(name):
 #
 
 rootlogger = getLogger('pwnlib')
+
+def install_default_handler():
+    '''install_default_handler()
+
+    Instantiates a :class:`Handler` and :class:`Formatter` and installs them for
+    the ``pwnlib`` root logger.  This function is automatically called from when
+    importing :mod:`pwn`.
+    '''
+    handler = Handler()
+    formatter = Formatter()
+    handler.setFormatter(formatter)
+    rootlogger.addHandler(handler)


### PR DESCRIPTION
After installation of the log handler was moved from `pwnlib.log` to `pwn.__init__` the command line tools needs to install it themselves.  I've left if to `pwn.__init__` to set the log level to `logging.DEBUG`, which means that the command line tools use the default setting (`logging.WARN`); should we set it explicitly? (and in that case, to what?).

Please comment before merging.