### PR TITLE
Backport #695

### DIFF
--- a/pwnlib/commandline/phd.py
+++ b/pwnlib/commandline/phd.py
@@ -83,8 +83,6 @@ def main():
         else:
             infile.seek(skip, os.SEEK_CUR)
 
-    data = infile.read(count)
-
     hl = []
     if args.highlight:
         for hs in args.highlight:
@@ -92,7 +90,7 @@ def main():
                 hl.append(asint(h))
 
     try:
-        for line in hexdump_iter(data, width, highlight = hl, begin = offset + skip):
+        for line in hexdump_iter(infile, width, highlight = hl, begin = offset + skip):
             print line
     except (KeyboardInterrupt, IOError):
         pass


### PR DESCRIPTION
… a string.  This massively speeds up `phd <file> | less` for huge files. (#695)
