### PR TITLE
Set rootlogger level to 1

### DIFF
--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -109,7 +109,6 @@ def closure():
     # install a log handler and turn logging all the way up
     import pwnlib.log as log
     import logging
-    log.rootlogger.setLevel(1)
     log.install_default_handler()
 
 closure()

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -109,7 +109,7 @@ def closure():
     # install a log handler and turn logging all the way up
     import pwnlib.log as log
     import logging
-    log.rootlogger.setLevel(logging.DEBUG)
+    log.rootlogger.setLevel(1)
     log.install_default_handler()
 
 closure()


### PR DESCRIPTION
Enable specifically setting the log level of objects, so that individual nodes on the logging tree can be lower than `context.log_level` and get printed.

I don't like the reverse lookup on loggers, but it works and it's easy.  There's another way to do this that's cleaner, but we moved away from `logging.getLoggerClass()` and `logging.setLoggerClass()` in one of br0ns' commits.

```
>>> log.debug('asdf')
>>> log.info('asdf')
[*] asdf
>>> log.warning('asdf')
[!] asdf
>>> import logging
>>> l2 = getLogger('pwnlib.xxx')
>>> l2.info('asdf')
[*] asdf
>>> l2.debug('asdf')
>>> l2.setLevel(logging.DEBUG)
>>> l2.debug('asdf')                                                                                                                                        
[DEBUG] asdf
>>> with context.local(log_level='error'):
..:     log.info('asdf')
..:     l2.debug('asdf')
[DEBUG] asdf
```