### PR TITLE
enable passing options to ssl.wrap_socket in remote tube

### DIFF
--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -70,7 +70,7 @@ class remote(sock):
             self.settimeout(self.timeout)
             self.lhost, self.lport = self.sock.getsockname()[:2]
 
-            if type(ssl) == dict:
+            if isinstance(ssl, dict):
                 self.sock = _ssl.wrap_socket(self.sock, **ssl)
             elif ssl:
                 self.sock = _ssl.wrap_socket(self.sock)

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -71,11 +71,10 @@ class remote(sock):
             self.settimeout(self.timeout)
             self.lhost, self.lport = self.sock.getsockname()[:2]
 
-            if ssl:
-                try:
-                    self.sock = _ssl.wrap_socket(self.sock, **ssl)
-                except TypeError:
-                    self.sock = _ssl.wrap_socket(self.sock)
+            if type(ssl) == dict:
+                self.sock = _ssl.wrap_socket(self.sock, **ssl)
+            elif ssl:
+                self.sock = _ssl.wrap_socket(self.sock)
 
     @staticmethod
     def _get_family(fam):

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -20,8 +20,7 @@ class remote(sock):
         fam: The string "any", "ipv4" or "ipv6" or an integer to pass to :func:`socket.getaddrinfo`.
         typ: The string "tcp" or "udp" or an integer to pass to :func:`socket.getaddrinfo`.
         timeout: A positive number, None or the string "default".
-        ssl(bool): Wrap the socket with SSL
-        ssl(dict): Wrap the socket with SSL, use the dict as arguments to `ssl.wrap_socket`
+        ssl(bool,dict): ``True`` to wrap the socket with SSL.  Use a ``dict`` to pass options to the SSL wraper.
         sock(socket): Socket to inherit, rather than connecting
 
     Examples:

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -21,6 +21,7 @@ class remote(sock):
         typ: The string "tcp" or "udp" or an integer to pass to :func:`socket.getaddrinfo`.
         timeout: A positive number, None or the string "default".
         ssl(bool): Wrap the socket with SSL
+        ssl(dict): Wrap the socket with SSL, use the dict as arguments to `ssl.wrap_socket`
         sock(socket): Socket to inherit, rather than connecting
 
     Examples:
@@ -71,8 +72,10 @@ class remote(sock):
             self.lhost, self.lport = self.sock.getsockname()[:2]
 
             if ssl:
-                self.sock = _ssl.wrap_socket(self.sock)
-
+                try:
+                    self.sock = _ssl.wrap_socket(self.sock, **ssl)
+                except TypeError:
+                    self.sock = _ssl.wrap_socket(self.sock)
 
     @staticmethod
     def _get_family(fam):

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -4,6 +4,7 @@ import re
 import string
 import subprocess
 import sys
+import ssl
 import threading
 import time
 
@@ -796,6 +797,8 @@ class tube(Timeout, Logger):
                     if cur:
                         sys.stdout.write(cur)
                         sys.stdout.flush()
+                except ssl.SSLError:
+                    pass
                 except EOFError:
                     self.info('Got EOF while reading in interactive')
                     break


### PR DESCRIPTION
Simple change, to let the user specify ssl options for ssl.wrap_socket in remote tubes. This is backwards compatible with the 'ssl=True' option.

tube.interactive can throw ssl.SSLError when the timeout happens.