### PR TITLE
Enhance functionality in process

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -101,6 +101,10 @@ class process(tube):
         >>> p.sendline('hello')
         >>> p.recvline()
         'hello\n'
+
+        >>> p = process(['python','-c','open("/dev/tty","wb").write("stack smashing detected")'])
+        >>> p.recv()
+        'stack smashing detected'
     """
 
     #: `subprocess.Popen` object
@@ -134,7 +138,7 @@ class process(tube):
                  stdout = PTY,
                  stderr = STDOUT,
                  close_fds = True,
-                 preexec_fn = None):
+                 preexec_fn = lambda: None):
         super(process, self).__init__(timeout)
 
         if not shell:
@@ -142,11 +146,11 @@ class process(tube):
 
         stdin, stdout, stderr, master = self._handles(stdin, stdout, stderr)
 
-        self.executable = self.program = executable
-        self.argv       = argv
-        self.env        = env
-        self.cwd        = cwd or os.path.curdir
-        self.preexec_fn = preexec_fn
+        self.executable   = self.program = executable
+        self.argv         = argv
+        self.env          = env
+        self.cwd          = cwd or os.path.curdir
+        self.preexec_user = preexec_fn
 
         message = "Starting program %r" % self.program
 
@@ -177,8 +181,8 @@ class process(tube):
         fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
     def preexec_fn(self):
-        os.setpgrp()
-        self.preexec_fn and preexec_fn()
+        self.__pty_make_controlling_tty(1)
+        self.preexec_user()
 
     @staticmethod
     def _validate(cwd, executable, argv, env):
@@ -426,3 +430,49 @@ class process(tube):
 
         if False not in [self.proc.stdin.closed, self.proc.stdout.closed]:
             self.close()
+
+    def __pty_make_controlling_tty(self, tty_fd):
+        '''This makes the pseudo-terminal the controlling tty. This should be
+        more portable than the pty.fork() function. Specifically, this should
+        work on Solaris. '''
+
+        child_name = os.ttyname(tty_fd)
+
+        # Disconnect from controlling tty. Harmless if not already connected.
+        try:
+            fd = os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)
+            if fd >= 0:
+                os.close(fd)
+        # which exception, shouldnt' we catch explicitly .. ?
+        except OSError:
+            # Already disconnected. This happens if running inside cron.
+            pass
+
+        os.setsid()
+
+        # Verify we are disconnected from controlling tty
+        # by attempting to open it again.
+        try:
+            fd = os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)
+            if fd >= 0:
+                os.close(fd)
+                raise Exception('Failed to disconnect from ' +
+                    'controlling tty. It is still possible to open /dev/tty.')
+        # which exception, shouldnt' we catch explicitly .. ?
+        except OSError:
+            # Good! We are disconnected from a controlling tty.
+            pass
+
+        # Verify we can open child pty.
+        fd = os.open(child_name, os.O_RDWR)
+        if fd < 0:
+            raise Exception("Could not open child pty, " + child_name)
+        else:
+            os.close(fd)
+
+        # Verify we now have a controlling tty.
+        fd = os.open("/dev/tty", os.O_WRONLY)
+        if fd < 0:
+            raise Exception("Could not open controlling tty, /dev/tty")
+        else:
+            os.close(fd)

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -1,19 +1,60 @@
-from .tube import tube
-from ..timeout import Timeout
-from ..util.misc import which
+import errno
+import fcntl
+import logging
+import os
+import pty
+import select
+import subprocess
+import tty
+
 from ..context import context
 from ..log import getLogger
-import subprocess, fcntl, os, select, pty, tty, errno
+from ..timeout import Timeout
+from ..util.misc import which
+from .tube import tube
 
 log = getLogger(__name__)
 
+PIPE = subprocess.PIPE
+STDOUT = subprocess.STDOUT
+PTY = object()
+
 class process(tube):
     r"""
-    Implements a tube which talks to a process on stdin/stdout/stderr.
+    Spawns a new process, and wraps it with a tube for communication.
+
+    Arguments:
+        argv(list):
+            List of arguments to pass to the spawned process.
+        shell(bool):
+            Set to `True` to interpret `argv` as a string
+            to pass to the shell for interpretation instead of as argv.
+        executable(str):
+            Path to the binary to execute.  If ``None``, uses ``argv[0]``.
+            Cannot be used with ``shell``.
+        cwd(str):
+            Working directory.  Uses the current working directory by default.
+        env(dict):
+            Environment variables.  By default, inherits from Python's environment.
+        timeout(int):
+            Timeout to use on ``tube`` ``recv`` operations.
+        stdin(int):
+            File object or file descriptor number to use for ``stdin``.
+            By default, a pipe is used.
+        stdout(int):
+            File object or file descriptor number to use for ``stdout``.
+            By default, a pty is used.
+            May also be ``subprocess.PIPE`` to use a normal pipe.
+        stderr(int):
+            File object or file descriptor number to use for ``stderr``.
+            By default, ``stdout`` is used.
+            May also be ``subprocess.PIPE`` to use a separate pipe,
+            although the ``tube`` wrapper will not be able to read this data.
+        preexec_fn(callable):
+            Callable to invoke immediately before calling ``execve``.
 
     Examples:
 
-        >>> context.log_level='error'
         >>> p = process(which('python2'))
         >>> p.sendline("print 'Hello world'")
         >>> p.sendline("print 'Wow, such data'");
@@ -50,44 +91,84 @@ class process(tube):
         >>> p.wait_for_close()
         >>> p.poll()
         0
+
+        >>> p = process('cat /dev/zero | head -c8', shell=True, stderr=open('/dev/null', 'w+'))
+        >>> p.recv()
+        '\x00\x00\x00\x00\x00\x00\x00\x00'
+
+        >>> p = process(['python','-c','import os; print os.read(2,1024)'],
+        ...             preexec_fn = lambda: os.dup2(0,2))
+        >>> p.sendline('hello')
+        >>> p.recvline()
+        'hello\n'
     """
-    def __init__(self, args, shell = False, executable = None,
-                 cwd = None, env = None, timeout = Timeout.default,
-                 stderr_debug = False, close_fds = True):
+
+    #: `subprocess.Popen` object
+    proc = None
+
+    #: Full path to the executable
+    executable = None
+
+    #: Full path to the executable
+    program = None
+
+    #: Arguments passed on argv
+    argv = None
+
+    #: Environment passed on envp
+    env = None
+
+    #: Directory the process was created in
+    cwd = None
+
+    #: Have we seen the process stop?
+    _stop_noticed = False
+
+    def __init__(self, argv,
+                 shell = False,
+                 executable = None,
+                 cwd = None,
+                 env = None,
+                 timeout = Timeout.default,
+                 stdin  = PIPE,
+                 stdout = PTY,
+                 stderr = STDOUT,
+                 close_fds = True,
+                 preexec_fn = None):
         super(process, self).__init__(timeout)
 
-        if executable:
-            self.program = executable
-        elif isinstance(args, (str, unicode)):
-            self.program = args
-        elif isinstance(args, (list, tuple)):
-            self.program = args[0]
-        else:
-            log.error("process(): Do not understand the arguments %r" % args)
+        if not shell:
+            executable, argv, env = self._validate(cwd, executable, argv, env)
 
-        # If we specify something not in $PATH, but which exists as a non-executable
-        # file then give an error message.
-        if not which(self.program) and os.path.exists(self.program) and not os.access(self.program, os.X_OK):
-            log.error('%r is not set to executable (chmod +x %s)' % (self.program, self.program))
+        stdin, stdout, stderr, master = self._handles(stdin, stdout, stderr)
 
-        # Make a pty pair for stdout
-        master, slave = pty.openpty()
+        self.executable = self.program = executable
+        self.argv       = argv
+        self.env        = env
+        self.cwd        = cwd or os.path.curdir
+        self.preexec_fn = preexec_fn
 
-        # Set master and slave to raw mode
-        tty.setraw(master)
-        tty.setraw(slave)
+        message = "Starting program %r" % self.program
 
-        self.proc = subprocess.Popen(
-            args, shell = shell, executable = executable,
-            cwd = cwd, env = env,
-            stdin = subprocess.PIPE, stdout = slave,
-            stderr = subprocess.PIPE if stderr_debug else slave,
-            close_fds = close_fds,
-            preexec_fn = os.setpgrp)
-        self.stop_noticed = False
+        if log.isEnabledFor(logging.DEBUG):
+            if self.argv != [self.executable]: message += ' argv=%r ' % self.argv
+            if self.env  != os.environ:        message += ' env=%r ' % self.env
 
-        self.proc.stdout = os.fdopen(master)
-        os.close(slave)
+        with log.progress(message) as p:
+            self.proc = subprocess.Popen(args = argv,
+                                         shell = shell,
+                                         executable = executable,
+                                         cwd = cwd,
+                                         env = env,
+                                         stdin = stdin,
+                                         stdout = stdout,
+                                         stderr = stderr,
+                                         close_fds = close_fds,
+                                         preexec_fn = self.preexec_fn)
+
+        if master:
+            self.proc.stdout = os.fdopen(master)
+            os.close(stdout)
 
         # Set in non-blocking mode so that a call to call recv(1000) will
         # return as soon as a the first byte is available
@@ -95,22 +176,124 @@ class process(tube):
         fl = fcntl.fcntl(fd, fcntl.F_GETFL)
         fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-        log.success("Started program %r" % self.program)
-        log.debug("...with arguments %r" % args)
+    def preexec_fn(self):
+        os.setpgrp()
+        self.preexec_fn and preexec_fn()
 
-        def printer():
-            try:
-                while True:
-                    line = self.proc.stderr.readline()
-                    if line: log.debug(line.rstrip())
-                    else: break
-            except:
-                pass
+    @staticmethod
+    def _validate(cwd, executable, argv, env):
+        """
+        Perform extended validation on the executable path, argv, and envp.
 
-        if stderr_debug:
-            t = context.Thread(target=printer)
-            t.daemon = True
-            t.start()
+        Mostly to make Python happy, but also to prevent common pitfalls.
+        """
+
+        cwd = cwd or os.path.curdir
+
+        #
+        # Validate argv
+        #
+        # - Must be a list/tuple of strings
+        # - Each string must not contain '\x00'
+        #
+        if isinstance(argv, (str, unicode)):
+            argv = [argv]
+
+        if not all(isinstance(arg, (str, unicode)) for arg in argv):
+            log.error("argv must be strings: %r" % argv)
+
+        # Create a duplicate so we can modify it
+        argv = list(argv or [])
+
+        for i, arg in enumerate(argv):
+            if '\x00' in arg[:-1]:
+                log.error('Inappropriate nulls in argv[%i]: %r' % (i, arg))
+
+            argv[i] = arg.rstrip('\x00')
+
+        #
+        # Validate executable
+        #
+        # - Must be an absolute or relative path to the target executable
+        # - If not, attempt to resolve the name in $PATH
+        #
+        if not executable:
+            if not argv:
+                log.error("Must specify argv or executable")
+            executable = argv[0]
+
+        # Do not change absolute paths to binaries
+        if executable.startswith(os.path.sep):
+            pass
+
+        # If there's no path component, it's in $PATH or relative to the
+        # target directory.
+        #
+        # For example, 'sh'
+        elif os.path.sep not in executable and which(executable):
+            executable = which(executable)
+
+        # Either there is a path component, or the binary is not in $PATH
+        # For example, 'foo/bar' or 'bar' with cwd=='foo'
+        elif os.path.sep not in executable:
+            executable = os.path.join(cwd, executable)
+
+        if not os.path.exists(executable):
+            log.error("%r does not exist"  % executable)
+        if not os.path.isfile(executable):
+            log.error("%r is not a file" % executable)
+        if not os.access(executable, os.X_OK):
+            log.error("%r is not marked as executable (+x)" % executable)
+
+        #
+        # Validate environment
+        #
+        # - Must be a dictionary of {string:string}
+        # - No strings may contain '\x00'
+        #
+
+        # Create a duplicate so we can modify it safely
+        env = dict(env or os.environ)
+
+        for k,v in env.items():
+            if not isinstance(k, (str, unicode)):
+                log.error('Environment keys must be strings: %r' % k)
+            if not isinstance(k, (str, unicode)):
+                log.error('Environment values must be strings: %r=%r' % (k,v))
+            if '\x00' in k[:-1]:
+                log.error('Inappropriate nulls in env key: %r' % (k))
+            if '\x00' in v[:-1]:
+                log.error('Inappropriate nulls in env value: %r=%r' % (k, v))
+
+            env[k.rstrip('\x00')] = v.rstrip('\x00')
+
+        return executable, argv, env
+
+    @staticmethod
+    def _handles(stdin, stdout, stderr):
+        master = None
+
+        if stdout is PTY:
+            # Normally we could just use subprocess.PIPE and be happy.
+            # Unfortunately, this results in undesired behavior when
+            # printf() and similar functions buffer data instead of
+            # sending it directly.
+            #
+            # By opening a PTY for STDOUT, the libc routines will not
+            # buffer any data on STDOUT.
+            master, slave = pty.openpty()
+
+            # By making STDOUT a PTY, the OS will attempt to interpret
+            # terminal control codes.  We don't want this, we want all
+            # input passed exactly and perfectly to the process.
+            tty.setraw(master)
+            tty.setraw(slave)
+
+            # Pick one side of the pty to pass to the child
+            stdout = slave
+
+        return stdin, stdout, stderr, master
+
 
     def kill(self):
         """kill()
@@ -127,8 +310,8 @@ class process(tube):
         process has not yet finished and the exit code otherwise.
         """
         self.proc.poll()
-        if self.proc.returncode != None and not self.stop_noticed:
-            self.stop_noticed = True
+        if self.proc.returncode != None and not self._stop_noticed:
+            self._stop_noticed = True
             log.info("Program %r stopped with exit code %d" % (self.program, self.proc.returncode))
 
         return self.proc.returncode
@@ -213,13 +396,16 @@ class process(tube):
             return not self.proc.stdout.closed
 
     def close(self):
+        if self.proc is None:
+            return
+
         # First check if we are already dead
         self.poll()
 
-        if not self.stop_noticed:
+        if not self._stop_noticed:
             try:
                 self.proc.kill()
-                self.stop_noticed = True
+                self._stop_noticed = True
                 log.info('Stopped program %r' % self.program)
             except OSError:
                 pass


### PR DESCRIPTION
- Make stdout a PTY
	- This disables buffering on stdout
- Add options to specify how stdin/stdout/stderr are created
- Expose preexec_fn
- Protect the user from common Python-specific pitfalls
	- e.g. argv elements cannot contain or even end with '\x00'