### PR TITLE
close file descriptors in process.close() and avoid leaving zombie processes around

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -406,9 +406,18 @@ class process(tube):
         # First check if we are already dead
         self.poll()
 
+        #close file descriptors
+        if self.proc.stdin is not None:
+            self.proc.stdin.close()
+        if self.proc.stderr is not None:
+            self.proc.stderr.close()
+        if self.proc.stdout is not None:
+            self.proc.stdout.close()
+
         if not self._stop_noticed:
             try:
                 self.proc.kill()
+                self.proc.wait() #avoid leaving zombies around
                 self._stop_noticed = True
                 log.info('Stopped program %r' % self.program)
             except OSError:


### PR DESCRIPTION
This commit fixes two problems:
1) File descriptors used to communicate with a forked process are not closed.
2) The return code of a killed/closed process is not read (leaving a zombie process around).

To reproduce these issues:
```python
for i in xrange(3000):
    p = process("ls")
    p.kill()
```
This code will generate the following error: `OSError: [Errno 24] Too many open files`.
In addition, a lot of zombie processes are created (use `ps aux | grep ls` to check).

With the proposed patch, both issues are solved.

