### PR TITLE
Add warning described in Gallopsled/pwntools#518

### DIFF
--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -6,3 +6,9 @@ pwnlib.log.install_default_handler()
 
 log = pwnlib.log.getLogger('pwnlib.exploit')
 args = pwnlib.args.args
+
+if not platform.architecture()[0].startswith('64'):
+    """Determines if the current Python interpreter is supported by Pwntools.
+
+    See Gallopsled/pwntools#518 for more information."""
+    log.warn_once('Pwntools does not support 32-bit Python.  Use a 64-bit release.')


### PR DESCRIPTION
Unfortunately, I had to add this to `pwn/__init__.py` instead of `pwnlib/__init__.py` since the default logger isn't installed until the former is invoked, so you just get a "No log handler installed" message.

Fixes Gallopsled/pwntools#518