### PR TITLE
Added support for generating a Dash docset.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,8 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
+DASHBUILD     = ./dashbuild.py
+TAR           = tar
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -14,7 +16,8 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sou
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext dash
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -34,6 +37,7 @@ help:
 	@echo "  texinfo    to make Texinfo files"
 	@echo "  info       to make Texinfo files and run them through makeinfo"
 	@echo "  gettext    to make PO message catalogs"
+	@echo "  dash       to make a Dash docset"
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
@@ -135,6 +139,11 @@ gettext:
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+
+dash:
+	$(DASHBUILD) source $(BUILDDIR)/dash
+	$(TAR) --exclude='.DS_Store' -cvzf $(BUILDDIR)/dash/pwntools.tgz -C $(BUILDDIR)/dash pwntools.docset
+	@echo "Build finished. The Dash docset is in $(BUILDDIR)/dash."
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes

--- a/docs/dashbuild.py
+++ b/docs/dashbuild.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+
+#
+# Helper to build Dash docset from sphinx source files.
+#
+# Dash docsets can be read by various applications:
+#
+# Dash         OS X, iOS         https://kapeli.com
+# Zeal         Linux, Windows    https://zealdocs.org
+# Velocity     Windows           http://velocity.silverlakesoftware.com
+# LovelyDocs   Android           http://lovelydocs.io
+# dasht        POSIX             https://github.com/sunaku/dasht
+# Helm Dash    emacs             https://github.com/areina/helm-dash
+#
+
+import argparse
+import doc2dash.__main__
+import os, os.path
+import sphinx
+import sqlite3
+import sys
+
+sys.path.append(os.path.abspath(os.path.join('..', 'pwnlib')))
+import version
+
+def main(args):
+	"""Generate a Dash docset from Sphinx source files."""
+	
+	srcdir = args.srcdir
+	dstdir = args.dstdir
+	name = args.name
+	
+	if not os.path.exists(dstdir):
+		os.makedirs(dstdir)
+
+	# Generate HTML without indices.
+	sphinx.build_main([ "sphinx-build", "-b", "html", "-d", os.path.join(dstdir, "doctrees"), \
+		"-t", "dash", srcdir, os.path.join(dstdir, "html") ])
+
+	# Convert to docset.
+	try:
+		doc2dash.__main__.main.main( \
+			[ os.path.join(dstdir, "html"), "-d", dstdir, "-n", name, \
+					"-f", "-I", "index.html"], "doc2dash", False)
+	except SystemExit,e:
+		pass
+		
+	# Insert a link to the online version.
+	online = args.online
+	if online is not None and online != "":
+		url = online.replace("@VERSION", args.version)
+		with open(os.path.join(dstdir, name+".docset", "Contents", "Info.plist"), "r+") as f_info:
+			pl = f_info.read()
+			pl = pl.replace("</dict>", \
+				"\t<key>DashDocSetFallbackURL</key>\n\t<string>%s</string>\n</dict>" % url)
+			f_info.seek(0)
+			f_info.write(pl)
+			f_info.truncate()
+			
+	# Modify the CSS to hide the menu included in the HTML.
+	with open(os.path.join(dstdir, name+".docset", "Contents", "Resources", "Documents", "_static", "css", "theme.css"), "r+") as f_css:
+		css = f_css.read()
+		css = css.replace( \
+			'@media screen and (max-width: 768px){.wy-body-for-nav{background:#fcfcfc}.wy-nav-top{display:block}',\
+			'@media screen {.wy-body-for-nav{background:#fcfcfc}' )
+		css = css.replace( \
+			'@media screen and (max-width: 480px)', \
+			'@media screen ')
+		f_css.seek(0)
+		f_css.write(css)
+		f_css.truncate()
+		
+	# Modify the index
+	db_conn = sqlite3.connect(os.path.join(dstdir, name+".docset", "Contents", "Resources", "docSet.dsidx"))
+	try:
+		db_conn.execute('INSERT INTO "searchIndex" ("name","type","path") VALUES ' \
+			'("1 Contents", "Guide", "index.html"), ' \
+			'("2 About pwntools", "Guide", "about.html"), ' \
+			'("3 Installation", "Guide", "install.html"), ' \
+			'("4 Getting Started", "Guide", "intro.html"), ' \
+			'("5 Globals (pwn)", "Guide", "globals.html"), ' \
+			'("6 Command Line Tools", "Guide", "commandline.html")')
+		db_conn.execute('DELETE FROM "searchIndex" WHERE "type" = "Module" AND ("name" = "pwn" OR "name" = "pwnlib")')
+		db_conn.commit()
+	finally:
+		db_conn.close()
+		
+	return 0
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--name", help="docset name", default="pwntools")
+parser.add_argument("--online", help="URL for online docs", default="https://pwntools.readthedocs.org/en/@VERSION/")
+parser.add_argument("--version", help="pwntools version", default=version.__version__)
+parser.add_argument("srcdir", help="Source directory containing .rst files")
+parser.add_argument("dstdir", help="Destination and working directory")
+
+main(parser.parse_args())

--- a/docs/dashbuild.py
+++ b/docs/dashbuild.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # -*- coding: utf-8 -*-
 
@@ -26,68 +26,68 @@ sys.path.append(os.path.abspath(os.path.join('..', 'pwnlib')))
 import version
 
 def main(args):
-	"""Generate a Dash docset from Sphinx source files."""
-	
-	srcdir = args.srcdir
-	dstdir = args.dstdir
-	name = args.name
-	
-	if not os.path.exists(dstdir):
-		os.makedirs(dstdir)
+    """Generate a Dash docset from Sphinx source files."""
 
-	# Generate HTML without indices.
-	sphinx.build_main([ "sphinx-build", "-b", "html", "-d", os.path.join(dstdir, "doctrees"), \
-		"-t", "dash", srcdir, os.path.join(dstdir, "html") ])
+    srcdir = args.srcdir
+    dstdir = args.dstdir
+    name = args.name
 
-	# Convert to docset.
-	try:
-		doc2dash.__main__.main.main( \
-			[ os.path.join(dstdir, "html"), "-d", dstdir, "-n", name, \
-					"-f", "-I", "index.html"], "doc2dash", False)
-	except SystemExit,e:
-		pass
-		
-	# Insert a link to the online version.
-	online = args.online
-	if online is not None and online != "":
-		url = online.replace("@VERSION", args.version)
-		with open(os.path.join(dstdir, name+".docset", "Contents", "Info.plist"), "r+") as f_info:
-			pl = f_info.read()
-			pl = pl.replace("</dict>", \
-				"\t<key>DashDocSetFallbackURL</key>\n\t<string>%s</string>\n</dict>" % url)
-			f_info.seek(0)
-			f_info.write(pl)
-			f_info.truncate()
-			
-	# Modify the CSS to hide the menu included in the HTML.
-	with open(os.path.join(dstdir, name+".docset", "Contents", "Resources", "Documents", "_static", "css", "theme.css"), "r+") as f_css:
-		css = f_css.read()
-		css = css.replace( \
-			'@media screen and (max-width: 768px){.wy-body-for-nav{background:#fcfcfc}.wy-nav-top{display:block}',\
-			'@media screen {.wy-body-for-nav{background:#fcfcfc}' )
-		css = css.replace( \
-			'@media screen and (max-width: 480px)', \
-			'@media screen ')
-		f_css.seek(0)
-		f_css.write(css)
-		f_css.truncate()
-		
-	# Modify the index
-	db_conn = sqlite3.connect(os.path.join(dstdir, name+".docset", "Contents", "Resources", "docSet.dsidx"))
-	try:
-		db_conn.execute('INSERT INTO "searchIndex" ("name","type","path") VALUES ' \
-			'("1 Contents", "Guide", "index.html"), ' \
-			'("2 About pwntools", "Guide", "about.html"), ' \
-			'("3 Installation", "Guide", "install.html"), ' \
-			'("4 Getting Started", "Guide", "intro.html"), ' \
-			'("5 Globals (pwn)", "Guide", "globals.html"), ' \
-			'("6 Command Line Tools", "Guide", "commandline.html")')
-		db_conn.execute('DELETE FROM "searchIndex" WHERE "type" = "Module" AND ("name" = "pwn" OR "name" = "pwnlib")')
-		db_conn.commit()
-	finally:
-		db_conn.close()
-		
-	return 0
+    if not os.path.exists(dstdir):
+        os.makedirs(dstdir)
+
+    # Generate HTML without indices.
+    sphinx.build_main([ "sphinx-build", "-b", "html", "-d", os.path.join(dstdir, "doctrees"), \
+        "-t", "dash", srcdir, os.path.join(dstdir, "html") ])
+
+    # Convert to docset.
+    try:
+        doc2dash.__main__.main.main( \
+            [ os.path.join(dstdir, "html"), "-d", dstdir, "-n", name, \
+                    "-f", "-I", "index.html"], "doc2dash", False)
+    except SystemExit,e:
+        pass
+
+    # Insert a link to the online version.
+    online = args.online
+    if online is not None and online != "":
+        url = online.replace("@VERSION", args.version)
+        with open(os.path.join(dstdir, name+".docset", "Contents", "Info.plist"), "r+") as f_info:
+            pl = f_info.read()
+            pl = pl.replace("</dict>", \
+                "\t<key>DashDocSetFallbackURL</key>\n\t<string>%s</string>\n</dict>" % url)
+            f_info.seek(0)
+            f_info.write(pl)
+            f_info.truncate()
+
+    # Modify the CSS to hide the menu included in the HTML.
+    with open(os.path.join(dstdir, name+".docset", "Contents", "Resources", "Documents", "_static", "css", "theme.css"), "r+") as f_css:
+        css = f_css.read()
+        css = css.replace( \
+            '@media screen and (max-width: 768px){.wy-body-for-nav{background:#fcfcfc}.wy-nav-top{display:block}',\
+            '@media screen {.wy-body-for-nav{background:#fcfcfc}' )
+        css = css.replace( \
+            '@media screen and (max-width: 480px)', \
+            '@media screen ')
+        f_css.seek(0)
+        f_css.write(css)
+        f_css.truncate()
+
+    # Modify the index
+    db_conn = sqlite3.connect(os.path.join(dstdir, name+".docset", "Contents", "Resources", "docSet.dsidx"))
+    try:
+        db_conn.execute('INSERT INTO "searchIndex" ("name","type","path") VALUES ' \
+            '("1 Contents", "Guide", "index.html"), ' \
+            '("2 About pwntools", "Guide", "about.html"), ' \
+            '("3 Installation", "Guide", "install.html"), ' \
+            '("4 Getting Started", "Guide", "intro.html"), ' \
+            '("5 Globals (pwn)", "Guide", "globals.html"), ' \
+            '("6 Command Line Tools", "Guide", "commandline.html")')
+        db_conn.execute('DELETE FROM "searchIndex" WHERE "type" = "Module" AND ("name" = "pwn" OR "name" = "pwnlib")')
+        db_conn.commit()
+    finally:
+        db_conn.close()
+
+    return 0
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--name", help="docset name", default="pwntools")

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,5 @@ mako
 pyelftools
 sphinxcontrib-napoleon
 sphinxcontrib-autoprogram
+sphinx_rtd_theme
+doc2dash

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,8 @@
 
 import sys, os, subprocess
 
+build_dash = tags.has('dash')
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -162,10 +164,10 @@ html_static_path = []
 #html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+html_domain_indices = not build_dash
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = not build_dash
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
@@ -313,3 +315,19 @@ def linkcode_resolve(domain, info):
                 pass
 
     return "https://github.com/Gallopsled/pwntools/blob/%s/%s" % (branch, filename)
+
+
+# The readthedocs theme is used by the Dash generator. (Can be used for HTML too.)
+
+if build_dash:
+
+    # on_rtd is whether we are on readthedocs.org
+    on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+    if not on_rtd:  # only import and set the theme if we're building docs locally
+        import sphinx_rtd_theme
+        html_theme = 'sphinx_rtd_theme'
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+    # otherwise, readthedocs.org uses their theme by default, so no need to specify it
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os, subprocess
+import os
+import subprocess
+import sys
 
 build_dash = tags.has('dash')
 
@@ -330,4 +332,3 @@ if build_dash:
         html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
     # otherwise, readthedocs.org uses their theme by default, so no need to specify it
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,7 +55,7 @@ Each of the ``pwntools`` modules is documented here.
 
    Indices and tables
    ==================
-   
+
    * :ref:`genindex`
    * :ref:`modindex`
    * :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,9 +51,11 @@ Each of the ``pwntools`` modules is documented here.
    useragents
    util/*
 
-Indices and tables
-==================
+.. only:: not dash
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   Indices and tables
+   ==================
+   
+   * :ref:`genindex`
+   * :ref:`modindex`
+   * :ref:`search`

--- a/examples/attach.py
+++ b/examples/attach.py
@@ -1,0 +1,12 @@
+"""
+Example showing `pwnlib.gdb.attach()`
+"""
+
+from pwn import *
+
+bash = process('/bin/bash')
+gdb.attach(bash, execute = '''
+p "hello from pwnlib"
+c
+''')
+bash.interactive()


### PR DESCRIPTION
    Dash docsets can be read by various applications:
    
    Dash         OS X, iOS         https://kapeli.com
    Zeal         Linux, Windows    https://zealdocs.org
    Velocity     Windows           http://velocity.silverlakesoftware.com
    LovelyDocs   Android           http://lovelydocs.io
    dasht        POSIX             https://github.com/sunaku/dasht
    Helm Dash    emacs             https://github.com/areina/helm-dash
