### PR TITLE
Wrap commands cont. ';' in sh when $SHELL == zsh

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -202,6 +202,10 @@ def run_in_new_terminal(command, terminal = None, args = None):
         elif 'TMUX' in os.environ:
             terminal = 'tmux'
             args     = ['splitw']
+            if 'zsh' in os.environ['SHELL'] and ';' in command:
+                # zsh and tmux have issues with handling SIGINT
+                # wrapping command with sh -c works around this
+                command = 'sh -c %s' % sh_string(command)
 
     if not terminal:
         log.error('Argument `terminal` is not set, and could not determine a default')


### PR DESCRIPTION
Continues on from #635 

@Idolf said at https://github.com/Gallopsled/pwntools/pull/635#issuecomment-241232567:

> Could you reopen this PR against the dev branch? Or perhaps against the stable branch? Is it a bugfix or a feature?

It's a bugfix. `run_in_new_terminal()` interacts poorly with zsh and tmux when told to run multiple `;`-separated commands. Something (zsh?) is seeing `Ctrl-C` (e.g. when telling a process inside gdb to break) and tearing down tmux panes as soon as the tmux pane is resized.

I'm not sure if it's a zsh or tmux bug, or if it's just one of those "handling `SIGINT` is hard" things, but it annoys me a lot. Nothing like lost gdb's to wreck your day.

Do you think the fix would be to wrap the command in `sh -c` as per this PR, or would you rather see `run_in_new_terminal()` not be used to run `;`-separated commands as per https://github.com/Gallopsled/pwntools/pull/635#issuecomment-229526002

As it's a bugfix (admittedly, one that seems to annoy no one but me even though others have reproduced my findings) I've PR'd against stable. Let me know if it'd be more suitable to target dev.
