### PR TITLE
Add an error to cyclic() if the requested length is too long

### DIFF
--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -66,6 +66,10 @@ def cyclic(length = None, alphabet = string.ascii_lowercase, n = None):
     if n is None:
         n = 4
 
+    if len(alphabet) ** n < length:
+        log.error("Can't create a pattern length=%i with len(alphabet)==%i and n==%i" \
+                  % (length, len(alphabet), n))
+
     out = []
     for ndx, c in enumerate(de_bruijn(alphabet, n)):
         if length != None and ndx >= length:


### PR DESCRIPTION
$ cyclic 999999999
[ERROR] Can't create a pattern length=999999999 with len(alphabet)==26 and n==4

Fixes Gallopsled/pwntools#781
