### PR TITLE
Enable per-thread logfiles via context, and retargetting the logfile at runtime

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,15 +45,7 @@ pwnlib.context.ContextType.defaults['log_level'] = 'ERROR'
 pwnlib.term.text.when = 'never'
 pwnlib.log.install_default_handler()
 pwnlib.log.console.stream = sys.stdout
-
-original_emit = pwnlib.log.log_file.emit
-
-def emit_and_flush(*a, **kw):
-    rv = original_emit(*a, **kw)
-    pwnlib.log.log_file.flush()
-    return rv
-
-pwnlib.log.log_file.emit = emit_and_flush
+pwnlib.log.rootlogger.setLevel(1)
 '''
 
 autodoc_member_order = 'alphabetical'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,15 @@ pwnlib.context.ContextType.defaults['log_level'] = 'ERROR'
 pwnlib.term.text.when = 'never'
 pwnlib.log.install_default_handler()
 pwnlib.log.console.stream = sys.stdout
+
+original_emit = pwnlib.log.log_file.emit
+
+def emit_and_flush(*a, **kw):
+    rv = original_emit(*a, **kw)
+    pwnlib.log.log_file.flush()
+    return rv
+
+pwnlib.log.log_file.emit = emit_and_flush
 '''
 
 autodoc_member_order = 'alphabetical'

--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -2,7 +2,8 @@
 
    import pwnlib
    from   pwnlib.context import context
-   import threading, logging
+   import threading, logging, time
+   log = pwnlib.log.getLogger('pwnlib.context')
 
 
 :mod:`pwnlib.context` --- Setting runtime variables

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -75,6 +75,7 @@ def closure():
     # install a log handler and turn logging all the way up
     import pwnlib.log as log
     import logging
+    log.rootlogger.setLevel(1)
     log.install_default_handler()
 
 closure()

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -75,7 +75,6 @@ def closure():
     # install a log handler and turn logging all the way up
     import pwnlib.log as log
     import logging
-    log.rootlogger.setLevel(logging.DEBUG)
     log.install_default_handler()
 
 closure()

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -1,6 +1,8 @@
 # Promote useful stuff to toplevel
 from .toplevel import *
 
+log = getLogger('pwnlib.exploit')
+
 # look for special args in argv
 def closure():
     term_mode = True
@@ -66,43 +68,7 @@ def closure():
     if 'LOG_LEVEL' in args:
         context.log_level = args['LOG_LEVEL']
     if 'LOG_FILE' in args:
-        # install a file logger
-        import logging, time
-        modes = ('w', 'wb', 'a', 'ab')
-        filename = args['LOG_FILE']
-        mode = 'a'
-        # check if mode was specified as "[filename],[mode]"
-        if ',' in filename:
-            filename_, mode_ = filename.rsplit(',', 1)
-            if mode in modes:
-                filename = filename_
-                mode = mode_
-        # ISO 8601
-        dfmt = '%Y-%m-%dT%H:%M:%S'
-        # write a "header" to the file, which makes it easier to find the start
-        # of a session
-        with open(filename, mode) as fd:
-            lines = [
-                '=' * 78,
-                ' Started at %s ' % time.strftime(dfmt),
-                ' sys.argv = [',
-                ]
-            for arg in argv:
-                lines.append('   %r,' % arg)
-            lines.append(' ]')
-            lines.append('=' * 78)
-            for line in lines:
-                fd.write('=%s=\n' % line.ljust(78))
-        # if the mode was 'w' or 'wb' we need to change it to 'a'/'ab' now so
-        # the logging module wont overwrite the header
-        mode = mode.replace('w', 'a')
-        # create a formatter and a handler and install them for the pwnlib root
-        # logger (i.e. 'pwnlib')
-        handler = logging.FileHandler(filename, mode)
-        fmt = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
-        formatter = logging.Formatter(fmt, dfmt)
-        handler.setFormatter(formatter)
-        logging.root.addHandler(handler)
+        context.log_file = args['LOG_FILE']
     # put the terminal in rawmode unless NOTERM was specified
     if term_mode:
         term.init()
@@ -114,5 +80,3 @@ def closure():
 
 closure()
 del closure
-
-log = getLogger('pwnlib.exploit')

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -4,7 +4,7 @@
 Implements context management so that nested/scoped contexts and threaded
 contexts work properly and as expected.
 """
-import threading, collections, string, logging
+import threading, collections, string, logging, time, sys
 from ..timeout import Timeout
 
 class _defaultdict(dict):
@@ -304,6 +304,7 @@ class ContextType(object):
         'bits': 32,
         'endian': 'little',
         'log_level': logging.INFO,
+        'log_file': open('/dev/null', 'wb'),
         'newline': '\n',
         'os': 'linux',
         'signed': False,
@@ -705,6 +706,43 @@ class ContextType(object):
         permitted = sorted(level_names)
         raise AttributeError('log_level must be an integer or one of %r' % permitted)
 
+    @_validator
+    def log_file(self, value):
+        """
+        Sets the target file for all logging output.
+
+        Works in a similar fashion to :attr:`log_level`.
+
+        Examples:
+
+            >>> context.log_file = 'foo.txt'
+        """
+        if isinstance(value, (str,unicode)):
+            modes = ('w', 'wb', 'a', 'ab')
+            # check if mode was specified as "[value],[mode]"
+            if ',' not in value:
+                value += ',a'
+            filename, mode = value.rsplit(',', 1)
+            value = open(filename, mode)
+
+        elif not isinstance(value, (file)):
+            raise AttributeError('log_file must be a file')
+
+        iso_8601 = '%Y-%m-%dT%H:%M:%S'
+        lines = [
+            '=' * 78,
+            ' Started at %s ' % time.strftime(iso_8601),
+            ' sys.argv = [',
+            ]
+        for arg in sys.argv:
+            lines.append('   %r,' % arg)
+        lines.append(' ]')
+        lines.append('=' * 78)
+        for line in lines:
+            value.write('=%-78s=\n' % line)
+        value.flush()
+
+        return value
 
     @_validator
     def os(self, os):
@@ -729,8 +767,6 @@ class ContextType(object):
             raise AttributeError("os must be one of %r" % sorted(ContextType.oses))
 
         return os
-
-
 
     @_validator
     def signed(self, signed):

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -723,17 +723,21 @@ class ContextType(object):
         Examples:
 
 
-            >>> context.log_file = '/dev/stdout'
-            ...
-            >>> log.debug('Hello!')
-            ...:DEBUG:...:Hello!
-            >>> with context.local(log_level='ERROR'):
+            >>> context.log_file = 'foo.txt' #doctest: +ELLIPSIS
+            >>> log.debug('Hello!') #doctest: +ELLIPSIS
+            >>> with context.local(log_level='ERROR'): #doctest: +ELLIPSIS
             ...     log.info('Hello again!')
-            ...:INFO:...:Hello again!
             >>> with context.local(log_file='bar.txt'):
             ...     log.debug('Hello from bar!')
-            >>> print file('bar.txt').readlines()[-1] #doctest: +ELLIPSIS
-            ...:DEBUG:...:Hello from bar!
+            >>> log.info('Hello from foo!')
+            >>> file('foo.txt').readlines()[-3] #doctest: +ELLIPSIS
+            '...:DEBUG:...:Hello!\n'
+            >>> file('foo.txt').readlines()[-2] #doctest: +ELLIPSIS
+            '...:INFO:...:Hello again!\n'
+            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
+            '...:INFO:...:Hello from foo!\n'
+            >>> file('bar.txt').readlines()[-1] #doctest: +ELLIPSIS
+            '...:DEBUG:...:Hello from bar!\n'
         """
         if isinstance(value, (str,unicode)):
             modes = ('w', 'wb', 'a', 'ab')

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -7,6 +7,13 @@ contexts work properly and as expected.
 import threading, collections, string, logging, time, sys
 from ..timeout import Timeout
 
+class _devnull(object):
+    name = None
+    def write(self, *a, **kw): pass
+    def read(self, *a, **kw):  return ''
+    def flush(self, *a, **kw): pass
+    def close(self, *a, **kw): pass
+
 class _defaultdict(dict):
     """
     Dictionary which loads missing keys from another dictionary.
@@ -304,7 +311,7 @@ class ContextType(object):
         'bits': 32,
         'endian': 'little',
         'log_level': logging.INFO,
-        'log_file': open('/dev/null', 'wb'),
+        'log_file': _devnull(),
         'newline': '\n',
         'os': 'linux',
         'signed': False,
@@ -715,21 +722,18 @@ class ContextType(object):
 
         Examples:
 
-            >>> context.log_file = 'foo.txt'
+
+            >>> context.log_file = '/dev/stdout'
+            ...
             >>> log.debug('Hello!')
-            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
-            '...:DEBUG:...:Hello!\n'
+            ...:DEBUG:...:Hello!
             >>> with context.local(log_level='ERROR'):
             ...     log.info('Hello again!')
-            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
-            '...:INFO:...:Hello again!\n'
+            ...:INFO:...:Hello again!
             >>> with context.local(log_file='bar.txt'):
             ...     log.debug('Hello from bar!')
-            >>> log.debug('Hello from foo!')
-            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
-            '...:DEBUG:...:Hello from foo!\n'
-            >>> file('bar.txt').readlines()[-1] #doctest: +ELLIPSIS
-            '...:DEBUG:...:Hello from bar!\n'
+            >>> print file('bar.txt').readlines()[-1] #doctest: +ELLIPSIS
+            ...:DEBUG:...:Hello from bar!
         """
         if isinstance(value, (str,unicode)):
             modes = ('w', 'wb', 'a', 'ab')
@@ -755,7 +759,6 @@ class ContextType(object):
         for line in lines:
             value.write('=%-78s=\n' % line)
         value.flush()
-
         return value
 
     @_validator

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -708,7 +708,7 @@ class ContextType(object):
 
     @_validator
     def log_file(self, value):
-        """
+        r"""
         Sets the target file for all logging output.
 
         Works in a similar fashion to :attr:`log_level`.
@@ -716,6 +716,20 @@ class ContextType(object):
         Examples:
 
             >>> context.log_file = 'foo.txt'
+            >>> log.debug('Hello!')
+            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
+            '...:DEBUG:...:Hello!\n'
+            >>> with context.local(log_level='ERROR'):
+            ...     log.info('Hello again!')
+            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
+            '...:INFO:...:Hello again!\n'
+            >>> with context.local(log_file='bar.txt'):
+            ...     log.debug('Hello from bar!')
+            >>> log.debug('Hello from foo!')
+            >>> file('foo.txt').readlines()[-1] #doctest: +ELLIPSIS
+            '...:DEBUG:...:Hello from foo!\n'
+            >>> file('bar.txt').readlines()[-1] #doctest: +ELLIPSIS
+            '...:DEBUG:...:Hello from bar!\n'
         """
         if isinstance(value, (str,unicode)):
             modes = ('w', 'wb', 'a', 'ab')

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -559,7 +559,7 @@ def getLogger(name):
 
 class LogfileHandler(logging.FileHandler):
     def __init__(self):
-        super(LogfileHandler, self).__init__('/dev/null')
+        super(LogfileHandler, self).__init__('', delay=1)
     @property
     def stream(self):
         return context.log_file
@@ -567,13 +567,15 @@ class LogfileHandler(logging.FileHandler):
     def stream(self, value):
         pass
     def handle(self, *a, **kw):
-        if self.stream.name != '/dev/null':
+        if self.stream.name is not None:
             super(LogfileHandler, self).handle(*a, **kw)
 
 iso_8601 = '%Y-%m-%dT%H:%M:%S'
 fmt      = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
 log_file = LogfileHandler()
 log_file.setFormatter(logging.Formatter(fmt, iso_8601))
+
+logging.root.setLevel(0)
 
 #
 # The root 'pwnlib' logger is declared here.  To change the target of all
@@ -587,6 +589,7 @@ log_file.setFormatter(logging.Formatter(fmt, iso_8601))
 #     map(rootlogger.removeHandler, rootlogger.handlers)
 #     logger.addHandler(myCoolPitchingHandler)
 #
+logging.root.setLevel(0)
 
 rootlogger = getLogger('pwnlib')
 rootlogger.addHandler(log_file)

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -557,6 +557,21 @@ def getLogger(name):
         _loggers[name] = Logger(logging.getLogger(name))
     return _loggers[name]
 
+class LogfileHandler(logging.FileHandler):
+    def __init__(self):
+        super(LogfileHandler, self).__init__('/dev/null')
+    @property
+    def stream(self):
+        return context.log_file
+    @stream.setter
+    def stream(self, value):
+        pass
+
+iso_8601 = '%Y-%m-%dT%H:%M:%S'
+fmt      = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
+log_file = LogfileHandler()
+log_file.setFormatter(logging.Formatter(fmt, iso_8601))
+
 #
 # The root 'pwnlib' logger is declared here.  To change the target of all
 # 'pwntools'-specific logging, only this logger needs to be changed.
@@ -571,6 +586,7 @@ def getLogger(name):
 #
 
 rootlogger = getLogger('pwnlib')
+rootlogger.addHandler(log_file)
 
 console   = Handler()
 formatter = Formatter()

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -589,7 +589,7 @@ log_file.setFormatter(logging.Formatter(fmt, iso_8601))
 #
 
 rootlogger = getLogger('pwnlib')
-rootlogger.addHandler(log_file)
+# rootlogger.addHandler(log_file)
 
 console   = Handler()
 formatter = Formatter()

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -575,8 +575,6 @@ fmt      = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
 log_file = LogfileHandler()
 log_file.setFormatter(logging.Formatter(fmt, iso_8601))
 
-logging.root.setLevel(0)
-
 #
 # The root 'pwnlib' logger is declared here.  To change the target of all
 # 'pwntools'-specific logging, only this logger needs to be changed.
@@ -603,7 +601,6 @@ def install_default_handler():
     the ``pwnlib`` root logger.  This function is automatically called from when
     importing :mod:`pwn`.
     '''
-
     console.stream = sys.stderr
     logger         = logging.getLogger('pwnlib')
 
@@ -612,4 +609,3 @@ def install_default_handler():
         logger.addHandler(log_file)
 
     logger.setLevel(1)
-

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -566,6 +566,9 @@ class LogfileHandler(logging.FileHandler):
     @stream.setter
     def stream(self, value):
         pass
+    def handle(self, *a, **kw):
+        if self.stream.name != '/dev/null':
+            super(LogfileHandler, self).handle(*a, **kw)
 
 iso_8601 = '%Y-%m-%dT%H:%M:%S'
 fmt      = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -589,10 +589,8 @@ logging.root.setLevel(0)
 #     map(rootlogger.removeHandler, rootlogger.handlers)
 #     logger.addHandler(myCoolPitchingHandler)
 #
-logging.root.setLevel(0)
 
 rootlogger = getLogger('pwnlib')
-rootlogger.addHandler(log_file)
 
 console   = Handler()
 formatter = Formatter()
@@ -605,7 +603,13 @@ def install_default_handler():
     the ``pwnlib`` root logger.  This function is automatically called from when
     importing :mod:`pwn`.
     '''
+
     console.stream = sys.stderr
     logger         = logging.getLogger('pwnlib')
+
     if console not in logger.handlers:
         logger.addHandler(console)
+        logger.addHandler(log_file)
+
+    logger.setLevel(1)
+

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -589,7 +589,7 @@ log_file.setFormatter(logging.Formatter(fmt, iso_8601))
 #
 
 rootlogger = getLogger('pwnlib')
-# rootlogger.addHandler(log_file)
+rootlogger.addHandler(log_file)
 
 console   = Handler()
 formatter = Formatter()


### PR DESCRIPTION
```
>>> context.log_file='log.txt'
>>> !cat log.txt
================================================================================
= Started at 2015-01-12T05:35:26                                               =
= sys.argv = [                                                                 =
=   '/usr/local/google/home/riggle/.pyenv/versions/2.7.9/bin/ipython',         =
= ]                                                                            =
================================================================================
>>> log.info("Yay")
[*] Yay
>>> log.debug("To the file")
>>> !cat log.txt
================================================================================
= Started at 2015-01-12T05:35:26                                               =
= sys.argv = [                                                                 =
=   '/usr/local/google/home/riggle/.pyenv/versions/2.7.9/bin/ipython',         =
= ]                                                                            =
================================================================================
2015-01-12T05:35:40:INFO:pwnlib.exploit:Yay
2015-01-12T05:35:44:DEBUG:pwnlib.exploit:To the file
```