### PR TITLE
Don't fail on unknown (numeric) ELF segment types

### DIFF
--- a/pwnlib/elf/__init__.py
+++ b/pwnlib/elf/__init__.py
@@ -596,18 +596,20 @@ class ELF(ELFFile):
         if self.dynamic_by_tag('DT_BIND_NOW'):
             return "Full"
 
-        if any('GNU_RELRO' in s.header.p_type for s in self.segments):
+        if 'PT_GNU_RELRO' in (seg.header.p_type for seg in self.segments):
             return "Partial"
         return None
 
     @property
     def nx(self):
-        if not any('GNU_STACK' in seg.header.p_type for seg in self.segments):
+        if 'PT_GNU_STACK' not in (seg.header.p_type for seg in self.segments):
             return False
 
         # Can't call self.executable_segments because of dependency loop.
-        exec_seg = [s for s in self.segments if s.header.p_flags & P_FLAGS.PF_X]
-        return not any('GNU_STACK' in seg.header.p_type for seg in exec_seg)
+        exec_seg_types = [seg.header.p_type
+                          for seg in self.segments
+                          if seg.header.p_flags & P_FLAGS.PF_X]
+        return 'PT_GNU_STACK' not in exec_seg_types
 
     @property
     def execstack(self):


### PR DESCRIPTION
Some executables can have unknown/non-standard ELF segment types (like `PT_PAX_FLAGS`) which show up as a numeric `p_type`, this makes the ELF class fail upon loading one of those files.

This uses an exact match (on `'PT_GNU_STACK'` and `'PT_GNU_RELRO'`) rather than a substring match so the comparison doesn't fail on integers.