### PR TITLE
Fix inconsistency between error message and code.

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -606,12 +606,12 @@ class ContextType(object):
             >>> context.bits = -1 #doctest: +ELLIPSIS
             Traceback (most recent call last):
             ...
-            AttributeError: bits must be >= 0 (-1)
+            AttributeError: bits must be > 0 (-1)
         """
         bits = int(bits)
 
         if bits <= 0:
-            raise AttributeError("bits must be >= 0 (%r)" % bits)
+            raise AttributeError("bits must be > 0 (%r)" % bits)
 
         return bits
 
@@ -660,7 +660,7 @@ class ContextType(object):
             >>> context.bytes = 0 #doctest: +ELLIPSIS
             Traceback (most recent call last):
             ...
-            AttributeError: bits must be >= 0 (0)
+            AttributeError: bits must be > 0 (0)
         """
         return self.bits/8
     @bytes.setter


### PR DESCRIPTION
Code says context.bits should be > 0, but error message says >= 0.
Since 0 bit architecture doesn't make sense at all, make them all be > 0.