### PR TITLE
Add heap leak from the linker. Fixes Gallopsled/pwntools#435

### DIFF
--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -860,3 +860,14 @@ class DynELF(object):
         self.success('*environ: %#x' % stack)
 
         return stack
+
+    def heap(self):
+        """Finds the beginning of the heap via __curbrk, which is an exported
+        symbol in the linker, which points to the current brk.
+        """
+        curbrk = self.lookup('__curbrk', 'libc')
+        brk    = self.leak.p(curbrk)
+
+        self.success('*curbrk: %#x' % brk)
+
+        return brk


### PR DESCRIPTION
(cherry picked from commit 5808882cfe7cc3c1ca967c6c6bf9dad6800b8541)