### PR TITLE
Set logging to stdout when running doctests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,11 +39,12 @@ extensions = [
 ]
 
 doctest_global_setup = '''
-import pwnlib
+import pwnlib, sys
 pwnlib.context.context.reset_local()
 pwnlib.context.ContextType.defaults['log_level'] = 'ERROR'
 pwnlib.term.text.when = 'never'
-
+pwnlib.log.install_default_handler()
+pwnlib.log.console.stream = sys.stdout
 '''
 
 autodoc_member_order = 'alphabetical'

--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -2,10 +2,6 @@
 
    from pwn import *
 
-   # redirect logging to `sys.stdout`
-   import logging
-   logging.getLogger('pwnlib').handlers[0].stream = sys.stdout
-
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================
 

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -572,6 +572,10 @@ def getLogger(name):
 
 rootlogger = getLogger('pwnlib')
 
+console = Handler()
+formatter = Formatter()
+console.setFormatter(formatter)
+
 def install_default_handler():
     '''install_default_handler()
 
@@ -579,7 +583,4 @@ def install_default_handler():
     the ``pwnlib`` root logger.  This function is automatically called from when
     importing :mod:`pwn`.
     '''
-    handler = Handler()
-    formatter = Formatter()
-    handler.setFormatter(formatter)
-    rootlogger.addHandler(handler)
+    rootlogger.addHandler(console)


### PR DESCRIPTION
Otherwise output is not captured.  Also fix assumption that the console handler is the first handler.  Also ensure that the console handler is applied for doctests, since some of them require it.