### PR TITLE
shellcraft.xxx.linux.sh now passes argv0

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -176,8 +176,8 @@ loaded with useful time-saving shellcodes.
 Let's say that we want to `setreuid(getuid(), getuid())` followed by `dup`ing
 file descriptor 4 to `stdin`, `stdout`, and `stderr`, and then pop a shell!
 
-    >>> asm(shellcraft.setreuid() + shellcraft.dupsh(4)).encode('hex')
-    '6a3158cd8089c36a465889d9cd806a045b6a0359496a3f58cd8075f86a68682f2f2f73682f62696e6a0b5889e331c999cd80'
+    >>> asm(shellcraft.setreuid() + shellcraft.dupsh(4)).encode('hex') # doctest: +ELLIPSIS
+    '6a3158cd80...'
 
 
 Misc Tools

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -27,8 +27,8 @@ Assembly
     Finally, :func:`asm` is used to assemble shellcode provided by ``pwntools``
     in the :mod:`shellcraft` module.
 
-        >>> asm(shellcraft.sh())
-        'jhh///sh/binj\x0bX\x89\xe31\xc9\x99\xcd\x80'
+        >>> asm(shellcraft.nop())
+        '\x90'
 
 Disassembly
 ------------------------

--- a/pwnlib/shellcraft/templates/__doc__
+++ b/pwnlib/shellcraft/templates/__doc__
@@ -3,14 +3,3 @@ The shellcode module.
 This module contains functions for generating shellcode.
 
 It is organized first by architecture and then by operating system.
-
-Example:
-
-    >>> print shellcraft.i386.nop().strip('\n')
-        nop
-    >>> print shellcraft.i386.linux.sh()
-        /* push '/bin///sh\x00' */
-        push 0x68
-        push 0x732f2f2f
-        push 0x6e69622f
-    ...

--- a/pwnlib/shellcraft/templates/amd64/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-${amd64.linux.execve('/bin///sh', 0, 0)}
+${amd64.linux.execve('/bin///sh', ['sh'], 0)}

--- a/pwnlib/shellcraft/templates/arm/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-    ${arm.linux.execve('/bin///sh', 0, 0)}
+    ${arm.linux.execve('/bin///sh', ['sh'], 0)}

--- a/pwnlib/shellcraft/templates/i386/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-${i386.linux.execve('/bin///sh', 0, 0)}
+${i386.linux.execve('/bin///sh', ['sh'], 0)}

--- a/pwnlib/shellcraft/templates/mips/android/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/android/sh.asm
@@ -1,11 +1,4 @@
 <% from pwnlib.shellcraft import mips %>
 <%docstring>Execute /bin/sh</%docstring>
 
-${mips.push(0)}
-${mips.pushstr('sh')}
-${mips.mov('$a1','$sp')}}
-
-${mips.pushstr('/system/bin//sh')}
-
-${mips.syscall('SYS_execve', '$sp', '$a1', 0)}
-
+${mips.execve('//system/bin/sh', ['sh'], {})}

--- a/pwnlib/shellcraft/templates/mips/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sh.asm
@@ -1,7 +1,4 @@
 <% from pwnlib.shellcraft import mips %>
 <%docstring>Execute /bin/sh</%docstring>
 
-${mips.pushstr('//bin/sh')}
-
-${mips.syscall('SYS_execve', '$sp', 0, 0)}
-
+${mips.execve('//bin/sh', ['sh'], {})}

--- a/pwnlib/shellcraft/templates/thumb/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-${thumb.linux.execve('/bin///sh', 0, 0)}
+${thumb.linux.execve('/bin///sh', ['sh'], 0)}


### PR DESCRIPTION
If you need shorter shellcode, use "execve" directly.

Fixes #626
