### PR TITLE
Enable mov reg, reg for ARM

### DIFF
--- a/pwnlib/shellcraft/templates/arm/mov.asm
+++ b/pwnlib/shellcraft/templates/arm/mov.asm
@@ -6,10 +6,10 @@
     Returns THUMB code for moving the specified source value
     into the specified destination register.
 </%docstring>
-/* Set ${dst} = ${src} = 0x${'%x' % src} */
 %if not isinstance(src, (int, long)):
     mov ${dst}, ${src}
 %else:
+/* Set ${dst} = ${src} = 0x${'%x' % src} */
   %if src == 0:
     eor ${dst}, ${dst}
   %elif src & 0xffff0000 == 0:

--- a/pwnlib/shellcraft/templates/arm/mov.asm
+++ b/pwnlib/shellcraft/templates/arm/mov.asm
@@ -7,7 +7,11 @@
     into the specified destination register.
 </%docstring>
 %if not isinstance(src, (int, long)):
+    %if dst == src:
+    /* mov %{dest}, ${src} is a no-op */
+    %else:
     mov ${dst}, ${src}
+    %endif
 %else:
 /* Set ${dst} = ${src} = 0x${'%x' % src} */
   %if src == 0:


### PR DESCRIPTION
Currently this fails because of the comment

```
$ shellcraft arm.mov r0 0
000020e0
$ shellcraft arm.mov r0 r0
Traceback (most recent call last):
  File "/usr/local/google/home/riggle/.pyenv/versions/2.7.9/bin/shellcraft", line 9, in <module>
    load_entry_point('binjitsu==2.2.1', 'console_scripts', 'shellcraft')()
  File "/usr/local/google/home/riggle/binjitsu/pwnlib/commandline/shellcraft.py", line 189, in main
    code = func(*args.args)
  File "<string>", line 6, in mov
  File "/usr/local/google/home/riggle/.pyenv/versions/2.7.9/lib/python2.7/site-packages/mako/template.py", line 443, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/local/google/home/riggle/.pyenv/versions/2.7.9/lib/python2.7/site-packages/mako/runtime.py", line 803, in _render
    **_kwargs_for_callable(callable_, data))
  File "/usr/local/google/home/riggle/.pyenv/versions/2.7.9/lib/python2.7/site-packages/mako/runtime.py", line 835, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/local/google/home/riggle/.pyenv/versions/2.7.9/lib/python2.7/site-packages/mako/runtime.py", line 860, in _exec_template
    callable_(context, *args, **kwargs)
  File "/usr/local/google/home/riggle/.pwntools-cache/mako/arm/mov.asm.py", line 35, in render_body
    __M_writer(unicode('%x' % src))
TypeError: %x format: a number is required, not str
```

```
$ gco arm-mov-reg-reg
Previous HEAD position was 32b0502... Merge pull request #482 from Gallopsled/bruteforce_bugfix
Switched to branch 'arm-mov-reg-reg'
Your branch is ahead of 'gallopsled/master' by 1 commit.
  (use "git push" to publish your local commits)
$ shellcraft arm.mov r0 r0
0000a0e1
```