### PR TITLE
Missed case where p_type needs to be converted to a string

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -736,7 +736,7 @@ class ELF(ELFFile):
 
         # Can't call self.executable_segments because of dependency loop.
         exec_seg = [s for s in self.segments if s.header.p_flags & P_FLAGS.PF_X]
-        return not any('GNU_STACK' in seg.header.p_type for seg in exec_seg)
+        return not any('GNU_STACK' in str(seg.header.p_type) for seg in exec_seg)
 
     @property
     def execstack(self):


### PR DESCRIPTION
Fixes #633 (the other cases fixed by #636)