### PR TITLE
Move log context level checking to the root 'pwnlib' logger

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -419,18 +419,6 @@ class Handler(logging.StreamHandler):
 
     An instance of this handler is added to the ``'pwnlib'`` logger.
     """
-    @property
-    def level(self):
-        """
-        The current log level; always equal to :data:`context.log_level`.
-        Setting this property is a no-op.
-        """
-        return context.log_level
-
-    @level.setter
-    def level(self, _):
-        pass
-
     def emit(self, record):
         """
         Emit a log record or create/update an animated progress logger
@@ -569,8 +557,19 @@ def getLogger(name):
 #     map(rootlogger.removeHandler, rootlogger.handlers)
 #     logger.addHandler(myCoolPitchingHandler)
 #
+rootlogger = logging.getLogger('pwnlib')
 
-rootlogger = getLogger('pwnlib')
+class RootLogger(rootlogger.__class__):
+    @property
+    def level(self):
+        return min(context.log_level, self.parent.getEffectiveLevel())
+
+    @level.setter
+    def level(self, value):
+        pass
+
+rootlogger.__class__ = RootLogger
+rootlogger = Logger(rootlogger)
 
 def install_default_handler():
     '''install_default_handler()


### PR DESCRIPTION
This enables the use case that I've been trying to get to work.

```py
from pwn import *
import logging
log.debug("FAIL")
log.info("A")
l = pwnlib.log.getLogger("pwnlib.foo")
l.debug("FAIL")
l.info("B")
l.setLevel(logging.DEBUG)
l.debug("C")
with context.local(log_level='WARN'):
    log.info("FAIL")
    l.info("D")
    l.debug("E")
```

When run with `PWNLIB_LOG_FILE=/dev/stderr python ...`, we get the following:

```
================================================================================
= Started at 2015-01-12T04:02:45                                               =
= sys.argv = [                                                                 =
=   '',                                                                        =
= ]                                                                            =
================================================================================
[*] A
2015-01-12T04:02:45:INFO:pwnlib.exploit:A
[*] B
2015-01-12T04:02:45:INFO:pwnlib.foo:B
[DEBUG] C
2015-01-12T04:02:45:DEBUG:pwnlib.foo:C
[*] D
2015-01-12T04:02:45:INFO:pwnlib.foo:D
[DEBUG] E
2015-01-12T04:02:45:DEBUG:pwnlib.foo:E
```