### PR TITLE
Adding escaped hex output format to shellcraft -f option

### DIFF
--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -60,7 +60,7 @@ p.add_argument(
                'd', 'escaped',
                'default'],
     default = 'default',
-    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, escape{d} hex string',
+    help = 'Output format (default: hex), choose from {e}lf, {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, escape{d} hex string',
 )
 
 p.add_argument(

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -57,10 +57,10 @@ p.add_argument(
                'p',
                'i', 'hexii',
                'e', 'elf',
-               'a', 'escaped',
+               'd', 'escaped',
                'default'],
     default = 'default',
-    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, esc{a}ped hex string',
+    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, escape{d} hex string',
 )
 
 p.add_argument(
@@ -330,7 +330,7 @@ def main(args):
         code = pwnlib.util.fiddling.enhex(code) + '\n'
     elif args.format in ['i', 'hexii']:
         code = hexii(code) + '\n'
-    elif args.format in ['a', 'escaped']:
+    elif args.format in ['d', 'escaped']:
         code = ''.join('\\x%02x' % ord(c) for c in code) + '\n'
     if not sys.stdin.isatty():
         args.out.write(sys.stdin.read())

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -331,9 +331,7 @@ def main(args):
     elif args.format in ['i', 'hexii']:
         code = hexii(code) + '\n'
     elif args.format in ['y', 'python']:
-        code = pwnlib.util.fiddling.enhex(code)
-        code = '\\x' + '\\x'.join(map(''.join, zip(code[::2], code[1::2]))) + '\n'
-
+        code = ''.join('\\x%02x' % ord(c) for c in code) + '\n'
     if not sys.stdin.isatty():
         args.out.write(sys.stdin.read())
 

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -57,9 +57,10 @@ p.add_argument(
                'p',
                'i', 'hexii',
                'e', 'elf',
+               'y', 'python',
                'default'],
     default = 'default',
-    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code',
+    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, p{y}thon-style array.',
 )
 
 p.add_argument(
@@ -329,6 +330,9 @@ def main(args):
         code = pwnlib.util.fiddling.enhex(code) + '\n'
     elif args.format in ['i', 'hexii']:
         code = hexii(code) + '\n'
+    elif args.format in ['y', 'python']:
+        code = pwnlib.util.fiddling.enhex(code)
+        code = '\\x' + '\\x'.join(map(''.join, zip(code[::2], code[1::2]))) + '\n'
 
     if not sys.stdin.isatty():
         args.out.write(sys.stdin.read())

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -57,10 +57,10 @@ p.add_argument(
                'p',
                'i', 'hexii',
                'e', 'elf',
-               'y', 'python',
+               'a', 'escaped',
                'default'],
     default = 'default',
-    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, p{y}thon-style array.',
+    help = 'Output format (default: hex), choose from {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, esc{a}ped hex string',
 )
 
 p.add_argument(
@@ -330,7 +330,7 @@ def main(args):
         code = pwnlib.util.fiddling.enhex(code) + '\n'
     elif args.format in ['i', 'hexii']:
         code = hexii(code) + '\n'
-    elif args.format in ['y', 'python']:
+    elif args.format in ['a', 'escaped']:
         code = ''.join('\\x%02x' % ord(c) for c in code) + '\n'
     if not sys.stdin.isatty():
         args.out.write(sys.stdin.read())


### PR DESCRIPTION
While using shellcraft as a stand-alone utility to generate shellcode for PoC's, I found the python hex notation very useful.

Maybe someone else can use it too?
