### PR TITLE
Fixed lookup feature where the packing util was being called with wrong argument

### DIFF
--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -55,9 +55,9 @@ def main():
         pat = args.lookup
 
         if pat.startswith('0x'):
-            pat = packing.pack(int(pat[2:], 16), subsize*8, 'little', 'unsigned')
+            pat = packing.pack(int(pat[2:], 16), subsize*8, 'little', False)
         elif pat.isdigit():
-            pat = packing.pack(int(pat, 10), subsize*8, 'little', 'unsigned')
+            pat = packing.pack(int(pat, 10), subsize*8, 'little', False)
 
         if len(pat) != subsize:
             log.critical('Subpattern must be %d bytes' % subsize)


### PR DESCRIPTION
The cyclic commandline tool was calling pack using a string 'unsigned' as the sign argument. The util.packing.pack method states string as type but is comparing against True|False value. This was causing a ValueError on line 51 of cyclic.py (94 in utils/packing.py)