### PR TITLE
Wrap context.log_console when using terminal I/O

### DIFF
--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -21,6 +21,7 @@ import termios
 import threading
 import traceback
 
+from ..context import ContextType
 from . import termcap
 
 settings = None
@@ -127,6 +128,11 @@ def init():
         sys.stdout = Wrapper(sys.stdout)
     if sys.stderr.isatty():
         sys.stderr = Wrapper(sys.stderr)
+
+    console = ContextType.defaults['log_console']
+    if console.isatty():
+        ContextType.defaults['log_console'] = Wrapper(console)
+
     # freeze all cells if an exception is thrown
     orig_hook = sys.excepthook
     def hook(*args):


### PR DESCRIPTION
Only affects the `dev` branch.

Fixes Gallopsled/pwntools#792