### PR TITLE
Add context.binary helper

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -301,6 +301,7 @@ class ContextType(object):
     #: Default values for :class:`pwnlib.context.ContextType`
     defaults = {
         'arch': 'i386',
+        'binary': None,
         'bits': 32,
         'endian': 'little',
         'log_level': logging.INFO,
@@ -606,6 +607,35 @@ class ContextType(object):
             raise AttributeError("bits must be >= 0 (%r)" % bits)
 
         return bits
+
+    @_validator
+    def binary(self, binary):
+        """
+        Infer target architecture, bit-with, and endianness from a binary file.
+        Data type is a :class:`pwnlib.elf.ELF` object.
+
+        Examples:
+
+            >>> context.clear()
+            >>> context.arch, context.bits
+            ('i386', 32)
+            >>> context.binary = '/bin/bash'
+            >>> context.arch, context.bits
+            ('amd64', 64)
+            >>> context.binary
+            ELF('/bin/bash')
+
+        """
+        # Cyclic imports... sorry Idolf.
+        from ..elf     import ELF
+
+        e = ELF(binary)
+
+        self.arch   = e.arch
+        self.bits   = e.bits
+        self.endian = e.endian
+
+        return e
 
     @property
     def bytes(self):


### PR DESCRIPTION
This encapsulates a few of the steps that we always go through into one single step.

This introduces a dependency cycle: `context` <= `elf` <= `asm` <= `context`

```py
>>> context.clear()
>>> context.arch, context.bits
('i386', 32)
>>> context.binary = '/bin/bash'
>>> context.arch, context.bits
('amd64', 64)
>>> context.binary
ELF('/bin/bash')
```