### PR TITLE
Make update mechanism more robust, add tests

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ Each of the ``pwntools`` modules is documented here.
    tubes
    tubes/*
    ui
+   update
    useragents
    util/*
 

--- a/docs/source/update.rst
+++ b/docs/source/update.rst
@@ -1,6 +1,7 @@
 .. testsetup:: *
 
    from pwn import *
+   from pwnlib.update import *
 
 :mod:`pwnlib.update` --- Updating Pwntools
 ===================================================

--- a/docs/source/update.rst
+++ b/docs/source/update.rst
@@ -1,0 +1,9 @@
+.. testsetup:: *
+
+   from pwn import *
+
+:mod:`pwnlib.update` --- Updating Pwntools
+===================================================
+
+.. automodule:: pwnlib.update
+   :members:

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -108,9 +108,9 @@ def perform_check(prerelease=current_version.is_prerelease):
 
     >>> pwnlib.update.available_on_pypi = bail
     >>> perform_check(prerelease=False)
-    ['pip', 'install', '-U', 'https://github.com/Gallopsled/pwntools.git@...']
+    ['pip', 'install', '-U', 'git+https://github.com/Gallopsled/pwntools.git@...']
     >>> perform_check(prerelease=True)  # doctest: +ELLIPSIS
-    ['pip', 'install', '-U', 'https://github.com/Gallopsled/pwntools.git@...']
+    ['pip', 'install', '-U', 'git+https://github.com/Gallopsled/pwntools.git@...']
     """
     pypi = current_version
     try:

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -91,7 +91,7 @@ def perform_check(prerelease=current_version.is_prerelease):
         A list of arguments to the update command.
 
     >>> from pkg_resources import parse_version
-    >>> current_version = parse_version("0.0.0")
+    >>> pwntools.update.current_version = parse_version("0.0.0")
     >>> perform_check() # doctest: +ELLIPSIS
     ['pip', 'install', '-U', ...]
 

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 import time
+import xmlrpclib
 
 import pip
 import pkg_resources
@@ -20,13 +21,18 @@ package_name    = 'pwntools'
 package_repo    = 'Gallopsled/pwntools'
 update_freq     = datetime.timedelta(days=7).total_seconds()
 
-def available_on_github(prerelease=False):
-    """Return True if an update is available on Github."""
+def available_on_github(prerelease=current_version.is_prerelease):
+    """Return True if an update is available on Github.
+
+    >>> available_on_github() # doctest: +ELLIPSIS
+    <Version('...')>
+    >>> available_on_github(prerelease=False).is_prerelease
+    False
+    """
     url = 'https://api.github.com/repos/%s/tags' % package_repo
 
     with context.quiet:
         tags = json.loads(wget(url))
-
 
     versions = map(pkg_resources.parse_version, [t['name'] for t in tags])
 
@@ -35,21 +41,22 @@ def available_on_github(prerelease=False):
 
     return max(versions)
 
-def available_on_pypi(prerelease=False):
-    """Return True if an update is available on PyPI."""
-    search_command = pip.commands.search.SearchCommand()
-    options, _ = search_command.parse_args([package_name])
-    pypi_hits = search_command.search(package_name, options)
-    for hit in pip.commands.search.transform_hits(pypi_hits):
-        if hit['name'] != 'pwntools':
-            continue
+def available_on_pypi(prerelease=current_version.is_prerelease):
+    """Return True if an update is available on PyPI.
 
-        versions = map(pkg_resources.parse_version, hit['versions'])
+    >>> available_on_pypi() # doctest: +ELLIPSIS
+    <Version('...')>
+    >>> available_on_pypi(prerelease=False).is_prerelease
+    False
+    """
+    client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
+    versions = client.package_releases('pwntools', True)
+    versions = map(pkg_resources.parse_version, versions)
 
-        if not prerelease:
-            versions = filter(lambda v: not v.is_prerelease, versions)
+    if not prerelease:
+        versions = filter(lambda v: not v.is_prerelease, versions)
 
-        return max(versions)
+    return max(versions)
 
 def cache_file():
     """Returns the path of the file used to cache update data, and ensures that it exists."""
@@ -74,18 +81,47 @@ def should_check():
         return False
     return time.time() > (last_check() + update_freq)
 
-def perform_check(prerelease=False):
-    """Perform the update check, and report to the user."""
+def perform_check(prerelease=current_version.is_prerelease):
+    """Perform the update check, and report to the user.
+
+    Arguments:
+        prerelease(bool): Whether or not to include pre-release versions.
+
+    Returns:
+        A list of arguments to the update command.
+
+    >>> from pkg_resources import parse_version
+    >>> current_version = parse_version("0.0.0")
+    >>> perform_check() # doctest: +ELLIPSIS
+    ['pip', 'install', '-U', ...]
+
+    >>> def bail(*a): raise Exception()
+    >>> github = pwnlib.update.available_on_github
+    >>> pypi   = pwnlib.update.available_on_pypi
+
+    >>> pwnlib.update.available_on_github = bail
+    >>> perform_check(prerelease=False)
+    ['pip', 'install', '-U', 'pwntools']
+    >>> perform_check(prerelease=True)  # doctest: +ELLIPSIS
+    ['pip', 'install', '-U', 'pwntools...']
+    >>> pwnlib.update.available_on_github = github
+
+    >>> pwnlib.update.available_on_pypi = bail
+    >>> perform_check(prerelease=False)
+    ['pip', 'install', '-U', 'https://github.com/Gallopsled/pwntools.git@...']
+    >>> perform_check(prerelease=True)  # doctest: +ELLIPSIS
+    ['pip', 'install', '-U', 'https://github.com/Gallopsled/pwntools.git@...']
+    """
     pypi = current_version
     try:
         pypi = available_on_pypi(prerelease)
-    except:
+    except Exception:
         log.warning("An issue occurred while checking PyPI")
 
     github = current_version
     try:
         github = available_on_github(prerelease)
-    except:
+    except Exception:
         log.warning("An issue occurred while checking Github")
 
     best = max(pypi, github, current_version)
@@ -98,15 +134,26 @@ def perform_check(prerelease=False):
         log.info("You have the latest version of Pwntools (%s)" % best)
         return
 
+    command = [
+        'pip',
+        'install',
+        '-U'
+    ]
+
     if best == pypi:
         where = 'pypi'
-        command = 'pip install -U %s' % package_name
+        pypi_package = package_name
+        if best.is_prerelease:
+            pypi_package += '==%s' % (best)
+        command += [pypi_package]
     else:
         where = 'GitHub'
-        command = 'pip install -U git+https://github.com/%s.git@%s' % (package_repo, github)
+        command += ['git+https://github.com/%s.git@%s' % (package_repo, github)]
+
+    command_str = ' '.join(command)
 
     log.info("A newer version of %s is available on %s (%s --> %s).\n" % (package_name, where, current_version, best) +
-             "Update with: $ %s" % command)
+             "Update with: $ %s" % command_str)
 
     return command
 

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -91,7 +91,7 @@ def perform_check(prerelease=current_version.is_prerelease):
         A list of arguments to the update command.
 
     >>> from pkg_resources import parse_version
-    >>> pwntools.update.current_version = parse_version("0.0.0")
+    >>> pwnlib.update.current_version = parse_version("0.0.0")
     >>> perform_check() # doctest: +ELLIPSIS
     ['pip', 'install', '-U', ...]
 


### PR DESCRIPTION
Fixes Gallopsled/pwntools#723
Fixes Gallopsled/pwntools#724

For pre-release version from PyPi, we specify the exact verison. Using `-U --pre` will use pre-release versions of **all** packages.  This is bad.

PyPi version information is fetched directly, rather than using the `pip search` functionality.

For versions from GitHub, we must always specify the tag name.  Otherwise, the default branch (`dev`) will be used.
