### PR TITLE
Enable use of hostnames for connect shellcode.

### DIFF
--- a/pwnlib/shellcraft/templates/i386/linux/connect.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/connect.asm
@@ -1,6 +1,6 @@
 <% from pwnlib.shellcraft import common %>
-<% from pwnlib.shellcraft import i386 %> 
-<% from socket import htons, inet_aton %>
+<% from pwnlib.shellcraft import i386 %>
+<% from socket import htons, inet_aton, gethostbyname %>
 <% from pwnlib.util import packing %>
 
 <%page args="host, port"/>
@@ -24,7 +24,10 @@ int 0x80
 /* save opened socket */
 mov ebp, eax
 
-${i386.pushstr(inet_aton(host), False)}
+<% ip_addr = gethostbyname(str(host)) %>
+/* ${repr(host)} == ${ip_addr} */
+${i386.pushstr(inet_aton(ip_addr), False)}
+
 pushw ${htons(port)}
 pushw AF_INET
 mov ecx, esp


### PR DESCRIPTION
Currently this shellcraft will die if given anything other than a dotted quad.

```
$ shellcraft i386.linux.connect google.com 80 -f asm
/* open new socket */
push SYS_socketcall
pop eax
push SYS_socketcall_socket
pop ebx
cdq
push edx
push ebx
push AF_INET
mov ecx, esp
int 0x80

/* save opened socket */
mov ebp, eax

/* 'google.com' == 74.125.69.102 */
    /* push 'J}Ef' */
    push 0x66457d4a

pushw 20480
pushw AF_INET
mov ecx, esp
push 0x10
push ecx
push eax
mov ecx, esp
inc ebx
inc ebx
mov al, SYS_socketcall
int 0x80

/* Socket that is maybe connected is in ebp */
```