### PR TITLE
Fix function-decorator use-case for context.quiet

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -525,10 +525,21 @@ class ContextType(object):
     def quiet(self, function=None):
         """Disables all non-error logging within the enclosed scope,
         *unless* the debugging level is set to 'debug' or lower."""
-        level = 'error'
-        if context.log_level <= logging.DEBUG:
-            level = None
-        return self.local(function, log_level=level)
+        if not function:
+            level = 'error'
+            if context.log_level <= logging.DEBUG:
+                level = None
+            return self.local(function, log_level=level)
+
+        @functools.wraps(function)
+        def wrapper(*a, **kw):
+            level = 'error'
+            if context.log_level <= logging.DEBUG:
+                level = None
+            with self.local(function, log_level=level):
+                return function(*a, **kw)
+        return wrapper
+
 
     @property
     def verbose(self):


### PR DESCRIPTION
The use of `context.quiet` as a function decorator was adopted by the ADB module in order to silence excessive _"Started process..."_ log messages for each invocation of the `adb` command-line tool.

It worked as intended to silence the messages, but with a subtle bug -- that logging would be forever disabled, unless debugging was enabled before the instantiation of the decorated function.

This means that the normal use case (no noisy output) and setting `PWNLIB_DEBUG` in the environment (which sets `log_level='debug'` before the evaluation of the decorator) both work fine.

However, settings `context.log_level='debug'` at runtime did not work to re-enable the logging for the `@context.quiet`-decorated functions.

This patch fixes the issue.

Since this functionality only affects logging, only in the ADB module, and the ADB module is no longer reliant on the `adb` command-line tool, this shouldn't need a backport.
