### PR TITLE
Enhance asm and shellcraft with auto-debugging; add checksec command-line

### DIFF
--- a/pwnlib/commandline/checksec.py
+++ b/pwnlib/commandline/checksec.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python2
+import argparse
+import sys
+
+from pwn import *
+
+from . import common
+
+parser = argparse.ArgumentParser(
+    description = 'Check binary security settings'
+)
+
+parser.add_argument(
+    'elf',
+    nargs='+',
+    type=file,
+    help='Files to check'
+)
+
+def main():
+    args   = parser.parse_args()
+    for f in args.elf:
+        e = ELF(f.name)
+
+if __name__ == '__main__': main()

--- a/pwnlib/commandline/common.py
+++ b/pwnlib/commandline/common.py
@@ -1,0 +1,19 @@
+from pwn import *
+
+pwnlib.log.console.stream = sys.stderr
+
+choices = map(str, [16,32,64])
+choices += list(context.oses)
+choices += list(context.architectures)
+choices += list(context.endiannesses)
+
+def context_arg(arg):
+    try: context.arch = arg
+    except Exception: pass
+    try: context.os = arg
+    except Exception: pass
+    try: context.bits = int(arg)
+    except Exception: arg
+    try: context.endian = arg
+    except Exception: pass
+    return arg


### PR DESCRIPTION
This depends on #495 and #496.

For `asm` and `shellcraft`, it adds a `-d`/`--debug` command which automatically assembles the shellcode, builds an ELF with it, starts qemu-user and attaches a debugger in a new terminal window at the entry point.  This *greatly* accelerates the workflow of writing/testing shellcraft templates.

`checksec` just exposes the functionality of the ELF's checksec routine.  It is better than `checksec.sh` in that [1] `checksec.sh` is not maintained and [2] it is wrong about e.g. pwnable.kr `tiny_easy` stack NX and [3] doesn't require you to type `--file`.