### PR TITLE
Changed `util.misc.run_in_terminal` to first look for tmux, and then X11

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -309,6 +309,7 @@ class ContextType(object):
         'os': 'linux',
         'signed': False,
         'timeout': Timeout.maximum,
+        'terminal': None,
     }
 
     #: Valid values for :meth:`pwnlib.context.ContextType.os`
@@ -809,6 +810,17 @@ class ContextType(object):
         valid values.
         """
         return Timeout(value).timeout
+
+    @_validator
+    def terminal(self, value):
+        """
+        Default terminal used by :meth:`pwnlib.util.misc.run_in_new_terminal`.
+        Can be a string or an iterable of strings.  In the latter case the first
+        entry is the terminal and the rest are default arguments.
+        """
+        if isinstance(value, (str, unicode)):
+            return [value]
+        return value
 
     #*************************************************************************
     #                               ALIASES

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -1,5 +1,6 @@
 import socket, re, os, stat, errno, string, base64
 from . import lists
+from ..context import context
 from ..log import getLogger
 log = getLogger(__name__)
 
@@ -150,10 +151,13 @@ def run_in_new_terminal(command, terminal = None, args = None):
 
     Run a command in a new terminal.
 
-    If X11 is detected, the terminal will be launched with
-    ``x-terminal-emulator``.
-
-    If X11 is not detected, a new tmux pane is opened if possible.
+    When `terminal` is not set:
+      - If `context.terminal` is set it will be used.  If it is an iterable then
+        `context.terminal[1:]` are default arguments.
+      - If X11 is detected (by the presence of the ``DISPLAY`` environment
+        variable), ``x-terminal-emulator`` is used.
+      - If tmux is detected (by the presence of the ``TMUX`` environment
+        variable), a new pane will be opened.
 
     Arguments:
       command (str): The command to run.
@@ -162,21 +166,29 @@ def run_in_new_terminal(command, terminal = None, args = None):
 
     Returns:
       None
+
     """
 
     if not terminal:
-        if 'XAUTHORITY' in os.environ:
+        if context.terminal:
+            terminal = context.terminal[0]
+            args     = context.terminal[1:]
+        elif 'DISPLAY' in os.environ:
             terminal = 'x-terminal-emulator'
             args     = ['-e']
-
         elif 'TMUX' in os.environ:
             terminal = 'tmux'
             args     = ['splitw']
 
     if not terminal:
-        log.error('could not find terminal: %s' % terminal)
+        log.error('Argument `terminal` is not set, and could not determine a default')
 
-    argv    = [which(terminal)] + args + [command]
+    terminal_path = which(terminal)
+
+    if not terminal_path:
+        log.error('Could not find terminal: %s' % terminal)
+
+    argv = [terminal_path] + args + [command]
     log.debug("Launching a new terminal: %r" % argv)
 
     if os.fork() == 0:


### PR DESCRIPTION
This is needed because looking for the environment variable `XAUTHORITY` is not enough to detect X11.  Specifically it is not set on my system.  The existence of the file `~/.Xauthority` is taken as an indication of running under X11.  But this file will still be present when running tmux, hence the changed order of detection.