### PR TITLE
There's no reason to cache pwnlib.log.Logger objects

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -223,11 +223,12 @@ class Logger(object):
 
     Loggers instantiated with :func:`getLogger` will be of this class.
     """
-    _one_time_infos    = set()
-    _one_time_warnings = set()
-
     def __init__(self, logger):
         self._logger = logger
+
+        if not hasattr(logger, '_one_time_infos'):
+            logger._one_time_infos    = set()
+            logger._one_time_warnings = set()
 
     def _log(self, level, msg, args, kwargs, msgtype, progress = None):
         extra = kwargs.get('extra', {})
@@ -297,8 +298,8 @@ class Logger(object):
         Logs an info message.  The same message is never printed again.
         """
         m = message % args
-        if m not in self._one_time_infos:
-            self._one_time_infos.add(m)
+        if m not in self._logger._one_time_infos:
+            self._logger._one_time_infos.add(m)
             self._log(logging.INFO, message, args, kwargs, 'info_once')
 
     def warning_once(self, message, *args, **kwargs):
@@ -307,8 +308,8 @@ class Logger(object):
         Logs a warning message.  The same message is never printed again.
         """
         m = message % args
-        if m not in self._one_time_warnings:
-            self._one_time_warnings.add(m)
+        if m not in self._logger._one_time_warnings:
+            self._logger._one_time_warnings.add(m)
             self._log(logging.WARNING, message, args, kwargs, 'warning_once')
 
     def warn_once(self, *args, **kwargs):

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -539,9 +539,6 @@ class Formatter(logging.Formatter):
         msg = self.nlindent.join(msg.splitlines())
         return msg
 
-# we keep a dictionary of loggers such that multiple calls to `getLogger` with
-# the same name will return the same logger
-_loggers = dict()
 def getLogger(name):
     '''getLogger(name) -> Logger
 
@@ -551,11 +548,7 @@ def getLogger(name):
     This function should be used instead of :func:`logging.getLogger` as we add
     some ``pwnlib`` flavor by wrapping it in a :class:`Logger`.
     '''
-    if name not in _loggers:
-        # if we don't have this logger create a new one and feed it through our
-        # "proxy" class
-        _loggers[name] = Logger(logging.getLogger(name))
-    return _loggers[name]
+    return Logger(logging.getLogger(name))
 
 #
 # The root 'pwnlib' logger is declared here.  To change the target of all


### PR DESCRIPTION
The logging module already performs the exact same caching.

Also, the same `pwnlib.log.Logger` object is never actually instantiated twice, as far as I can tell.