### PR TITLE
Allowing tubes buffer size to be variable defaulted

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -138,8 +138,9 @@ class process(tube):
                  stdout = PTY,
                  stderr = STDOUT,
                  close_fds = True,
-                 preexec_fn = lambda: None):
-        super(process, self).__init__(timeout)
+                 preexec_fn = lambda: None,
+                 bufSize = 4096):
+        super(process, self).__init__(timeout,bufSize = bufSize)
 
         if not shell:
             executable, argv, env = self._validate(cwd, executable, argv, env)

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -45,8 +45,8 @@ class remote(sock):
 
     def __init__(self, host, port,
                  fam = "any", typ = "tcp",
-                 timeout = Timeout.default, ssl=False, sock=None):
-        super(remote, self).__init__(timeout)
+                 timeout = Timeout.default, ssl=False, sock=None, bufSize = 4096):
+        super(remote, self).__init__(timeout, bufSize = bufSize)
 
         self.rport  = int(port)
         self.rhost  = host

--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -10,8 +10,8 @@ log = getLogger(__name__)
 class sock(tube):
     """Methods available exclusively to sockets."""
 
-    def __init__(self, timeout):
-        super(sock, self).__init__(timeout)
+    def __init__(self, timeout, bufSize = 4096):
+        super(sock, self).__init__(timeout, bufSize = bufSize)
         self.closed = {"recv": False, "send": False}
 
     # Overwritten for better usability


### PR DESCRIPTION
In working with large return values on pwntools, i noticed there's no good way to get them to return properly. For instance, I was attempting to do a "recvuntil" on data that was larger than 4096. Even going in and changing the default values to higher didn't have the intended change since the fillbuffer method had statically mapped in 4096.

The proposed changes simply allow a variable when creating process/remote objects that allow the user to define the buffer size. 4096 is fine for most, so I have left that as the default. However, it is now possible to define your own size with "bufSize=9999" or whatever. In my example problematic situation, this change solved the problem.