### PR TITLE
Change process() stdin to be a raw PTY by default

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -203,7 +203,7 @@ class process(tube):
                  cwd = None,
                  env = None,
                  timeout = Timeout.default,
-                 stdin  = PIPE,
+                 stdin  = PTY,
                  stdout = PTY,
                  stderr = STDOUT,
                  level = None,


### PR DESCRIPTION
I vaguely remember this breaking things, but my memory is not good enough to be sure of that.

Let's turn this on in `dev` and see if it breaks anything.