### PR TITLE
Automatic update checking should not log to stdout.

### DIFF
--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -13,4 +13,5 @@ if not platform.architecture()[0].startswith('64'):
     See Gallopsled/pwntools#518 for more information."""
     log.warn_once('Pwntools does not support 32-bit Python.  Use a 64-bit release.')
 
-pwnlib.update.check_automatically()
+with context.local(log_console=sys.stderr):
+    pwnlib.update.check_automatically()


### PR DESCRIPTION
This breaks piping into files for all of the command-line utilities.
