### PR TITLE
Remove unused statement in context.arch

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -566,9 +566,8 @@ class ContextType(object):
             True
         """
 
-        # Lowercase, remove everything non-alphanumeric
+        # Lowercase
         arch = arch.lower()
-        arch = arch.replace(string.punctuation, '')
 
         # Attempt to perform convenience and legacy compatibility
         # transformations.


### PR DESCRIPTION
The code does not work as what the comment says at all, unless you write:
```ruby
context.arch='amd64!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
```
Since it never works as intended, seems to be safe to just remove this behavior.