### PR TITLE
Updated a lot of shellcode

### DIFF
--- a/pwnlib/constants/__init__.py
+++ b/pwnlib/constants/__init__.py
@@ -50,6 +50,8 @@ class module(ModuleType):
             '__all__':     submodules,
         })
 
+        self._env_store = {}
+
     def __getattr__(self, key):
         if key in self.__all__:
             mod = importlib.import_module('.' + key, __package__)
@@ -85,8 +87,10 @@ class module(ModuleType):
             ...    print constants.eval('SYS_execve + PROT_WRITE')
             61
         """
-        env = {key: getattr(self, key) for key in dir(self) if not key.endswith('__')}
-        return safeeval.values(string, env)
+        key = context.os, context.arch
+        if key not in self._env_store:
+            self._env_store[key] = {key: getattr(self, key) for key in dir(self) if not key.endswith('__')}
+        return safeeval.values(string, self._env_store[key])
 
 # To prevent garbage collection
 tether = sys.modules[__name__]

--- a/pwnlib/shellcraft/templates/amd64/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/echo.asm
@@ -1,5 +1,4 @@
 <% from pwnlib.shellcraft import amd64 %>
-<% from pwnlib.constants.linux.amd64 import SYS_write %>
 <%page args="string, sock = 'rbp'"/>
 <%docstring>Writes a string to a file descriptor</%docstring>
 

--- a/pwnlib/shellcraft/templates/amd64/linux/mov.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/mov.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.shellcraft import amd64
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="dest, src, stack_allowed = True"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.amd64.mov`, which sets
+`context.os` to `'linux'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.amd64.linux.mov('eax', 'SYS_execve').rstrip()
+        push 0x3b
+        pop rax
+
+</%docstring>
+
+% with ctx.local(os = 'linux'):
+  ${amd64.mov(dest, src, stack_allowed)}
+% endwith

--- a/pwnlib/shellcraft/templates/amd64/linux/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/push.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.shellcraft import amd64
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="value"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.amd64.push`, which sets
+`context.os` to `'linux'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.amd64.linux.push('SYS_execve').rstrip()
+        /* push 'SYS_execve' */
+        push 0x3b
+
+</%docstring>
+
+% with ctx.local(os = 'linux'):
+  ${amd64.push(value)}
+% endwith

--- a/pwnlib/shellcraft/templates/amd64/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/syscall.asm
@@ -1,9 +1,13 @@
-<% from pwnlib.shellcraft import amd64 %>\
-<% from pwnlib.constants.linux import amd64 as constants %>\
+<%
+  from pwnlib.shellcraft import amd64
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
 <%page args="syscall = None, arg0 = None, arg1 = None, arg2 = None, arg3 = None, arg4 = None, arg5 = None"/>
 <%docstring>
-Args: [syscall_number, *args]
+Args: [syscall_number, \*args]
     Does a syscall
+
+Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constants.eval`.
 
 Example:
 
@@ -45,6 +49,26 @@ Example:
             pop rdx
             mov rax, rbp
             syscall
+        >>> print pwnlib.shellcraft.amd64.linux.syscall(
+        ...               'SYS_mmap', 0, 0x1000,
+        ...               'PROT_READ | PROT_WRITE | PROT_EXEC',
+        ...               'MAP_PRIVATE | MAP_ANONYMOUS',
+        ...               -1, 0).rstrip()
+            /* call mmap(0, 4096, 'PROT_READ | PROT_WRITE | PROT_EXEC', 'MAP_PRIVATE | MAP_ANONYMOUS', -1, 0) */
+            xor edi, edi
+            mov esi, 0x1010101
+            xor esi, 0x1011101
+            push 0x7
+            pop rdx
+            push 0x22
+            pop r10
+            push -1
+            pop r8
+            xor r9d, r9d
+            push 0x9
+            pop rax
+            syscall
+
 </%docstring>
 <%
   append_cdq = False
@@ -72,11 +96,7 @@ Example:
   % if dst == 'rdx' and src == 0:
     <% append_cdq = True %>\
   % elif src != None:
-    <%
-      if isinstance(src, (str, unicode)):
-          src = getattr(constants, src, src)
-    %>\
-    ${amd64.mov(dst, src)}
+    ${amd64.linux.mov(dst, src)}
   % endif
 % endfor
 % if append_cdq:

--- a/pwnlib/shellcraft/templates/amd64/pushstr.asm
+++ b/pwnlib/shellcraft/templates/amd64/pushstr.asm
@@ -8,7 +8,7 @@ Example:
 
     >>> print shellcraft.amd64.pushstr('').rstrip()
         /* push '\x00' */
-        push 1
+        push 0x1
         dec byte ptr [rsp]
     >>> print shellcraft.amd64.pushstr('a').rstrip()
         /* push 'a\x00' */
@@ -78,7 +78,7 @@ Args:
     sign = packing.u64(word, 'little', 'signed')
 %>\
 % if sign in [0, 0xa]:
-    push ${sign + 1}
+    push ${pretty(sign + 1)}
     dec byte ptr [rsp]
 % elif -0x80 <= sign <= 0x7f and okay(word[0]):
     push ${pretty(sign)}

--- a/pwnlib/shellcraft/templates/i386/freebsd/mov.asm
+++ b/pwnlib/shellcraft/templates/i386/freebsd/mov.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.shellcraft import i386
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="dest, src, stack_allowed = True"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.i386.mov`, which sets
+`context.os` to `'freebsd'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.i386.freebsd.mov('eax', 'SYS_execve').rstrip()
+        push 0x3b
+        pop eax
+
+</%docstring>
+
+% with ctx.local(os = 'freebsd'):
+  ${i386.mov(dest, src, stack_allowed)}
+% endwith

--- a/pwnlib/shellcraft/templates/i386/freebsd/push.asm
+++ b/pwnlib/shellcraft/templates/i386/freebsd/push.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.shellcraft import i386
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="value"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.i386.push`, which sets
+`context.os` to `'freebsd'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.i386.freebsd.push('SYS_execve').rstrip()
+        /* push 'SYS_execve' */
+        push 0x3b
+
+</%docstring>
+
+% with ctx.local(os = 'freebsd'):
+  ${i386.push(value)}
+% endwith

--- a/pwnlib/shellcraft/templates/i386/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/echo.asm
@@ -1,5 +1,4 @@
 <% from pwnlib.shellcraft import i386 %>
-<% from pwnlib.constants.linux.i386 import SYS_write %>
 <%page args="string, sock = 'ebp'"/>
 <%docstring>Writes a string to a file descriptor</%docstring>
 

--- a/pwnlib/shellcraft/templates/i386/linux/mov.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/mov.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.shellcraft import i386
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="dest, src, stack_allowed = True"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.i386.mov`, which sets
+`context.os` to `'linux'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.i386.linux.mov('eax', 'SYS_execve').rstrip()
+        push 0xb
+        pop eax
+
+</%docstring>
+
+% with ctx.local(os = 'linux'):
+  ${i386.mov(dest, src, stack_allowed)}
+% endwith

--- a/pwnlib/shellcraft/templates/i386/linux/push.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/push.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.shellcraft import i386
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="value"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.i386.push`, which sets
+`context.os` to `'linux'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.i386.linux.push('SYS_execve').rstrip()
+        /* push 'SYS_execve' */
+        push 0xb
+
+</%docstring>
+
+% with ctx.local(os = 'linux'):
+  ${i386.push(value)}
+% endwith

--- a/pwnlib/shellcraft/templates/i386/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/sh.asm
@@ -1,5 +1,4 @@
 <% from pwnlib.shellcraft import i386 %>
-<% from pwnlib.constants.linux.i386 import SYS_execve %>
 <%docstring>Execute /bin/sh</%docstring>
 
 ${i386.pushstr('/bin///sh')}

--- a/pwnlib/shellcraft/templates/i386/linux/stager.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/stager.asm
@@ -1,7 +1,5 @@
 <% from pwnlib.shellcraft import common %>
 <% from pwnlib.shellcraft import i386 %>
-<% from pwnlib.shellcraft.i386 import linux %>
-<% from pwnlib.constants import SYS_mmap2, SYS_read, PROT_EXEC, PROT_WRITE, PROT_READ, MAP_ANON, MAP_PRIVATE %>
 <%docstring>
 Recives a fixed sized payload into a mmaped buffer
 Useful in conjuncion with findpeer.
@@ -17,7 +15,7 @@ Args:
 %>
 ${stager}:
     push ${sock}
-    ${i386.linux.syscall(SYS_mmap2, 0, size, PROT_EXEC+PROT_WRITE+PROT_READ,  MAP_ANON+MAP_PRIVATE, 0xffffffff, 0)}
+    ${i386.linux.syscall('SYS_mmap2', 0, size, 'PROT_EXEC | PROT_WRITE | PROT_READ', 'MAP_ANON | MAP_PRIVATE', -1, 0)}
     mov ecx, eax
     pop ebx /* sock */
     push ecx /* save for: pop eax; call eax later */
@@ -25,7 +23,7 @@ ${stager}:
 
 /* read/recv loop */
 ${looplabel}:
-    ${i386.linux.syscall(SYS_read, 'ebx', 'ecx', 'edx')}
+    ${i386.linux.syscall('SYS_read', 'ebx', 'ecx', 'edx')}
     test eax, eax
 % if handle_error:
     js ${errlabel}

--- a/pwnlib/shellcraft/templates/i386/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/syscall.asm
@@ -1,9 +1,13 @@
-<% from pwnlib.shellcraft import i386 %>\
-<% from pwnlib.constants.linux import i386 as constants %>\
+<%
+  from pwnlib.shellcraft import i386
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
 <%page args="syscall = None, arg0 = None, arg1 = None, arg2 = None, arg3 = None, arg4 = None, arg5 = None"/>
 <%docstring>
-Args: [syscall_number, *args]
+Args: [syscall_number, \*args]
     Does a syscall
+
+Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constants.eval`.
 
 Example:
 
@@ -45,8 +49,12 @@ Example:
             pop edx
             mov eax, ebp
             int 0x80
-        >>> print pwnlib.shellcraft.i386.linux.syscall('SYS_mmap2', 0, 0x1000, 7, 0x22, -1, 0).rstrip()
-            /* call mmap2(0, 4096, 7, 34, -1, 0) */
+        >>> print pwnlib.shellcraft.i386.linux.syscall(
+        ...               'SYS_mmap2', 0, 0x1000,
+        ...               'PROT_READ | PROT_WRITE | PROT_EXEC',
+        ...               'MAP_PRIVATE | MAP_ANONYMOUS',
+        ...               -1, 0).rstrip()
+            /* call mmap2(0, 4096, 'PROT_READ | PROT_WRITE | PROT_EXEC', 'MAP_PRIVATE | MAP_ANONYMOUS', -1, 0) */
             xor ebx, ebx
             mov ecx, 0x1010101
             xor ecx, 0x1011101
@@ -87,11 +95,7 @@ Example:
   % if dst == 'edx' and src == 0:
     <% append_cdq = True %>\
   % elif src != None:
-    <%
-      if isinstance(src, (str, unicode)):
-          src = getattr(constants, src, src)
-    %>\
-    ${i386.mov(dst, src)}
+    ${i386.linux.mov(dst, src)}
   % endif
 % endfor
 % if append_cdq:

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -1,17 +1,61 @@
-<% from pwnlib.util import packing %>
-<% from pwnlib.shellcraft import i386 %>
-<% import re %>
+<%
+  from pwnlib.util import packing
+  from pwnlib.shellcraft import i386
+  from pwnlib import constants
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+  import re
+%>
 <%page args="value"/>
 <%docstring>
 Pushes a value onto the stack without using
 null bytes or newline characters.
 
+If src is a string, then we try to evaluate with `context.arch = 'i386'` using
+:func:`pwnlib.constants.eval` before determining how to push it. Note that this
+means that this shellcode can change behavior depending on the value of
+`context.os`.
+
 Args:
   value (int,str): The value or register to push
+
+Example:
+
+    >>> print pwnlib.shellcraft.i386.push(0).rstrip()
+        /* push 0 */
+        push 0x1
+        dec byte ptr [esp]
+    >>> print pwnlib.shellcraft.i386.push(1).rstrip()
+        /* push 1 */
+        push 0x1
+    >>> print pwnlib.shellcraft.i386.push(256).rstrip()
+        /* push 256 */
+        push 0x1010201
+        xor dword ptr [esp], 0x1010301
+    >>> with context.local(os = 'linux'):
+    ...     print pwnlib.shellcraft.i386.push('SYS_execve').rstrip()
+        /* push 'SYS_execve' */
+        push 0xb
+    >>> with context.local(os = 'freebsd'):
+    ...     print pwnlib.shellcraft.i386.push('SYS_execve').rstrip()
+        /* push 'SYS_execve' */
+        push 0x3b
 </%docstring>
 
+<%
+  value_orig = value
+  # There are no meaningful constants of length < 3.
+  # There are however constants such as EBP, which we would
+  # prefer to avoid.
+  if isinstance(value, (str, unicode)) and len(value) > 3:
+    try:
+      with ctx.local(arch = 'i386'):
+        value = constants.eval(value)
+    except (ValueError, AttributeError):
+      pass
+%>
+
 % if isinstance(value, (int,long)):
-    /* push ${repr(value)} */
+    /* push ${repr(value_orig)} */
     ${re.sub(r'^\s*/.*\n', '', i386.pushstr(packing.pack(value, 32, 'little', True), False), 1)}
 % else:
     push ${value}

--- a/pwnlib/shellcraft/templates/i386/pushstr.asm
+++ b/pwnlib/shellcraft/templates/i386/pushstr.asm
@@ -8,7 +8,7 @@ Example:
 
     >>> print shellcraft.i386.pushstr('').rstrip()
         /* push '\x00' */
-        push 1
+        push 0x1
         dec byte ptr [esp]
     >>> print shellcraft.i386.pushstr('a').rstrip()
         /* push 'a\x00' */
@@ -23,7 +23,7 @@ Example:
         xor dword ptr [esp], 0x1606060
     >>> print shellcraft.i386.pushstr('aaaa').rstrip()
         /* push 'aaaa\x00' */
-        push 1
+        push 0x1
         dec byte ptr [esp]
         push 0x61616161
     >>> print shellcraft.i386.pushstr('aaaaa').rstrip()
@@ -80,7 +80,7 @@ Args:
     sign = packing.u32(word, 'little', 'signed')
 %>\
 % if sign in [0, 0xa]:
-    push ${sign + 1}
+    push ${pretty(sign + 1)}
     dec byte ptr [esp]
 % elif -0x80 <= sign <= 0x7f and okay(word[0]):
     push ${pretty(sign)}

--- a/pwnlib/shellcraft/templates/thumb/linux/bindsh.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/bindsh.asm
@@ -1,6 +1,4 @@
 <% from pwnlib.shellcraft.thumb.linux import listen, dupsh%>
-<% from pwnlib import constants %>
-<% from socket import htons %>
 <%page args="port, network='ipv4'"/>
 <%docstring>
     bindsh(port,network)

--- a/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
@@ -1,5 +1,4 @@
-<% from pwnlib.shellcraft.thumb import mov %>
-<% from pwnlib import constants %>
+<% from pwnlib.shellcraft.thumb.linux import mov %>
 <% from socket import htons %>
 <%page args="port = None"/>
 <%docstring>
@@ -20,7 +19,7 @@ next_socket:
     /* Next file descriptor */
     add r6, #1
 
-    ${mov('r7', constants.linux.thumb.SYS_getpeername)}
+    ${mov('r7', 'SYS_getpeername')}
 
     /* Reset stack */
     mov sp, lr

--- a/pwnlib/shellcraft/templates/thumb/linux/listen.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/listen.asm
@@ -1,5 +1,4 @@
-<% from pwnlib.shellcraft.thumb import mov %>
-<% from pwnlib import constants %>
+<% from pwnlib.shellcraft.thumb.linux import mov %>
 <% from socket import htons %>
 <%page args="port, network='ipv4'"/>
 <%docstring>
@@ -9,13 +8,13 @@
     Port is the TCP port to listen on, network is either 'ipv4' or 'ipv6'.
 </%docstring>
     /* First create listening socket */
-    ${mov('r7', constants.linux.thumb.SYS_socket)}
+    ${mov('r7', 'SYS_socket')}
 %if network == 'ipv4':
-    ${mov('r0', constants.linux.thumb.AF_INET)}
+    ${mov('r0', 'AF_INET')}
 %else:
-    ${mov('r0', constants.linux.thumb.AF_INET6)}
+    ${mov('r0', 'AF_INET6')}
 %endif
-    ${mov('r1', constants.linux.thumb.SOCK_STREAM)}
+    ${mov('r1', 'SOCK_STREAM')}
     eor r2, r2
     svc 1
 
@@ -26,7 +25,7 @@
     /* Build sockaddr_in structure */
     /* r2 is zero == INADDR_ANY */
     /* Put port and address family into r1 */
-    ${mov('r1', ((htons(port) << 16) + constants.linux.thumb.AF_INET))}
+    ${mov('r1', 'AF_INET | (%d << 16)' % htons(port))}
     push {r1, r2}
 
     /* Address of sockaddr_in into r1 */
@@ -48,7 +47,7 @@
     push {r1, r2, r3}
     
     /* Then port = %d */
-    ${mov('r1', (htons(port) << 16) + constants.linux.thumb.AF_INET6)}
+    ${mov('r1', 'AF_INET6 | (%d << 16)' % htons(port))}
     push {r1, r2, r3}
 
     /* Address of sockaddr_in6 into r1 */

--- a/pwnlib/shellcraft/templates/thumb/linux/mov.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/mov.asm
@@ -1,0 +1,20 @@
+<%
+  from pwnlib.shellcraft import thumb
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="dest, src"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.thumb.mov`, which sets
+`context.os` to `'linux'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.thumb.linux.mov('r1', 'SYS_execve').rstrip()
+        mov r1, #11
+
+</%docstring>
+
+% with ctx.local(os = 'linux'):
+  ${thumb.mov(dest, src)}
+% endwith

--- a/pwnlib/shellcraft/templates/thumb/linux/push.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/push.asm
@@ -1,0 +1,22 @@
+<%
+  from pwnlib.shellcraft import thumb
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
+<%page args="value"/>
+<%docstring>
+
+Thin wrapper around :func:`pwnlib.shellcraft.thumb.push`, which sets
+`context.os` to `'linux'` before calling.
+
+Example:
+
+    >>> print pwnlib.shellcraft.thumb.linux.push('SYS_execve').rstrip()
+        /* push 'SYS_execve' */
+        mov r1, #11
+        push {r1}
+
+</%docstring>
+
+% with ctx.local(os = 'linux'):
+  ${thumb.push(value)}
+% endwith

--- a/pwnlib/shellcraft/templates/thumb/mov.asm
+++ b/pwnlib/shellcraft/templates/thumb/mov.asm
@@ -1,19 +1,73 @@
-<% from pwnlib.shellcraft import common %>
+<%
+  from pwnlib.shellcraft import common
+  from pwnlib import constants
+  from pwnlib.context import context as ctx # Ugly hack, mako will not let it be called context
+%>
 <%page args="dst, src"/>
 <%docstring>
     mov(dst, src)
 
     Returns THUMB code for moving the specified source value
     into the specified destination register.
+
+    If src is a string that is not a register, then it will locally set
+    `context.arch` to `'thumb'` and use :func:`pwnlib.constants.eval` to evaluate the
+    string. Note that this means that this shellcode can change behavior depending
+    on the value of `context.os`.
+
+Example:
+
+   >>> print shellcraft.thumb.mov('r1','r2').rstrip()
+       mov r1, r2
+   >>> print shellcraft.thumb.mov('r1', 0).rstrip()
+       eor r1, r1
+   >>> print shellcraft.thumb.mov('r1', 10).rstrip()
+       mov r1, #10
+   >>> print shellcraft.thumb.mov('r1', 17).rstrip()
+       mov r1, #17
+   >>> print shellcraft.thumb.mov('r1', 'r1').rstrip()
+       /* moving r1 into r1, but this is a no-op */
+   >>> print shellcraft.thumb.mov('r1', 0xdead00ff).rstrip()
+       ldr r1, value_...
+       b value_..._after
+   value_...: .word 3735879935
+   value_..._after:
+   >>> with context.local(os = 'linux'):
+   ...     print shellcraft.thumb.mov('r1', 'SYS_execve').rstrip()
+       mov r1, #11
+   >>> with context.local(os = 'freebsd'):
+   ...     print shellcraft.thumb.mov('r1', 'SYS_execve').rstrip()
+       mov r1, #59
+   >>> with context.local(os = 'linux'):
+   ...     print shellcraft.thumb.mov('r1', 'PROT_READ | PROT_WRITE | PROT_EXEC').rstrip()
+       mov r1, #7
+
 </%docstring>
-/* Set ${dst} = ${src} */
-%if not isinstance(src, (int, long)):
+<%
+all_regs = ['r' + str(n) for n in range(16)] + ['sp', 'fp', 'pc', 'lr']
+src_orig = src
+if isinstance(src, (str, unicode)):
+    src = src.strip()
+    if src.lower() in all_regs:
+        src = src.lower()
+    else:
+        with ctx.local(arch = 'thumb'):
+            try:
+                src = constants.eval(src)
+            except (AttributeError, ValueError):
+                log.error("Could not figure out the value of %r" % src)
+                return
+
+%>
+% if dst == src:
+  /* moving ${src} into ${dst}, but this is a no-op */
+% elif not isinstance(src, (int, long)):
     mov ${dst}, ${src}
-%else:
+% else:
   <%
     srcu = src & 0xffffffff
     srcs = srcu - 2 * (srcu & 0x80000000)
-  %>
+  %>\
   %if srcu == 0:
     eor ${dst}, ${dst}
   %elif srcu < 256:
@@ -26,7 +80,7 @@
       shift1 = 0
       while (1 << shift1) & src == 0:
           shift1 += 1
-    %>
+    %>\
     %if (0xff << shift1) & src == src:
       %if shift1 < 4:
         mov ${dst}, #${src >> shift1}
@@ -41,7 +95,7 @@
         shift2 = 8
         while (1 << shift2) & src == 0:
             shift2 += 1
-      %>
+      %>\
       %if ((0xff << shift2) | 0xff) & src == src:
         mov ${dst}, #${src >> shift2}
         lsl ${dst}, #${shift2}
@@ -51,7 +105,7 @@
           shift3 = shift1 + 8
           while (1 << shift3) & src == 0:
               shift3 += 1
-        %>
+        %>\
         %if ((0xff << shift1) | (0xff << shift3)) & src == src:
           mov ${dst}, #${src >> shift3}
           lsl ${dst}, #${shift3 - shift1}
@@ -67,7 +121,7 @@
                     "lsl %s, #8" % dst,
                     "lsr %s, #8" % dst
                   ])
-            %>
+            %>\
             ldr ${dst}, ${id}
             b ${id}_after
             ${id}: .word ${src}

--- a/pwnlib/shellcraft/templates/thumb/pushstr.asm
+++ b/pwnlib/shellcraft/templates/thumb/pushstr.asm
@@ -1,5 +1,7 @@
-<% from pwnlib.shellcraft.thumb import mov %>
-<% from pwnlib.util import lists, packing %>\
+<%
+  from pwnlib.shellcraft import thumb
+  from pwnlib.util import lists, packing
+%>
 <%page args="string, append_null = True"/>
 <%docstring>
 Pushes a string onto the stack without using
@@ -32,8 +34,7 @@ Examples:
 
 %>\
     /* push ${repr(string)} */
-
 % for word in lists.group(4, string, 'fill', '\x00')[::-1]:
-    ${mov('r1', packing.unpack(word))}
+    ${thumb.mov('r1', packing.unpack(word))}
     push {r1}
 % endfor


### PR DESCRIPTION
This PR implements a new eval method on the constants module to evaluate
constants in the current context.

It then updates the mov and push shellcodes to use these new methods.

It adds new shellcodes `[arch].[os].{push,mov}`, which is thin wrappers
around `[arch].{push,mov}`, which sets the context first.

Finally it updates all the shellcodes using mov and push shellcodes, to
take advantage of these new features of mov and push.