### PR TITLE
Simplify docstring stripping for the shellcraft command line tool.

### DIFF
--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-import argparse, sys, os, types
+import argparse, sys, os, types, textwrap
 import pwnlib
 from pwnlib import util
 import pwnlib.term.text as text
@@ -166,49 +166,10 @@ def main():
         func = vals[0][1]
 
     if args.show:
-        # remove doctests
-        doc = []
-        in_doctest = False
-        block_indent = None
-        caption = None
-        lines = func.__doc__.splitlines()
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-            if line.lstrip().startswith('>>>'):
-                # this line starts a doctest
-                in_doctest = True
-                block_indent = None
-                if caption:
-                    # delete back up to the caption
-                    doc = doc[:caption - i]
-                    caption = None
-            elif line == '':
-                # skip blank lines
-                pass
-            elif in_doctest:
-                # indentation marks the end of a doctest
-                indent = len(line) - len(line.lstrip())
-                if block_indent is None:
-                    if not line.lstrip().startswith('...'):
-                        block_indent = indent
-                elif indent < block_indent:
-                    in_doctest = False
-                    block_indent = None
-                    # re-evalutate this line
-                    continue
-            elif line.endswith(':'):
-                # save index of caption
-                caption = i
-            else:
-                # this is not blank space and we're not in a doctest, so the
-                # previous caption (if any) was not for a doctest
-                caption = None
-
-            if not in_doctest:
-                doc.append(line)
-            i += 1
-        print '\n'.join(doc).rstrip()
+        docstring = func.__doc__
+        docstring, examples = docstring.split('Example:')
+        docstring = textwrap.dedent(docstring)
+        print docstring.rstrip()
         exit()
 
     defargs = len(func.func_defaults or ())

--- a/pwnlib/shellcraft/templates/amd64/mov.asm
+++ b/pwnlib/shellcraft/templates/amd64/mov.asm
@@ -20,6 +20,11 @@ If src is a string that is not a register, then it will locally set
 string. Note that this means that this shellcode can change behavior depending
 on the value of `context.os`.
 
+Arguments:
+  dest (str): The destination register.
+  src (str): Either the input register, or an immediate value.
+  stack_allowed (bool): Can the stack be used?
+
 Example:
 
     >>> print shellcraft.amd64.mov('eax','ebx').rstrip()
@@ -74,11 +79,6 @@ Example:
    ...     print shellcraft.amd64.mov('eax', 'PROT_READ | PROT_WRITE | PROT_EXEC').rstrip()
        push 0x7
        pop rax
-
-Args:
-  dest (str): The destination register.
-  src (str): Either the input register, or an immediate value.
-  stack_allowed (bool): Can the stack be used?
 </%docstring>
 <%
 regs = [['rax', 'eax', 'ax', 'ah', 'al'],

--- a/pwnlib/shellcraft/templates/amd64/pushstr.asm
+++ b/pwnlib/shellcraft/templates/amd64/pushstr.asm
@@ -4,6 +4,10 @@
 Pushes a string onto the stack without using
 null bytes or newline characters.
 
+Arguments:
+  string (str): The string to push.
+  append_null (bool): Whether to append a single NULL-byte before pushing.
+
 Example:
 
     >>> print shellcraft.amd64.pushstr('').rstrip()
@@ -50,10 +54,6 @@ Example:
     ...    context.arch = 'amd64'
     ...    print enhex(asm(shellcraft.pushstr("\x00", False)))
     6a01fe0c24
-
-Args:
-  string (str): The string to push.
-  append_null (bool): Whether to append a single NULL-byte before pushing.
 </%docstring>
 <%
     if append_null:

--- a/pwnlib/shellcraft/templates/arm/ret.asm
+++ b/pwnlib/shellcraft/templates/arm/ret.asm
@@ -4,7 +4,7 @@
 Args:
     return_value: Value to return
 
-Examples:
+Example:
     >>> with context.local(arch='arm'):
     ...     print enhex(asm(shellcraft.ret()))
     ...     print enhex(asm(shellcraft.ret(0)))

--- a/pwnlib/shellcraft/templates/i386/pushstr.asm
+++ b/pwnlib/shellcraft/templates/i386/pushstr.asm
@@ -4,6 +4,10 @@
 Pushes a string onto the stack without using
 null bytes or newline characters.
 
+Arguments:
+  string (str): The string to push.
+  append_null (bool): Whether to append a single NULL-byte before pushing.
+
 Example:
 
     >>> print shellcraft.i386.pushstr('').rstrip()
@@ -52,10 +56,6 @@ Example:
     ...    context.arch = 'i386'
     ...    print enhex(asm(shellcraft.pushstr("\x00", False)))
     6a01fe0c24
-
-Args:
-  string (str): The string to push.
-  append_null (bool): Whether to append a single NULL-byte before pushing.
 </%docstring>
 <%
     if append_null:

--- a/pwnlib/shellcraft/templates/thumb/pushstr.asm
+++ b/pwnlib/shellcraft/templates/thumb/pushstr.asm
@@ -11,7 +11,7 @@ Args:
   string (str): The string to push.
   append_null (bool): Whether to append a single NULL-byte before pushing.
 
-Examples:
+Example:
     >>>> with context.local():
     ...    context.arch = 'thumb'
     ...    print enhex(asm(shellcraft.pushstr('Hello\nWorld!', True)))


### PR DESCRIPTION
We can get away with the code being simpler as long as we ensure that
all of the docstrings come after the string "Example".  Most of them
did, and I fixed the ones that did not.

Some of the Example blocks came before the Arguments block, I moved
those up so they wouldn't be stripped.

Additionally, some of the docstrings are actually indented. For example,
compare `i386.stackhunter` to `i386.mov`.  The `textwrap` module has a
utility function to uniformly dedent text.  I've added this to make
everything left-aligned.