### PR TITLE
Multiple ADB performance and functionality fixes

### DIFF
--- a/pwnlib/adb/protocol.py
+++ b/pwnlib/adb/protocol.py
@@ -43,13 +43,11 @@ class Message(object):
 class Connection(remote):
     """Connection to the ADB server"""
     def __init__(self, host, port, level=None, *a, **kw):
-
         # Try to make sure ADB is running if it's on the default host and port.
         if host == context.defaults['adb_host'] \
         and port == context.defaults['adb_port']:
-            with context.local():
-                context.clear()
-                process(context.adb + ['start-server'], level='error').wait_for_close()
+            with context.quiet:
+                process(context.adb + ['start-server']).recvall()
 
         with context.quiet:
             super(Connection, self).__init__(host, port, level=level, *a, **kw)

--- a/pwnlib/adb/protocol.py
+++ b/pwnlib/adb/protocol.py
@@ -46,7 +46,9 @@ class Connection(remote):
         # Try to make sure ADB is running if it's on the default host and port.
         if host == context.defaults['adb_host'] \
         and port == context.defaults['adb_port']:
-            process(context.adb + ['start-server'], level='error').wait_for_close()
+            with context.local():
+                context.clear()
+                process(context.adb + ['start-server'], level='error').wait_for_close()
 
         with context.quiet:
             super(Connection, self).__init__(host, port, level=level, *a, **kw)

--- a/pwnlib/adb/protocol.py
+++ b/pwnlib/adb/protocol.py
@@ -329,7 +329,9 @@ class Client(Logger):
             >>> pprint(adb.Client().list('/data/user'))
             {'0': {'mode': 41471, 'size': 11, 'time': ...}}
             >>> adb.Client().list('/does/not/exist')
-            {}
+            Traceback (most recent call last):
+            ...
+            PwnlibException: Cannot list directory '/does/not/exist': Does not exist
         """
         st = self.stat(path)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1107,8 +1107,13 @@ class ContextType(object):
 
     @property
     def adb(self):
-        """Returns an argument array for connecting to adb."""
-        command = ['adb']
+        """Returns an argument array for connecting to adb.
+
+        Unless ``$ADB_PATH`` is set, uses the default ``adb`` binary in ``$PATH``.
+        """
+        ADB_PATH = os.environ.get('ADB_PATH', 'adb')
+
+        command = [ADB_PATH]
 
         if self.adb_host != self.defaults['adb_host']:
             command += ['-H', self.adb_host]

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -3,6 +3,7 @@ import errno
 import fcntl
 import logging
 import os
+import platform
 import pty
 import resource
 import select
@@ -190,6 +191,9 @@ class process(tube):
         >>> io = process(['sh','-c','sleep 10; exit 7'], alarm=2)
         >>> io.poll(block=True) == -signal.SIGALRM
         True
+
+        >>> binary = ELF.from_assembly('nop', arch='mips')
+        >>> p = process(binary.path)
     """
 
     PTY = PTY
@@ -276,7 +280,7 @@ class process(tube):
         with self.progress(message) as p:
 
             if not self.aslr:
-                log.warn_once("ASLR is disabled!")
+                self.warn_once("ASLR is disabled!")
 
             # In the event the binary is a foreign architecture,
             # and binfmt is not installed (e.g. when running on
@@ -285,12 +289,6 @@ class process(tube):
             prefixes = [([], executable)]
             executables = [executable]
             exception = None
-
-            try:
-                if not context.native:
-                    qemu = get_qemu_user()
-                    prefixes.append(([qemu], qemu))
-            except: pass
 
             for prefix, executable in prefixes:
                 try:
@@ -308,11 +306,7 @@ class process(tube):
                 except OSError as exception:
                     if exception.errno != errno.ENOEXEC:
                         raise
-            else:
-                try:
-                    raise exception
-                except:
-                    log.exception(str(prefixes))
+                    prefixes.append(self.__on_enoexec(exception))
 
         if self.pty is not None:
             if stdin is slave:
@@ -349,7 +343,7 @@ class process(tube):
 
                 resource.setrlimit(resource.RLIMIT_STACK, (-1, -1))
             except:
-                log.exception("Could not disable ASLR")
+                self.exception("Could not disable ASLR")
 
         # Assume that the user would prefer to have core dumps.
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
@@ -373,13 +367,43 @@ class process(tube):
 
         self.preexec_fn()
 
+    def __on_enoexec(self, exception):
+        """We received an 'exec format' error (ENOEXEC)
+
+        This implies that the user tried to execute e.g.
+        an ARM binary on a non-ARM system, and does not have
+        binfmt helpers installed for QEMU.
+        """
+        # Get the ELF binary for the target executable
+        with context.quiet:
+            # XXX: Cyclic imports :(
+            from ..elf import ELF
+            binary = ELF(self.executable)
+
+        # If we're on macOS, this will never work.  Bail now.
+        # if platform.mac_ver()[0]:
+            # self.error("Cannot run ELF binaries on macOS")
+
+        # Determine what architecture the binary is, and find the
+        # appropriate qemu binary to run it.
+        qemu = get_qemu_user(arch=binary.arch)
+        if qemu:
+            args = [qemu]
+            if self.argv:
+                args += ['-0', self.argv[0]]
+            args += ['--']
+            return [args, qemu]
+
+        # If we get here, we couldn't run the binary directly, and
+        # we don't have a qemu which can run it.
+        self.exception(exception)
+
     @property
     def program(self):
         """Alias for ``executable``, for backward compatibility"""
         return self.executable
 
-    @staticmethod
-    def _validate(cwd, executable, argv, env):
+    def _validate(self, cwd, executable, argv, env):
         """
         Perform extended validation on the executable path, argv, and envp.
 
@@ -398,14 +422,14 @@ class process(tube):
             argv = [argv]
 
         if not all(isinstance(arg, (str, unicode)) for arg in argv):
-            log.error("argv must be strings: %r" % argv)
+            self.error("argv must be strings: %r" % argv)
 
         # Create a duplicate so we can modify it
         argv = list(argv or [])
 
         for i, arg in enumerate(argv):
             if '\x00' in arg[:-1]:
-                log.error('Inappropriate nulls in argv[%i]: %r' % (i, arg))
+                self.error('Inappropriate nulls in argv[%i]: %r' % (i, arg))
 
             argv[i] = arg.rstrip('\x00')
 
@@ -417,7 +441,7 @@ class process(tube):
         #
         if not executable:
             if not argv:
-                log.error("Must specify argv or executable")
+                self.error("Must specify argv or executable")
             executable = argv[0]
 
         # Do not change absolute paths to binaries
@@ -437,11 +461,11 @@ class process(tube):
             executable = os.path.join(cwd, executable)
 
         if not os.path.exists(executable):
-            log.error("%r does not exist"  % executable)
+            self.error("%r does not exist"  % executable)
         if not os.path.isfile(executable):
-            log.error("%r is not a file" % executable)
+            self.error("%r is not a file" % executable)
         if not os.access(executable, os.X_OK):
-            log.error("%r is not marked as executable (+x)" % executable)
+            self.error("%r is not marked as executable (+x)" % executable)
 
         #
         # Validate environment
@@ -455,13 +479,13 @@ class process(tube):
 
         for k,v in env.items():
             if not isinstance(k, (str, unicode)):
-                log.error('Environment keys must be strings: %r' % k)
+                self.error('Environment keys must be strings: %r' % k)
             if not isinstance(k, (str, unicode)):
-                log.error('Environment values must be strings: %r=%r' % (k,v))
+                self.error('Environment values must be strings: %r=%r' % (k,v))
             if '\x00' in k[:-1]:
-                log.error('Inappropriate nulls in env key: %r' % (k))
+                self.error('Inappropriate nulls in env key: %r' % (k))
             if '\x00' in v[:-1]:
-                log.error('Inappropriate nulls in env value: %r=%r' % (k, v))
+                self.error('Inappropriate nulls in env value: %r=%r' % (k, v))
 
             env[k.rstrip('\x00')] = v.rstrip('\x00')
 
@@ -771,7 +795,7 @@ class process(tube):
         """
         # If it's running under qemu-user, don't leak anything.
         if 'qemu-' in os.path.realpath('/proc/%i/exe' % self.pid):
-            log.error("Cannot use leaker on binaries under QEMU.")
+            self.error("Cannot use leaker on binaries under QEMU.")
 
         with open('/proc/%i/mem' % self.pid, 'rb') as mem:
             mem.seek(address)


### PR DESCRIPTION
Currently, `adb.wait_for_device` performs incorrectly when:

- Multiple devices are available
- `context.device` or `$ANDROID_SERIAL` are set

The intended result is that the chosen `Device` object is returned via `adb.wait_for_device()`.  However, the first device is always returned.

Separately, the constructor for `AdbDevice` objects is slow due to fetching properties for the device.  Since `adb.devices()` creates an `AdbDevice` object for each device, and `adb.wait_for_device()` uses `adb.devices()`, this makes the process of waiting much slower than it needs to be -- we effectively run `shell getprop` for each device.

```
$ git checkout dev
$ export ANDROID_SERIAL=00a1d5381d8e1c4f
$ time python -c 'from pwn import *; print adb.wait_for_device()'
[+] Waiting for device to come online: HT6640200015 (marlin NDE63V 2016-Oct-23)
HT6640200015 #<-- wrong serial
python -c 'from pwn import *; print adb.wait_for_device()'  0.26s user 0.19s system 8% cpu 5.118 total #<-- five seconds
```

```
$ git checkout adb-3.2-fixes
Switched to branch 'adb-3.2-fixes'
Your branch is up-to-date with 'origin/adb-3.2-fixes'.
$ export ANDROID_SERIAL=00a1d5381d8e1c4f
$ time python -c 'from pwn import *; print adb.wait_for_device()'
[+] Waiting for device to come online: Done
00a1d5381d8e1c4f #<-- correct serial
python -c 'from pwn import *; print adb.wait_for_device()'  0.17s user 0.10s system 32% cpu 0.841 total #<-- 0.8 seconds
```

Compare with the native functionality, and baseline.

```
$ time python -c 'from pwn import *'
python -c 'from pwn import *'  0.14s user 0.08s system 96% cpu 0.234 total
$ time adb devices -l >/dev/null
adb devices -l > /dev/null  0.00s user 0.00s system 2% cpu 0.230 total
```

Separately, the following may cause a `qemu` warning to be emitted:

```
>>> context.device = adb.wait_for_device()
[x] Waiting for device to come online
[+] Waiting for device to come online: Done
>>> context.device = adb.wait_for_device()
[x] Waiting for device to come online
[!] Neither 'qemu-aarch64' nor 'qemu-aarch64-static' are available
[+] Waiting for device to come online: Done
```

This is because `context.arch` has been set, and we're attempting to locate the correct `qemu-xxx` to run the binary.  However, no foreign-architecture binaries are actually being executed *locally*.

We resolve this by attempting to execute the binary first, and catching `ENOEXEC`, and then checking the type of the target binary.