### PR TITLE
Fix #469 - verify search_results has items before using

### DIFF
--- a/pwnlib/term/readline.py
+++ b/pwnlib/term/readline.py
@@ -136,7 +136,7 @@ def cancel_search(*_):
 
 def commit_search():
     global search_idx
-    if search_idx is not None:
+    if search_idx is not None and search_results:
         set_buffer(history[search_results[search_idx][0]], u'')
         search_idx = None
         redisplay()


### PR DESCRIPTION
This was a simple fix, not sure search_idx should be set to None elsewhere, but this at least stops the crash