### PR TITLE
Fix exception thrown under 32-bit Python interpreters.

### DIFF
--- a/pwnlib/elf/datatypes.py
+++ b/pwnlib/elf/datatypes.py
@@ -539,7 +539,8 @@ class elf_prstatus_i386(ctypes.Structure):
 assert ctypes.sizeof(elf_prstatus_i386) == 0x90
 
 class elf_prstatus_amd64(ctypes.Structure):
-    _fields_ = generate_prstatus_common(64, user_regs_struct_amd64)
+    _fields_ = generate_prstatus_common(64, user_regs_struct_amd64) \
+             + [('padding', ctypes.c_uint32)]
 
 assert ctypes.sizeof(elf_prstatus_amd64) == 0x150
 


### PR DESCRIPTION
Fixes Gallopsled/pwntools#518