### PR TITLE
Use tty by default, and run "stty raw" by default except for when doing a shell (process==None).

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -728,7 +728,7 @@ class ssh(Timeout):
         """
 
         with context.local(log_level = 'ERROR'):
-            s = self.run('cat>' + misc.sh_string(remote))
+            s = self.run('cat>' + misc.sh_string(remote), tty=False)
             s.send(data)
             s.shutdown('send')
             s.recvall()

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -44,6 +44,9 @@ class ssh_channel(sock):
                         log.error('run(): Invalid environment key $r' % name)
                     process = '%s=%s %s' % (name, misc.sh_string(value), process)
 
+            if process and tty:
+                process = 'stty raw -ctlecho -echo; ' + process
+
             self.sock = parent.transport.open_session()
             if self.tty:
                 self.sock.get_pty('xterm', term.width, term.height)
@@ -218,9 +221,8 @@ class ssh_connecter(sock):
         with log.waitfor(msg) as h:
             try:
                 self.sock = parent.transport.open_channel('direct-tcpip', (host, port), ('127.0.0.1', 0))
-            except:
-                h.failure()
-                raise
+            except Exception as e:
+                self.exception(e.message)
 
             sockname = self.sock.get_transport().sock.getsockname()
             self.lhost = sockname[0]
@@ -354,7 +356,7 @@ class ssh(Timeout):
         self.close()
 
     def shell(self, shell = None, tty = True, timeout = Timeout.default):
-        """shell(shell = None, tty = False, timeout = Timeout.default) -> ssh_channel
+        """shell(shell = None, tty = True, timeout = Timeout.default) -> ssh_channel
 
         Open a new channel with a shell inside.
 
@@ -377,8 +379,8 @@ class ssh(Timeout):
         """
         return self.run(shell, tty, timeout = timeout)
 
-    def run(self, process, tty = False, wd = None, env = None, timeout = Timeout.default):
-        r"""run(process, tty = False, wd = None, env = None, timeout = Timeout.default) -> ssh_channel
+    def run(self, process, tty = True, wd = None, env = None, timeout = Timeout.default):
+        r"""run(process, tty = True, wd = None, env = None, timeout = Timeout.default) -> ssh_channel
 
         Open a new channel with a specific process inside. If `tty` is True,
         then a TTY is requested on the remote server.


### PR DESCRIPTION
This **should** make zero difference for anything at all, **except** when the target binary makes use of `printf`.

Specifically, `printf` buffers if `stdout` is not a tty, which is currently the default.  This makes pwntools behave in a manner that is normal and correct, but quite unexpected.

By defaulting to use `tty = True`, `stdout` is now a tty, but so is `stdin` -- so control characters are interpreted by the remote end (e.g. `'\x08'` is a backspace).

Use the `stty` command if `tty == True` in order to disable interpretation of all control codes (`stty raw`).

Now the remote end will echo control characters back.  Disable this (`stty -ctlecho -echo`).