### PR TITLE
bugfix: `ui.yesno()` now correctly handles <enter>

### DIFF
--- a/pwnlib/term/key.py
+++ b/pwnlib/term/key.py
@@ -417,7 +417,7 @@ def _peek_simple():
                 k = Key(kc.TYPE_KEYSYM, kc.KEY_BACKSPACE)
             elif c0 == 9:
                 k = Key(kc.TYPE_KEYSYM, kc.KEY_TAB)
-            elif c0 == 13:
+            elif c0 in (10, 13):
                 k = Key(kc.TYPE_KEYSYM, kc.KEY_ENTER)
             else:
                 k = Key(kc.TYPE_UNICODE)


### PR DESCRIPTION
This bug happened because we no longer disable input processing in the terminal.
In particular `\r` is now translated to `\n`.  The fix is to interpret both `\r`
and `\n` as <enter> in `term/key.py`.