### PR TITLE
Fix wrong format string parameters in memleak.py

### DIFF
--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -105,7 +105,7 @@ class MemLeak(object):
                 if prev != b:
                     raise ValueError(
                         "Leaked byte 0x%02x at address 0x%x disagrees with "
-                        "previously leaked byte 0x%02x" % (b, prev))
+                        "previously leaked byte 0x%02x" % (ord(b), a, ord(prev)))
                 else:
                     continue
 


### PR DESCRIPTION
Fix wrong format string parameters of a debug message which is a `ValueError` exception in `memleak.py`.

`b` and `prev` are 1-byte long strings. You should convert them to `int` for `%02x`.
