### PR TITLE
Fix wait-for-device with kick=True re-using the same client

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -290,6 +290,7 @@ def wait_for_device(kick=False):
             if context.device:
                 serial = str(context.device)
 
+        with Client() as c:
             c.wait_for_device(serial)
 
         for device in devices():


### PR DESCRIPTION
Pwntools 3.2.0 and later may cause issues with `adb.wait_for_device()` when `kick=True` due to reuse of an `adb.protocol.Client` object which has specified a `transport`.

This issue is resolved by using a new `adb.protocol.Client`.
