### PR TITLE
Enable a configurable timeout for recvall

### DIFF
--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -12,7 +12,7 @@ class sock(tube):
         self.closed = {"recv": False, "send": False}
 
     # Overwritten for better usability
-    def recvall(self):
+    def recvall(self, timeout = tube.forever):
         """recvall() -> str
 
         Receives data until the socket is closed.
@@ -21,7 +21,7 @@ class sock(tube):
         if getattr(self, 'type', None) == socket.SOCK_DGRAM:
             log.error("UDP sockets does not supports recvall")
         else:
-            return super(sock, self).recvall()
+            return super(sock, self).recvall(timeout)
 
     def recv_raw(self, numb):
         if self.closed["recv"]:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -78,14 +78,15 @@ class ssh_channel(sock):
 
         self.close()
 
-    def recvall(self):
+    def recvall(self, timeout = sock.forever):
         # We subclass tubes.sock which sets self.sock to None.
         #
         # However, we need to wait for the return value to propagate,
         # which may not happen by the time .close() is called by tube.recvall()
         tmp_sock = self.sock
 
-        data = super(ssh_channel, self).recvall()
+        timeout = self.maximum if self.timeout is self.forever else self.timeout
+        data = super(ssh_channel, self).recvall(timeout)
 
         # Restore self.sock to be able to call wait()
         self.sock = tmp_sock
@@ -106,9 +107,11 @@ class ssh_channel(sock):
         process has not yet finished and the exit code otherwise.
         """
 
-        if self.returncode == None:
-            if self.sock and (block or self.sock.exit_status_ready()):
-                self.returncode = self.sock.recv_exit_status()
+        if self.returncode == None and self.sock \
+        and (block or self.sock.exit_status_ready()):
+            while not self.sock.status_event.is_set():
+                self.sock.status_event.wait(0.05)
+            self.returncode = self.sock.recv_exit_status()
 
         return self.returncode
 

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -647,7 +647,7 @@ class tube(Timeout):
 
         return self.buffer.get()
 
-    def recvall(self):
+    def recvall(self, timeout=Timeout.forever):
         """recvall() -> str
 
         Receives data until EOF is reached.
@@ -655,7 +655,7 @@ class tube(Timeout):
 
         with log.waitfor('Recieving all data') as h:
             l = len(self.buffer)
-            with self.local(Timeout.forever):
+            with self.local(timeout):
                 try:
                     while True:
                         l = misc.size(len(self.buffer))


### PR DESCRIPTION
It should be possible to set a timeout on `recvall`.

I would vote that the default timeout value would be `Timeout.default` to inherit the configured timeout duration, but the exact same effect can be achieved through `tube.recvall`.

The reason for the configurability is that the `ssh` module ultimately calls into a `paramiko` recv function which behaves differently if there is a non-`None` timeout set.  We leverage this to work around the fact that `threading.Event().wait()` cannot be interrupted with `Ctrl-C`.

Additionally, add an explicit work-around for this same issue in `pwnlib.tubes.ssh.ssh.wait()`.