### PR TITLE
Fix pack when sign=True and word_size='all'

### DIFF
--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -82,6 +82,8 @@ def pack(number, word_size = None, endianness = None, sign = None, **kwargs):
         '\\xff\\x00'
         >>> pack(0x0102030405, 'all', 'little', True)
         '\\x05\\x04\\x03\\x02\\x01'
+        >>> pack(0x80000000, 'all', 'big', True)
+        '\\x00\\x80\\x00\\x00\\x00'
 """
     if sign is None and number < 0:
         sign = True
@@ -112,7 +114,10 @@ def pack(number, word_size = None, endianness = None, sign = None, **kwargs):
             if number == 0:
                 word_size = 8
             elif number > 0:
-                word_size = ((number.bit_length() - 1) | 7) + 1
+                if sign == False:
+                    word_size = ((number.bit_length() - 1) | 7) + 1
+                else:
+                    word_size = (number.bit_length() | 7) + 1
             else:
                 if sign == False:
                     raise ValueError("pack(): number does not fit within word_size")


### PR DESCRIPTION
When `sign=True` and `word_size='all'`, we should also consider the sign bit in calculation of real `word_size`.