### PR TITLE
Add .os to Device and set it automatically

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -150,6 +150,7 @@ class AdbDevice(Device):
         self.product = product
         self.model   = model.replace('_', ' ')
         self.device  = device
+        self.os      = 'android'
 
         if product == 'unknown':
             return

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1097,6 +1097,7 @@ class ContextType(object):
             self.arch = device.arch or self.arch
             self.bits = device.bits or self.bits
             self.endian = device.endian or self.endian
+            self.os = device.os or self.os
         elif isinstance(device, str):
             device = Device(device)
         else:

--- a/pwnlib/device.py
+++ b/pwnlib/device.py
@@ -4,12 +4,13 @@ class Device(object):
     bits = None
     endian = None
     serial = None
+    os = None
 
     def __init__(self, serial=None):
         self.serial = serial
 
     def __str__(self):
         return self.serial
- 
+
     def __eq__(self, other):
         return self.serial == other or self.serial == str(other)


### PR DESCRIPTION
The use case here is setting context.os via:

``` py
>>> context.device = adb.wait_for_device()
```
