### PR TITLE
Don't explicitly rm the gdb command tmpfiles

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -304,9 +304,9 @@ def attach(target, execute = None, exe = None, arch = None):
     if execute:
         tmp = tempfile.NamedTemporaryFile(prefix = 'pwn', suffix = '.gdb',
                                           delete = False)
+        tmp.write("shell /bin/rm %s\n" % tmp.name)
         tmp.write(execute)
         tmp.close()
-        atexit.register(lambda: os.unlink(tmp.name))
         cmd += ' -x "%s"' % tmp.name
 
     log.info('running in new terminal: %s' % cmd)

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -307,7 +307,7 @@ def attach(target, execute = None, exe = None, arch = None):
         tmp.write(execute)
         tmp.close()
         atexit.register(lambda: os.unlink(tmp.name))
-        cmd += ' -x "%s" ; rm "%s"' % (tmp.name, tmp.name)
+        cmd += ' -x "%s"' % tmp.name
 
     log.info('running in new terminal: %s' % cmd)
     misc.run_in_new_terminal(cmd)


### PR DESCRIPTION
local gdb in a tmux split, when the tmux split is told to do more than just run
gdb, is unhappy about being resized immediately following a Ctrl-C. The tmux
pane hosting gdb quietly dies. It doesn't seem to be an issue for remote gdb's
via pwnlib.tubes.ssh

Let's not explicitly tell terminals launched by run_in_new_terminal for local
instances of gdb to rm tmpfiles created for gdb commands.

The atexit handler that is being registered should eventually look after the
cleanup of tmpfiles in normal cases?

---

So this is dumb, it sucked to get to the bottom of, and it's probably not pwntools' fault. It could be tmux or gdb, but whatever it is, it's triggered by pwntools in my environment. I'd be curious if anyone else can reproduce it.

My setup:
* pwntools at 29bf5fc5fc36929020d5579ff33e965993cf40dc
* tmux 1.9-6 via Debian Jessie
    * Has bind-key's set up to do `resize-pane -L 3` for each of left, right, up and down
* gdb 7.7.1+dfsg-5 via Debian Jessie

When I do something like:

```
% python         
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pwn
>>> pwn.context.log_level = 'debug'
>>> pwn.process("yes")
[x] Starting program '/usr/bin/yes' argv=['yes'] 
[+] Starting program '/usr/bin/yes' argv=['yes'] : Done
<pwnlib.tubes.process.process object at 0x7f4996e29f90>
>>> pwn.gdb.attach("yes")
[*] attaching you youngest process "yes" (PID = 304)
[*] running in new terminal: gdb "/usr/bin/yes" 304
[DEBUG] Launching a new terminal: ['/usr/bin/tmux', 'splitw', 'gdb "/usr/bin/yes" 304']
[x] Waiting for debugger
[+] Waiting for debugger: Done
>>>
```

Everything is fine, and I can resize gdb's tmux split.

When I do:

```
% python
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pwn
>>> pwn.context.log_level = 'debug'
>>> pwn.process("yes")
[x] Starting program '/usr/bin/yes' argv=['yes'] 
[+] Starting program '/usr/bin/yes' argv=['yes'] : Done
<pwnlib.tubes.process.process object at 0x7fd60ed10f90>
>>> pwn.gdb.attach("yes", execute = "continue")
[*] attaching you youngest process "yes" (PID = 312)
[*] running in new terminal: gdb "/usr/bin/yes" 312 -x "/tmp/pwn3ZVzMQ.gdb" ; rm "/tmp/pwn3ZVzMQ.gdb"
[DEBUG] Launching a new terminal: ['/usr/bin/tmux', 'splitw', 'gdb "/usr/bin/yes" 312 -x "/tmp/pwn3ZVzMQ.gdb" ; rm "/tmp/pwn3ZVzMQ.gdb"']
[x] Waiting for debugger
[+] Waiting for debugger: Done
>>> 
```

If I resize the pane, it's fine

If I hit enter in gdb and resize the pane, it's fine.

As soon as I hit Ctrl-C in gdb and resize the pane, the pane with gdb simply disappears.

Minimal reproduction:

```
% python
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pwn
>>> pwn.run_in_new_terminal("gdb")
```

Everything is fine.

```
% python
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pwn
>>> pwn.run_in_new_terminal("gdb;true")
```

I get the buggy behaviour with Ctrl-C then resizing the pane.

Seems like something is unhappy when we try to get tmux to pop gdb then do something else.

My local workaround is to not bother rm'ing gdb command files. Thought if others can reproduce the behaviour, it might be worth considering as a patch, since leaving tmpfiles behind mightn't be worse than the buggy behaviour and we're already registering an atexit handler to look after cleanup of tmpfiles eventually.