### PR TITLE
fixed RuntimeError in setup.py caused by pandoc on non-amd64 arches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import glob
 import os
 import platform
 import sys
+import traceback
 from distutils.command.install import INSTALL_SCHEMES
 from distutils.sysconfig import get_python_inc
 from distutils.util import convert_path
@@ -78,6 +79,9 @@ try:
     long_description = pypandoc.convert_file('README.md', 'rst')
 except ImportError:
     pass
+except Exception as e:
+    print >>sys.stderr, "Failed to convert README.md through pandoc, proceeding anyway"
+    traceback.print_exc()
 
 
 setup(


### PR DESCRIPTION
If pandoc is not installed locally, pwntools' setup.py tells pypandoc to download one.

Unfortunately, it fails on non-amd64 arches because
pypandocs provides precompiled binaries only for amd64.

Since pypandoc is not hard dependency for pwntools,
this error can be skipped without major harm.

In fact, pwntools' setup.py already handles ImportError
gracefully. The problem is, arch mismatch causes
a completely different exception.