### PR TITLE
Dont emit CRLF since it shows empty lines

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -218,6 +218,7 @@ class ssh_channel(sock):
             while not event.is_set():
                 try:
                     cur = self.recv(timeout = 0.05)
+                    cur = cur.replace('\r\n','\n')
                     if cur == None:
                         continue
                     elif cur == '\a':

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -786,6 +786,7 @@ class tube(Timeout):
             while not go.isSet():
                 try:
                     cur = self.recv(timeout = 0.05)
+                    cur = cur.replace('\r\n', '\n')
                     if cur:
                         sys.stderr.write(cur)
                         sys.stderr.flush()


### PR DESCRIPTION
The problem is that some remote endpoints send CRLF as a line terminator instead of just LF.

This ends up showing a bunch of empty lines, and is pretty useless.

The easiest example to demonstrate this is the script below.  Without this patch, it looks like nothing particularly interesting happens.  If run with `DEBUG` or `PWNLIB_LOG_LEVEL=debug`, you see that there's information being sent, it's just not displaying how you might expect it to.  With this patch, everything displays OK.

Since the data is only lossy within the `.interactive` loop, which is intended to be text-based, this lossy transformation *should* be okay.

```py
from pwn import *

session = ssh('level1', 'ioarm.smashthestack.org', 2201, 'level1')
session.interactive()
```