### PR TITLE
corrected util.fiddling.bits implementation to handle 0 validly

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -123,6 +123,8 @@ def bits(s, endian = 'big', zero = 0, one = 1):
             else:
                 out += byte[::-1]
     elif isinstance(s, (int, long)):
+        if s == 0:
+            out.append(zero)
         while s:
             bit, s = one if s & 1 else zero, s >> 1
             out.append(bit)


### PR DESCRIPTION
Corrected #436 - bits(0) now returns [0, 0, 0, 0, 0, 0, 0, 0].