### PR TITLE
Add docs for Xenial binutils, and attempt to auto-detect Debian packages

### DIFF
--- a/docs/source/install/binutils.rst
+++ b/docs/source/install/binutils.rst
@@ -11,7 +11,10 @@ Building `binutils` from source takes about 60 seconds on a modern 8-core machin
 
 Ubuntu
 ^^^^^^^^^^^^^^^^
-First, add our `Personal Package Archive repository <http://binutils.pwntools.com>`__.
+
+For Ubuntu 12.04 through 15.10, you must first add the pwntools `Personal Package Archive repository <http://binutils.pwntools.com>`__.
+
+Ubuntu Xenial (16.04) has official packages for most architectures, and does not require this step.
 
 .. code-block:: bash
 


### PR DESCRIPTION
An error message will be printed like this when a package is found:

```
>>> context.arch='powerpc'
>>> pwnlib.asm.print_binutils_instructions('objdump', context)
[ERROR] Could not find 'objdump' installed for ContextType(arch = 'powerpc', bits = 32, endian = 'big')
    Try installing binutils for this architecture:
    $ sudo apt-get install binutils-powerpc-linux-gnu
```

Fixes Gallopsled/pwntools#716
