### PR TITLE
Fix annoying setup.py behaviour.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'capstone',
                         'ropgadget>=5.3',
                         'pyserial>=2.7',
-                        'requests>=2.5.1']
+                        'requests>=2.0']
 
 # This is a hack until somebody ports psutil to OpenBSD
 if platform.system() != 'OpenBSD':


### PR DESCRIPTION
When installing pwntools, setup.py required a very new version of
requests -- even though we never used any new features.

This is a problem, since the required version is much never than what is
in e.g. ubuntu's package repo. While this by itself is not much of a
problem, it is a problem if one installs python-pip from the distro's
repo as well, since python-pip will try to use the newest version of the
requests library, which caused pip to break.

The solution: Do not force such a new version of python, instead live
with a much older version.