### PR TITLE
Fix bug introduced by internal changes to pyelftools v0.2.4

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -6,7 +6,6 @@ from elftools.common.py3compat import bytes2str
 from elftools.common.utils import roundup
 from elftools.common.utils import struct_parse
 from elftools.construct import CString
-
 from ..context import context
 from ..log import getLogger
 from ..tubes.tube import tube
@@ -30,11 +29,11 @@ def iter_notes(self):
     end = self['p_offset'] + self['p_filesz']
     while offset < end:
         note = struct_parse(
-            self._elfstructs.Elf_Nhdr,
+            self.elffile.structs.Elf_Nhdr,
             self.stream,
             stream_pos=offset)
         note['n_offset'] = offset
-        offset += self._elfstructs.Elf_Nhdr.sizeof()
+        offset += self.elffile.structs.Elf_Nhdr.sizeof()
         self.stream.seek(offset)
         # n_namesz is 4-byte aligned.
         disk_namesz = roundup(note['n_namesz'], 2)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ for filename in glob.glob('pwnlib/commandline/*'):
 
 install_requires     = ['paramiko>=1.15.2',
                         'mako>=1.0.0',
-                        'pyelftools>=0.2.3',
+                        'pyelftools>=0.2.4',
                         'capstone',
                         'ropgadget>=5.3',
                         'pyserial>=2.7',


### PR DESCRIPTION
PyElfTools v0.2.4 was released in early August, and changed around some internal members.

This addresses the change, and bumps the minimum version.
