### PR TITLE
Fix mis-reporting of NX when there is no GNU_STACK segment

### DIFF
--- a/pwnlib/elf/__init__.py
+++ b/pwnlib/elf/__init__.py
@@ -531,6 +531,8 @@ class ELF(ELFFile):
 
     @property
     def nx(self):
+        if not any('GNU_STACK' in seg.header.p_type for seg in self.segments):
+            return False
         return not any('GNU_STACK' in seg.header.p_type for seg in self.executable_segments)
 
     @property


### PR DESCRIPTION
Fixes #442 