### PR TITLE
Fix cyclic_find packing when subseq=int

### DIFF
--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -71,7 +71,7 @@ def cyclic(length = None, alphabet = string.ascii_lowercase, n = 4):
     else:
         return out
 
-def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = None):
+def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = 0):
     """cyclic_find(subseq, alphabet = string.ascii_lowercase, n = None) -> int
 
     Calculates the position of a substring into a De Bruijn sequence.
@@ -98,12 +98,12 @@ def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = None):
       >>> cyclic_find(cyclic(1000)[514:518])
       514
     """
-    if any(c not in alphabet for c in subseq):
-        return -1
-
     if isinstance(subseq, (int, long)):
         width = n * 8 or 'all'
         subseq = packing.pack(subseq, width, 'little', False)
+
+    if any(c not in alphabet for c in subseq):
+        return -1
 
     n = n or len(subseq)
 


### PR DESCRIPTION
when instance of cyclic_find subseq argument is int, int to str packing is not working.
because any iter before isinstance check


before

def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = None):
...
    if any(c not in alphabet for c in subseq):
        return -1

    if isinstance(subseq, (int, long)):
        width = n * 8 or 'all'
        subseq = packing.pack(subseq, width, 'little', False)

>>> cyclic_find(0x61616162)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pwnlib/util/cyclic.py", line 101, in cyclic_find
    if any(c not in alphabet for c in subseq):
TypeError: 'int' object is not iterable

after

def cyclic_find(subseq, alphabet = string.ascii_lowercase, n = 0):
...

    if isinstance(subseq, (int, long)):
        width = n * 8 or 'all'
        subseq = packing.pack(subseq, width, 'little', False)

    if any(c not in alphabet for c in subseq):
        return -1

>>> cyclic_find(0x61616162)
4

it worked