### PR TITLE
Logging dont cache loggers

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -437,17 +437,6 @@ class Handler(logging.StreamHandler):
 
     An instance of this handler is added to the ``'pwnlib'`` logger.
     """
-    @property
-    def level(self):
-        """
-        The current log level; always equal to :data:`context.log_level`.
-        Setting this property is a no-op.
-        """
-        return context.log_level
-
-    @level.setter
-    def level(self, _):
-        pass
 
     def emit(self, record):
         """
@@ -605,8 +594,7 @@ def closure():
     def setter(self, level):
         self._level = level
     def getter(self):
-        return self._level or min(context.log_level, logging.INFO,
-                                  self.parent.getEffectiveLevel())
+        return context.log_level
     prop = property(
         getter,
         setter,

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -542,7 +542,7 @@ class Formatter(logging.Formatter):
 
         msg = prefix + msg
         msg = self.nlindent.join(msg.splitlines())
-        return msg
+        return msg % record.__dict__
 
 # we keep a dictionary of loggers such that multiple calls to `getLogger` with
 # the same name will return the same logger

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -546,7 +546,6 @@ class Formatter(logging.Formatter):
 
 # we keep a dictionary of loggers such that multiple calls to `getLogger` with
 # the same name will return the same logger
-_loggers = dict()
 def getLogger(name):
     '''getLogger(name) -> Logger
 
@@ -556,11 +555,7 @@ def getLogger(name):
     This function should be used instead of :func:`logging.getLogger` as we add
     some ``pwnlib`` flavor by wrapping it in a :class:`Logger`.
     '''
-    if name not in _loggers:
-        # if we don't have this logger create a new one and feed it through our
-        # "proxy" class
-        _loggers[name] = Logger(logging.getLogger(name))
-    return _loggers[name]
+    return Logger(logging.getLogger(name))
 
 #
 # By default, everything will log to the console.

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -589,25 +589,13 @@ _console.setFormatter(Formatter())
 # Since properties are looked up on an instance's class we need to monkey patch
 # the whole class...
 rootlogger = logging.getLogger('pwnlib')
-def closure():
-    import types
-    def setter(self, level):
-        self._level = level
-    def getter(self):
-        return context.log_level
-    prop = property(
-        getter,
-        setter,
-        None,
-        None
-    )
-    cls = rootlogger.__class__
-    cls = type(cls.__name__, (cls,), {})
-    cls.level = prop
-    rootlogger.__class__ = cls
-closure()
-del closure
-rootlogger.level = logging.NOTSET
+
+class RootLogger(rootlogger.__class__):
+    @property
+    def level(self):
+        return min(context.log_level, self.parent.getEffectiveLevel())
+
+rootlogger.__class__ = RootLogger
 rootlogger.addHandler(_console)
 rootlogger = Logger(rootlogger)
 _loggers['pwnlib'] = rootlogger


### PR DESCRIPTION
There's no reason to cache pwnlib.log.Logger objects; the logging module already performs the exact same caching.