### PR TITLE
Set stdout to be a PTY on spawned processes so that stdout is not buffered

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -36,6 +36,19 @@ class process(tube):
         Traceback (most recent call last):
         ...
         EOFError
+
+        >>> p = process('cat')
+        >>> d = open('/dev/urandom').read(4096)
+        >>> p.recv(timeout=0.1)
+        ''
+        >>> p.write(d)
+        >>> p.recvrepeat(0.1) == d
+        True
+        >>> p.recv(timeout=0.1)
+        ''
+        >>> p.shutdown('send')
+        >>> p.poll()
+        0
     """
     def __init__(self, args, shell = False, executable = None,
                  cwd = None, env = None, timeout = Timeout.default,

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -47,6 +47,7 @@ class process(tube):
         >>> p.recv(timeout=0.1)
         ''
         >>> p.shutdown('send')
+        >>> p.wait_for_close()
         >>> p.poll()
         0
     """


### PR DESCRIPTION
This has the effect of working much better with poorly-written CTF binaries which use `printf` but don't disable buffering.  We can work around this by making `stdout` be a `pty`, which `libc` will write to immediately.

Since being a `tty` could cause issues due to the way escape codes might be interpreted, we set the `pty` pair into raw mode.

## Demo Program

```c
int main () {
    printf("Hello\x03World\x08\n");
    getchar();
};
```

## `master` behavior

```
>>> context.timeout = 1
>>> p = process('./demo')
>>> p.recv()
''
```

## pull request behavior

```
>>> context.timeout = 1
>>> p = process('./demo')
>>> p.recv()
'Hello\x03World\x08\n'
```