### PR TITLE
Make sock.connected much more robust by using socket.poll

### DIFF
--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -26,13 +26,13 @@ class sock(tube):
         else:
             return super(sock, self).recvall(timeout)
 
-    def recv_raw(self, numb, flags=0):
+    def recv_raw(self, numb, *a):
         if self.closed["recv"]:
             raise EOFError
 
         while True:
             try:
-                data = self.sock.recv(numb, flags)
+                data = self.sock.recv(numb, *a)
                 break
             except socket.timeout:
                 return None

--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -26,13 +26,13 @@ class sock(tube):
         else:
             return super(sock, self).recvall(timeout)
 
-    def recv_raw(self, numb):
+    def recv_raw(self, numb, flags=0):
         if self.closed["recv"]:
             raise EOFError
 
         while True:
             try:
-                data = self.sock.recv(numb)
+                data = self.sock.recv(numb, flags)
                 break
             except socket.timeout:
                 return None
@@ -72,21 +72,88 @@ class sock(tube):
             self.sock.settimeout(timeout)
 
     def can_recv_raw(self, timeout):
+        """
+        Tests:
+
+            >>> l = listen()
+            >>> r = remote('localhost', l.lport)
+            >>> r.can_recv_raw(timeout=0)
+            False
+            >>> l.send('a')
+            >>> r.can_recv_raw(timeout=1)
+            True
+            >>> r.recv()
+            'a'
+            >>> r.can_recv_raw(timeout=0)
+            False
+            >>> l.close()
+            >>> r.can_recv_raw(timeout=1)
+            False
+            >>> r.closed['recv']
+            True
+        """
         if not self.sock or self.closed["recv"]:
             return False
 
-        return select.select([self.sock], [], [], timeout) == ([self.sock], [], [])
+        # select() will tell us data is available at EOF
+        can_recv = select.select([self.sock], [], [], timeout) == ([self.sock], [], [])
+
+        if not can_recv:
+            return False
+
+        # Ensure there's actually data, not just EOF
+        try:
+            self.recv_raw(1, socket.MSG_PEEK)
+        except EOFError:
+            return False
+
+        return True
 
     def connected_raw(self, direction):
+        """
+        Tests:
+
+            >>> l = listen()
+            >>> r = remote('localhost', l.lport)
+            >>> r.connected()
+            True
+            >>> l.close()
+            >>> time.sleep(1) # Avoid race condition
+            >>> r.connected()
+            False
+        """
+        # If there's no socket, it's definitely closed
         if not self.sock:
             return False
 
-        if direction == 'any':
-            return True
-        elif direction == 'recv':
-            return not self.closed['recv']
-        elif direction == 'send':
-            return not self.closed['send']
+        # If we have noticed a connection close in a given direction before,
+        # return fast.
+        if self.closed.get(direction, False):
+            return False
+
+        # If a connection is closed in all manners, return fast
+        if all(self.closed.values()):
+            return False
+
+        # Use poll() to determine the connection state
+        want = {
+            'recv': select.POLLIN,
+            'send': select.POLLOUT,
+            'any':  select.POLLIN | select.POLLOUT,
+        }[direction]
+
+        poll = select.poll()
+        poll.register(self, want | select.POLLHUP | select.POLLERR)
+
+        for fd, event in poll.poll(0):
+            if event & select.POLLHUP:
+                return False
+            if event & select.POLLIN:
+                return True
+            if event & select.POLLOUT:
+                return True
+
+        return True
 
     def close(self):
         if not getattr(self, 'sock', None):


### PR DESCRIPTION
The current code for `sock.can_recv_raw` and `sock.connected_raw` are a bit lacking, and only show what we know about the socket.

Specifically,

- `can_recv_raw()` will return `True` if the socket has closed
    - An attempt to `recv` will immediately throw `EOFError`
    - This is undesirable and incorrect, per the documentation on `tube.can_recv`
- `connected()` only knows about the internal state
    - If the remote side disconnects, and `while sock.connected(): time.sleep(1)` will never return
    - This is undesirable and incorrect, since we can't detect disconnections

This adds a bit of code using `socket.poll` for `connected_raw()`, and `recv(..., MSG_PEEK)` for `can_recv_raw()`.