### PR TITLE
Make coding style comply  with PEP8 (excluding E501)

### DIFF
--- a/pwnlib/shellcraft/__init__.py
+++ b/pwnlib/shellcraft/__init__.py
@@ -2,7 +2,6 @@ import os
 import re
 import sys
 from types import ModuleType
-
 from . import internal
 from .. import constants
 from ..context import context
@@ -109,7 +108,7 @@ class module(ModuleType):
         return result
 
     template_dir = os.path.join(os.path.dirname(__file__), 'templates')
-    templates    = []
+    templates = []
 
     for root, subfolder, files in os.walk(template_dir):
         for file in filter(lambda x: x.endswith('.asm'), files):
@@ -123,7 +122,7 @@ class module(ModuleType):
     templates = sorted(templates)
 
     def eval(self, item):
-        if isinstance(item, (int,long)):
+        if isinstance(item, (int, long)):
             return item
         return constants.eval(item)
 
@@ -133,8 +132,10 @@ class module(ModuleType):
         if not isinstance(n, int):
             return n
         if isinstance(n, constants.Constant):
-            if comment: return '%s /* %s */' % (n,self.pretty(int(n)))
-            else:       return '%s (%s)'     % (n,self.pretty(int(n)))
+            if comment:
+                return '%s /* %s */' % (n, self.pretty(int(n)))
+            else:
+                return '%s (%s)' % (n, self.pretty(int(n)))
         elif abs(n) < 10:
             return str(n)
         else:
@@ -152,6 +153,7 @@ tether = sys.modules[__name__]
 
 # Create the module structure
 shellcraft = module(__name__, '')
+
 
 class LazyImporter:
     def find_module(self, fullname, path):

--- a/pwnlib/shellcraft/internal.py
+++ b/pwnlib/shellcraft/internal.py
@@ -5,6 +5,8 @@ __all__ = ['make_function']
 
 loaded = {}
 lookup = None
+
+
 def init_mako():
     global lookup, render_global
     from mako.lookup import TemplateLookup
@@ -12,16 +14,18 @@ def init_mako():
     from mako import ast
     import threading
 
-    if lookup != None:
+    if lookup is not None:
         return
 
     class IsInsideManager:
         def __init__(self, parent):
             self.parent = parent
+
         def __enter__(self):
             self.oldval = self.parent.is_inside
             self.parent.is_inside = True
             return self.oldval
+
         def __exit__(self, *args):
             self.parent.is_inside = self.oldval
 
@@ -35,8 +39,8 @@ def init_mako():
 
     curdir = os.path.dirname(os.path.abspath(__file__))
     lookup = TemplateLookup(
-        directories      = [os.path.join(curdir, 'templates')],
-        module_directory = os.path.expanduser('~/.pwntools-cache/mako')
+        directories=[os.path.join(curdir, 'templates')],
+        module_directory=os.path.expanduser('~/.pwntools-cache/mako')
     )
 
     # The purpose of this definition is to create a new Tag.
@@ -67,6 +71,7 @@ def init_mako():
             method = getattr(visitor, "visitCode", lambda x: x)
             method(self)
 
+
 def lookup_template(filename):
     init_mako()
 
@@ -74,6 +79,7 @@ def lookup_template(filename):
         loaded[filename] = lookup.get_template(filename)
 
     return loaded[filename]
+
 
 def get_context_from_dirpath(directory):
     """
@@ -84,23 +90,26 @@ def get_context_from_dirpath(directory):
     >>> get_context_from_dirpath('amd64/linux') == {'arch': 'amd64', 'os': 'linux'}
     True
     """
-    A,O = os.path.split(directory)
+    A, O = os.path.split(directory)
 
     if O == 'common':
         O = None
 
     if not A:
-        A,O = O,None
+        A, O = O, None
 
     rv = {}
-    if O: rv['os']=O
-    if A: rv['arch']=A
+    if O:
+        rv['os'] = O
+    if A:
+        rv['arch'] = A
     return rv
+
 
 def make_function(funcname, filename, directory):
     import inspect
-    path       = os.path.join(directory, filename)
-    template   = lookup_template(path)
+    path = os.path.join(directory, filename)
+    template = lookup_template(path)
 
     args, varargs, keywords, defaults = inspect.getargspec(template.module.render_body)
 
@@ -123,7 +132,7 @@ def make_function(funcname, filename, directory):
         args_used.append('**' + keywords)
 
     docstring = inspect.cleandoc(template.module.__doc__ or '')
-    args      = ', '.join(args)
+    args = ', '.join(args)
     args_used = ', '.join(args_used)
     local_ctx = get_context_from_dirpath(directory)
 
@@ -166,18 +175,21 @@ def wrap(template, render_global):
     # Setting _relpath is a slight hack only used to get better documentation
     res = wrap(template, render_global)
     res._relpath = path
-    res.__module__ = 'pwnlib.shellcraft.' + os.path.dirname(path).replace('/','.')
+    res.__module__ = 'pwnlib.shellcraft.' + os.path.dirname(path).replace('/', '.')
 
-    import sys, inspect, functools
+    import sys
+    import inspect
+    import functools
 
     @functools.wraps(res)
     def function(*a):
         return sys.modules[res.__module__].function(res.__name__, res, *a)
+
     @functools.wraps(res)
     def call(*a):
         return sys.modules[res.__module__].call(res.__name__, *a)
 
     res.function = function
-    res.call     = call
+    res.call = call
 
     return res

--- a/pwnlib/shellcraft/registers.py
+++ b/pwnlib/shellcraft/registers.py
@@ -4,16 +4,16 @@ from ..context import context
 from ..util.misc import register_sizes
 
 mips = {
-    '$0' :  0, '$zero': 0,
-    '$1' :  1, '$at':  1,
-    '$2' :  2, '$v0':  2,
-    '$3' :  3, '$v1':  3,
-    '$4' :  4, '$a0':  4,
-    '$5' :  5, '$a1':  5,
-    '$6' :  6, '$a2':  6,
-    '$7' :  7, '$a3':  7,
-    '$8' :  8, '$t0':  8,
-    '$9' :  9, '$t1':  9,
+    '$0': 0, '$zero': 0,
+    '$1': 1, '$at': 1,
+    '$2': 2, '$v0': 2,
+    '$3': 3, '$v1': 3,
+    '$4': 4, '$a0': 4,
+    '$5': 5, '$a1': 5,
+    '$6': 6, '$a2': 6,
+    '$7': 7, '$a3': 7,
+    '$8': 8, '$t0': 8,
+    '$9': 9, '$t1': 9,
     '$10': 10, '$t2': 10,
     '$11': 11, '$t3': 11,
     '$12': 12, '$t4': 12,
@@ -46,29 +46,27 @@ thumb = arm
 aarch64 = map('x{}'.format, range(32))
 aarch64 += ["sp", "lr", "pc", "cpsr"]
 
-i386_baseregs = [ "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "ip"]
+i386_baseregs = ["ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "ip"]
 
 i386 = map('e{}'.format, i386_baseregs)
 i386 += i386_baseregs
-i386 += [ "eflags", "cs", "ss", "ds", "es", "fs", "gs", ]
+i386 += ["eflags", "cs", "ss", "ds", "es", "fs", "gs", ]
 
-amd64 =  map('r{}'.format, i386_baseregs)
-amd64 += map('r{}'.format, range(8,16))
-amd64 += map('r{}d'.format, range(8,16))
+amd64 = map('r{}'.format, i386_baseregs)
+amd64 += map('r{}'.format, range(8, 16))
+amd64 += map('r{}d'.format, range(8, 16))
 amd64 += i386
 
-powerpc =  map('r{}'.format, range(32))
-powerpc += ["pc", "msr", "cr", "lr", "ctr", "xer", "orig_r3", "trap" ]
-powerpc =  map('%{}'.format, powerpc)
+powerpc = map('r{}'.format, range(32))
+powerpc += ["pc", "msr", "cr", "lr", "ctr", "xer", "orig_r3", "trap"]
+powerpc = map('%{}'.format, powerpc)
 
-sparc =  map('g{}'.format, range(8))
+sparc = map('g{}'.format, range(8))
 sparc += map('o{}'.format, range(5))
 sparc += map('l{}'.format, range(8))
 sparc += map('i{}'.format, range(5))
-sparc += ["pc", "sp", "fp", "psr" ]
-sparc =  map('%{}'.format, sparc)
-
-
+sparc += ["pc", "sp", "fp", "psr"]
+sparc = map('%{}'.format, sparc)
 
 # x86/amd64 registers in decreasing size
 i386_ordered = [
@@ -91,8 +89,9 @@ i386_ordered = [
 ]
 
 all_regs, sizes, bigger, smaller = register_sizes(i386_ordered, [64, 32, 16, 8, 8])
-native64 = {k:v[0] for k,v in bigger.items()}
-native32 = {k:v[1] for k,v in bigger.items() if not k.startswith('r')}
+native64 = {k: v[0] for k, v in bigger.items()}
+native32 = {k: v[1] for k, v in bigger.items() if not k.startswith('r')}
+
 
 class Register(object):
     #: Register name
@@ -136,9 +135,9 @@ class Register(object):
 
         for row in i386_ordered:
             if name in row:
-                self.bigger  = row[0:row.index(name)]
+                self.bigger = row[0:row.index(name)]
                 self.smaller = row[row.index(name)+1:]
-                self.sizes   = {64>>i:r for i,r in enumerate(row)}
+                self.sizes = {64 >> i: r for i, r in enumerate(row)}
                 self.native64 = row[0]
                 self.native32 = row[1]
                 self.xor = self.sizes[min(self.size, 32)]
@@ -178,12 +177,14 @@ for row in i386_ordered:
     for i, reg in enumerate(row):
         intel[reg] = Register(reg, 64 >> i)
 
+
 def get_register(name):
     if isinstance(name, Register):
         return name
     if isinstance(name, str):
         return intel.get(name, None)
     return None
+
 
 def is_register(obj):
     if isinstance(obj, Register):
@@ -192,7 +193,7 @@ def is_register(obj):
 
 
 def bits_required(value):
-    bits  = 0
+    bits = 0
 
     if value < 0:
         value = -(value)
@@ -220,8 +221,10 @@ def bits_required(value):
 #     except:
 #         return False
 
+
 def register_size(reg):
     return sizes[reg]
+
 
 def fits_in_register(reg, value):
     return register_size(reg) >= bits_required(value)


### PR DESCRIPTION
Initial commit to make pwntools comply with the PEP8 code style guide.

https://www.python.org/dev/peps/pep-0008/

After speaking with @Idolf about this, we decided to try and see how PEP8 would fit the pwntools project. We might need to bend a few rules (like E501, 'long lines').

Look at the diff, suggestions are welcome...
