### PR TITLE
Add code for libcdb lookups

### DIFF
--- a/pwnlib/__init__.py
+++ b/pwnlib/__init__.py
@@ -1,18 +1,34 @@
+import importlib
+
+from .version import __version__
+
+version = __version__
+
 __all__ = [
-    'atexception' , 'atexit'      , 'asm'         , 'constants'   ,
-    'context'     , 'dynelf'      , 'elf'         , 'exception'   ,
-    'gdb'         , 'fmtstr'      , 'log'         , 'memleak'     ,
-    'replacements', 'rop'         , 'shellcraft'  , 'term'        ,
-    'tubes'       , 'ui'          , 'useragents'  , 'util'
+    'asm',
+    'atexception',
+    'atexit',
+    'commandline',
+    'constants',
+    'context',
+    'dynelf',
+    'elf',
+    'exception',
+    'fmtstr',
+    'gdb',
+    'libcdb',
+    'log',
+    'memleak',
+    'pep237',
+    'replacements',
+    'rop',
+    'shellcraft',
+    'term',
+    'tubes',
+    'ui',
+    'useragents',
+    'util'
 ]
 
-from . import \
-    atexception   , atexit        , asm           , constants     , \
-    fmtstr        , dynelf        , elf           , exception     , \
-    gdb                           , log           , memleak       , \
-    replacements  , rop           , shellcraft    , term          , \
-    tubes         , ui            , useragents    , util          , \
-    pep237
-
-# from .context import context
-from .version import __version__
+for module in __all__:
+    importlib.import_module('.%s' % module, 'pwnlib')

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -47,15 +47,21 @@ Example
 
 DynELF
 """
-from . import elf
-from .elf     import ELF, constants
-from .memleak import MemLeak
-from .context import context
-from .log     import getLogger
+import ctypes
 
 from elftools.elf.enums import ENUM_D_TAG
 
-import ctypes
+from . import elf
+from . import libcdb
+from .context import context
+from .elf import ELF
+from .elf import constants
+from .log import getLogger
+from .memleak import MemLeak
+from .util.fiddling import enhex
+from .util.packing import unpack
+from .util.web     import wget
+
 
 log    = getLogger(__name__)
 sizeof = ctypes.sizeof
@@ -460,8 +466,23 @@ class DynELF(object):
         #
         # If we are resolving a symbol in the library, find it.
         #
-        if symb: result = dynlib._lookup(symb)
-        else:    result = dynlib.libbase
+        if symb:
+            # Try a quick lookup by build ID
+            self.status("Trying lookup based on Build ID")
+            build_id = dynlib._lookup_build_id(lib=lib)
+            if build_id:
+                path = libcdb.search_by_build_id(build_id)
+                if path:
+                    with context.local(log_level='error'):
+                        e = ELF(path)
+                        e.address = dynlib.libbase
+                        result = e.symbols[symb]
+
+            if not result:
+                self.status("Trying remote lookup")
+                result = dynlib._lookup(symb)
+        else:
+            result = dynlib.libbase
 
         #
         # Did we win?
@@ -707,3 +728,15 @@ class DynELF(object):
         else:
             self.failure('Could not find a GNU hash that matched %#x' % hsh)
             return None
+
+    def _lookup_build_id(self, lib = None):
+
+        libbase = self.libbase
+
+        if lib is not None:
+            libbase = self.lookup(symb = None, lib = lib)
+
+        for offset in libcdb.get_build_id_offsets():
+            address = libbase + offset
+            if self.leak.d(address + 0xC) == unpack("GNU\x00"):
+                return enhex(''.join(self.leak.raw(address + 0x10, 20)))

--- a/pwnlib/elf/__init__.py
+++ b/pwnlib/elf/__init__.py
@@ -117,7 +117,10 @@ class ELF(ELFFile):
             'EM_AARCH64': 'aarch64',
             'EM_MIPS': 'mips',
             'EM_PPC': 'powerpc',
-            'EM_SPARC32PLUS': 'sparc'
+            'EM_PPC64': 'powerpc64',
+            'EM_SPARC32PLUS': 'sparc',
+            'EM_SPARCV9': 'sparc64',
+            'EM_IA_64': 'ia64'
         }.get(self['e_machine'], self['e_machine'])
 
     @property

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -34,13 +34,15 @@ def search_by_build_id(hex_encoded_id):
 
     log.info("Downloading data from GitHub")
 
-    url_base = "https://raw.githubusercontent.com/zachriggle/libcdb/master/build_id/"
+    url_base = "https://gitlab.com/libcdb/libcdb/raw/master/hashes/build_id/"
     url      = urlparse.urljoin(url_base, hex_encoded_id)
 
-    headers={'Accept':'application/vnd.github.v3.json'}
     data   = ""
     while not data.startswith('\x7fELF'):
-        data = wget(url, headers=headers)
+        data = wget(url)
+
+        if not data:
+            return None
 
         if data.startswith('..'):
             url = os.path.dirname(url) + '/'

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -1,0 +1,104 @@
+"""
+Fetch a LIBC binary based on some heuristics.
+"""
+import codecs
+import json
+import os
+import tempfile
+import urlparse
+
+from .context       import context
+from .elf           import ELF
+from .log           import getLogger
+from .util.safeeval import const
+from .util.web      import wget
+from .util.fiddling import b64d, hexdump
+from .util.misc     import read, write
+
+log = getLogger(__name__)
+
+cache_dir = os.path.join(tempfile.gettempdir(), 'pwn')
+
+def search_by_build_id(hex_encoded_id):
+    """
+    Given a hex-encoded Build ID, return the path to an ELF with that Build ID
+    only the local system.
+
+    If it can't be found, return None.
+    """
+    cache = cache_dir + hex_encoded_id
+
+    if os.path.exists(cache) and read(cache).startswith('\x7FELF'):
+        log.info_once("Using cached data from %r" % cache)
+        return cache
+
+    log.info("Downloading data from GitHub")
+
+    url_base = "https://raw.githubusercontent.com/zachriggle/libcdb/master/build_id/"
+    url      = urlparse.urljoin(url_base, hex_encoded_id)
+
+    headers={'Accept':'application/vnd.github.v3.json'}
+    data   = ""
+    while not data.startswith('\x7fELF'):
+        data = wget(url, headers=headers)
+
+        if data.startswith('..'):
+            url = os.path.dirname(url) + '/'
+            url = urlparse.urljoin(url, data)
+
+    write(cache, data)
+    return cache
+
+def get_build_id_offsets():
+    """
+    Returns a list of file offsets where the Build ID should reside within
+    an ELF file of the currentlys-elected architecture.
+    """
+    # Given the corpus of almost all libc to have been released with
+    # RedHat, Fedora, Ubuntu, Debian, etc. over the past several years,
+    # we can say with 99% certainty that the GNU Build ID section will
+    # be at one of the specified addresses.
+    #
+    # The point here is to get an easy win by reading less DWORDs than would
+    # have otherwise been required to walk the section table and the string
+    # stable.
+    #
+    # function check_arch() {
+    # readelf -n $(file -L * | grep -i "$1" | cut -d ':' -f 1) \
+    #       | grep -B3 BUILD_ID \
+    #       | grep offset \
+    #       | sort \
+    #       | uniq -c
+    # }
+
+    return {
+    # $ check_arch 80386
+    #     181 Displaying notes found at file offset 0x00000174 with length 0x00000024:
+        'i386': [0x174],
+    # $ check_arch "ARM, EABI5"
+    #      69 Displaying notes found at file offset 0x00000174 with length 0x00000024:
+        'arm':  [0x174],
+        'thumb':  [0x174],
+    # $ check_arch "ARM aarch64"
+    #       1 Displaying notes found at file offset 0x00000238 with length 0x00000024:
+        'aarch64': [0x238],
+    # $ check_arch "x86-64"
+    #       6 Displaying notes found at file offset 0x00000174 with length 0x00000024:
+    #      82 Displaying notes found at file offset 0x00000270 with length 0x00000024:
+        'amd64': [0x270, 0x174],
+    # $ check_arch "PowerPC or cisco"
+    #      88 Displaying notes found at file offset 0x00000174 with length 0x00000024:
+        'powerpc': [0x174],
+    # $ check_arch "64-bit PowerPC"
+    #      30 Displaying notes found at file offset 0x00000238 with length 0x00000024:
+        'powerpc64': [0x238],
+    # $ check_arch "SPARC32"
+    #      32 Displaying notes found at file offset 0x00000174 with length 0x00000024:
+        'sparc': [0x174],
+    # $ check_arch "SPARC V9"
+    #      33 Displaying notes found at file offset 0x00000270 with length 0x00000024:
+        'sparc64': [0x270]
+    }.get(context.arch, [])
+
+
+__all__ = ['get_build_id_offsets', 'search_by_build_id']

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -25,8 +25,15 @@ def search_by_build_id(hex_encoded_id):
     only the local system.
 
     If it can't be found, return None.
+
+    Arguments:
+        hex_encoded_id(str):
+            Hex-encoded Build ID (e.g. 'ABCDEF...') of the library
+
+    Returns:
+        Path to the downloaded library on disk, or ``None``.
     """
-    cache = cache_dir + hex_encoded_id
+    cache = cache_dir + '-libc.so.' + hex_encoded_id
 
     if os.path.exists(cache) and read(cache).startswith('\x7FELF'):
         log.info_once("Using cached data from %r" % cache)

--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -1,6 +1,7 @@
-from .util.packing import pack, unpack
 from .log import getLogger
-from ctypes import sizeof
+from .util.packing import pack
+from .util.packing import unpack
+
 log = getLogger(__name__)
 
 class MemLeak(object):
@@ -55,13 +56,10 @@ class MemLeak(object):
 
     def struct(self, address, struct):
         """struct(address, struct) => structure object
-
         Leak an entire structure.
-
         Arguments:
             address(int):  Addess of structure in memory
             struct(class): A ctypes structure to be instantiated with leaked data
-
         Return Value:
             An instance of the provided struct class, with the leaked data decoded
         """
@@ -141,7 +139,7 @@ class MemLeak(object):
         """raw(addr, numb) -> list
 
         Leak `numb` bytes at `addr`"""
-        return map(self._leak, range(addr, addr+numb))
+        return map(lambda a: self._leak(a, 1), range(addr, addr+numb))
 
 
     def _b(self, addr, ndx, size):

--- a/pwnlib/rop.py
+++ b/pwnlib/rop.py
@@ -110,7 +110,7 @@ class ROP(object):
         else:
             log.error("ROP: Cannot flatten value %r" % value)
 
-    def _build_x86(self):
+    def _build_i386(self):
         # Stage 1:
         #   Convert every call in self._chain from a (addr, args) tuple
         #   into a (addr, pivot, args, pad) tuple.
@@ -179,6 +179,8 @@ class ROP(object):
                 outrop.append('$$$$')
 
         return output
+
+    _build_x86 = _build_i386
 
     def build(self, base = None):
         """Build the ROP chain into a list (addr, int/string, bool), where the


### PR DESCRIPTION
Adds support to DynELF to perform lookups on-the-fly given only a GNU Build ID.

These are useful, in that it's 20 bytes of data which for almost any libc I can find, are at a static offset from the library base.  This saves time on over-the-wire lookups, and may be useful in scenarios where the number of leaks we can perform is restricted.

Additionally, this includes some fixes/enhancements to MemLeak and ELF, some of which are required for this functionality (I just grabbed the whole file from Binjitsu rather than pick individual features).