### PR TITLE
Handle None in MemLeak

### DIFF
--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -129,6 +129,8 @@ class MemLeak(object):
         size   = obj.size
         offset = obj.offset
         data   = self.n(address + offset, size)
+        if not data:
+            return None
         return unpack(data, size*8)
 
     def field_compare(self, address, obj, expected):


### PR DESCRIPTION
This fixes Gallopsled/pwntools#808, and is identical except that it is targeted against `stable`.