### PR TITLE
Correct commandline parsing

### DIFF
--- a/pwnlib/commandline/unhex.py
+++ b/pwnlib/commandline/unhex.py
@@ -20,7 +20,7 @@ def main(args):
             s = sys.stdin.read().translate(None, whitespace)
             sys.stdout.write(s.decode('hex'))
         else:
-            sys.stdout.write(''.join(sys.argv[1:]).decode('hex'))
+            sys.stdout.write(''.join(sys.argv[2:]).decode('hex'))
     except TypeError, e:
         sys.stderr.write(str(e) + '\n')
 


### PR DESCRIPTION
## Explanation

argv[1] is 'unhex' which is causing the hex arguments to fail translation. Changed argv[1:] to argv[2:] so that only hex arguments are decoded.
# hacktoberfest
## Target Branch

| Branch | Type of PR |
| --- | --- |
| `stable` | Bug fixes that affect the current `stable` branch |
