### PR TITLE
Add PR_SET_PTRACER to process and ssh.process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - mksh
     - zsh
     - pandoc
+    - gdb
 cache:
     - pip
     - directories:

--- a/docs/source/gdb.rst
+++ b/docs/source/gdb.rst
@@ -1,3 +1,7 @@
+.. testsetup:: *
+
+    from pwn import *
+
 :mod:`pwnlib.gdb` --- Working with GDB
 ======================================
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -708,7 +708,7 @@ class ELF(ELFFile):
         return curr_bss + offset
 
     def __repr__(self):
-        return "ELF(%r)" % self.path
+        return "%s(%r)" % (self.__class__.__name__, self.path)
 
     def dynamic_by_tag(self, tag):
         dt      = None

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -625,7 +625,7 @@ def corefile(process):
     # we cannot* use gcore to generate core-files, as it will not
     # contain all memory -- unless we want to add version detection.
     # Easier to just work around it for all versions.
-    gdb_args = ['--batch',
+    gdb_args = ['-batch',
                 '-q',
                 '--nx',
                 '--nh',
@@ -635,8 +635,6 @@ def corefile(process):
 
     with context.local(terminal = ['sh', '-c']):
         pid = attach(process, gdb_args=gdb_args)
-
-        while pid in proc.all_pids():
-            time.sleep(0.1)
+        os.waitpid(pid, 0)
 
     return elf.corefile.Core(temp.name)

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -635,7 +635,7 @@ def corefile(process):
 
     # Due to https://sourceware.org/bugzilla/show_bug.cgi?id=16092
     # will disregard coredump_filter, and will not dump private mappings.
-    if version() < (7,111):
+    if version() < (7,11):
         log.warn_once('The installed GDB (%s) does not emit core-dumps which '
                       'contain all of the data in the process.\n'
                       'Upgrade to GDB >= 7.11 for better core-dumps.' % binary())

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -5,6 +5,7 @@ import random
 import re
 import shlex
 import tempfile
+import time
 
 from pwnlib import adb
 from pwnlib import atexit

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -648,8 +648,7 @@ def version(program='gdb'):
 
     Example:
 
-        >>> version = version()
-        >>> (7,0) <= version <= (8,0)
+        >>> (7,0) <= gdb.version() <= (8,0)
         True
     """
     program = misc.which(program)

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -304,9 +304,12 @@ def attach(target, execute = None, exe = None, need_ptrace_scope = True):
             pre += 'set gnutarget ' + _bfdname() + '\n'
     else:
         # If ptrace_scope is set and we're not root, we cannot attach to a
-        # running process.
+        # running process*.
+        #
         # We assume that we do not need this to be set if we are debugging on
         # a different architecture (e.g. under qemu-user).
+        #
+        # *Unless the process explicitly called PR_SET_PTRACER.
         try:
             ptrace_scope = open('/proc/sys/kernel/yama/ptrace_scope').read().strip()
             if need_ptrace_scope and ptrace_scope != '0' and os.geteuid() != 0:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -652,8 +652,9 @@ def corefile(process):
                 '-ex', 'detach']
 
     with context.local(terminal = ['sh', '-c']):
-        pid = attach(process, gdb_args=gdb_args)
-        os.waitpid(pid, 0)
+        with context.quiet:
+            pid = attach(process, gdb_args=gdb_args)
+            os.waitpid(pid, 0)
 
     return elf.corefile.Core(temp.name)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -648,13 +648,16 @@ def version(program='gdb'):
 
     Example:
 
-        >>> version = gdb.version()
+        >>> version = version()
         >>> (7,0) <= version <= (8,0)
         True
     """
     program = misc.which(program)
+    expr = r'([0-9]+\.?)+'
 
     with tubes.process.process([program, '--version'], level='error') as gdb:
-        version = gdb.recvline().split()[-1]
-    versions = tuple(map(int, version.split('.')))
-    return versions
+        version = gdb.recvline()
+
+    versions = re.search(expr, version).group()
+
+    return tuple(map(int, versions.split('.')))

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -249,7 +249,7 @@ def get_gdb_arch():
 
 
 @LocalContext
-def attach(target, execute = None, exe = None, need_ptrace_scope = True, gdb_args = []):
+def attach(target, execute = None, exe = None, need_ptrace_scope = True, gdb_args = None):
     """attach(target, execute = None, exe = None, arch = None) -> None
 
     Start GDB in a new terminal and attach to `target`.

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -678,5 +678,5 @@ def version(program='gdb'):
 
     with tubes.process.process([program, '--version'], level='error') as gdb:
         version = gdb.recvline().split()[-1]
-    major, minor = map(int, version.split('.'))
-    return (major, minor)
+    versions = tuple(map(int, version.split('.')))
+    return versions

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -317,29 +317,6 @@ def attach(target, execute = None, exe = None, need_ptrace_scope = True, gdb_arg
 
         if context.os == 'android':
             pre += 'set gnutarget ' + _bfdname() + '\n'
-    elif isinstance(target, tubes.process.process):
-        # All processes spawned disable YAMA ptrace mitigations
-        pass
-    elif isinstance(target, tubes.ssh.ssh_channel):
-        # All SSH processes spawned disable YAMA ptrace mitigations
-        pass
-    else:
-        # If ptrace_scope is set and we're not root, we cannot attach to a
-        # running process*.
-        #
-        # We assume that we do not need this to be set if we are debugging on
-        # a different architecture (e.g. under qemu-user).
-        #
-        # *Unless the process explicitly called PR_SET_PTRACER.
-        try:
-            ptrace_scope = open('/proc/sys/kernel/yama/ptrace_scope').read().strip()
-            if need_ptrace_scope and ptrace_scope != '0' and os.geteuid() != 0:
-                msg =  'Disable ptrace_scope to attach to running processes.\n'
-                msg += 'More info: https://askubuntu.com/q/41629'
-                log.warning(msg)
-                return
-        except IOError:
-            pass
 
     # let's see if we can find a pid to attach to
     pid = None

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -302,6 +302,12 @@ def attach(target, execute = None, exe = None, need_ptrace_scope = True):
 
         if context.os == 'android':
             pre += 'set gnutarget ' + _bfdname() + '\n'
+    elif isinstance(target, tubes.process.process):
+        # All processes spawned disable YAMA ptrace mitigations
+        pass
+    elif isinstance(target, tubes.ssh.ssh_channel):
+        # All SSH processes spawned disable YAMA ptrace mitigations
+        pass
     else:
         # If ptrace_scope is set and we're not root, we cannot attach to a
         # running process*.

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -351,7 +351,7 @@ class process(tube):
                     ctypes.CDLL('libc.so.6').personality(ADDR_NO_RANDOMIZE)
 
                 resource.setrlimit(resource.RLIMIT_STACK, (-1, -1))
-            except:
+            except Exception:
                 self.exception("Could not disable ASLR")
 
         # Assume that the user would prefer to have core dumps.
@@ -368,7 +368,7 @@ class process(tube):
             try:
                 PR_SET_NO_NEW_PRIVS = 38
                 ctypes.CDLL('libc.so.6').prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
-            except:
+            except Exception:
                 pass
 
         # Avoid issues with attaching to processes when yama-ptrace is set
@@ -376,7 +376,7 @@ class process(tube):
             PR_SET_PTRACER = 0x59616d61
             PR_SET_PTRACER_ANY = -1
             ctypes.CDLL('libc.so.6').prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0)
-        except:
+        except Exception:
             pass
 
 

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -817,7 +817,7 @@ class process(tube):
         Example:
 
             >>> proc = process('bash')
-            >>> proc.executable in proc.corefile.maps
+            >>> proc.corefile.elftype == 'core.elftype'
             True
         """
         import pwnlib.gdb

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -808,6 +808,9 @@ class process(tube):
         """
         filename = 'core.%i' % (self.pid)
 
+        if not which('gcore'):
+            self.error("Cannot generate corefile without GDB installed")
+
         gcore = process(['gcore', '-o', 'core', str(self.pid)])
 
         data = gcore.recvall()

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -101,6 +101,9 @@ class process(tube):
             List of arguments to display, instead of the main executable name.
         alarm(int):
             Set a SIGALRM alarm timeout on the process.
+        stopped(bool):
+            Start the process in ``STOPPED`` state.
+            Must attach a debugger, or use ``process.continue`` to resume execution.
 
     Attributes:
         proc(subprocess)
@@ -217,6 +220,7 @@ class process(tube):
                  where = 'local',
                  display = None,
                  alarm = None,
+                 stopped = False,
                  *args,
                  **kwargs
                  ):
@@ -552,13 +556,33 @@ class process(tube):
             return getattr(self.proc, attr)
         raise AttributeError("'process' object has no attribute '%s'" % attr)
 
-    def kill(self):
-        """kill()
+    def kill(self, signal=signal.SIGKILL):
+        """kill(signal=signal.SIGKILL)
 
         Kills the process.
-        """
 
+        Arguments:
+            signal(int): Signal to send to the process
+        """
+        if self.proc:
+            self.proc.send_signal(signal)
         self.close()
+
+    def stop(self):
+        """stop()
+
+        Stops the process with ``SIGSTOP``.
+        """
+        if self.proc:
+            self.proc.send_signal(signal.SIGSTOP)
+
+    def resume(self):
+        """continue()
+
+        Resumes the process with ``SIGCONT``.
+        """
+        if self.proc:
+            self.proc.send_signal(signal.SIGCONT)
 
     def poll(self, block = False):
         """poll(block = False) -> int

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -476,7 +476,9 @@ class process(tube):
         # Either there is a path component, or the binary is not in $PATH
         # For example, 'foo/bar' or 'bar' with cwd=='foo'
         elif os.path.sep not in executable:
+            tmp = executable
             executable = os.path.join(cwd, executable)
+            log.warn_once("Could not find executable %r in $PATH, using %r instead" % (tmp, executable))
 
         if not os.path.exists(executable):
             self.error("%r does not exist"  % executable)

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -817,8 +817,8 @@ class process(tube):
         Example:
 
             >>> proc = process('bash')
-            >>> proc.corefile.vdso.data[:4]
-            'LOLELF'
+            >>> proc.executable in proc.corefile.maps
+            True
         """
         import pwnlib.gdb
         return pwnlib.gdb.corefile(self)

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -11,7 +11,6 @@ import resource
 import select
 import signal
 import subprocess
-import tempfile
 import tty
 
 from pwnlib.context import context

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -817,7 +817,7 @@ class process(tube):
         Example:
 
             >>> proc = process('bash')
-            >>> proc.corefile.elftype == 'core.elftype'
+            >>> isinstance(proc.corefile, pwnlib.elf.corefile.Core)
             True
         """
         import pwnlib.gdb

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -830,7 +830,7 @@ class process(tube):
             >>> e = ELF('/bin/sh')
             >>> p = process(e.path)
             >>> p.leak(e.address, 4)
-            '\7xELF'
+            '\x7fELF'
         """
         # If it's running under qemu-user, don't leak anything.
         if 'qemu-' in os.path.realpath('/proc/%i/exe' % self.pid):

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -101,9 +101,6 @@ class process(tube):
             List of arguments to display, instead of the main executable name.
         alarm(int):
             Set a SIGALRM alarm timeout on the process.
-        stopped(bool):
-            Start the process in ``STOPPED`` state.
-            Must attach a debugger, or use ``process.continue`` to resume execution.
 
     Attributes:
         proc(subprocess)
@@ -220,7 +217,6 @@ class process(tube):
                  where = 'local',
                  display = None,
                  alarm = None,
-                 stopped = False,
                  *args,
                  **kwargs
                  ):
@@ -556,33 +552,12 @@ class process(tube):
             return getattr(self.proc, attr)
         raise AttributeError("'process' object has no attribute '%s'" % attr)
 
-    def kill(self, signal=signal.SIGKILL):
-        """kill(signal=signal.SIGKILL)
+    def kill(self):
+        """kill()
 
         Kills the process.
-
-        Arguments:
-            signal(int): Signal to send to the process
         """
-        if self.proc:
-            self.proc.send_signal(signal)
         self.close()
-
-    def stop(self):
-        """stop()
-
-        Stops the process with ``SIGSTOP``.
-        """
-        if self.proc:
-            self.proc.send_signal(signal.SIGSTOP)
-
-    def resume(self):
-        """continue()
-
-        Resumes the process with ``SIGCONT``.
-        """
-        if self.proc:
-            self.proc.send_signal(signal.SIGCONT)
 
     def poll(self, block = False):
         """poll(block = False) -> int
@@ -842,7 +817,7 @@ class process(tube):
         Example:
 
             >>> proc = process('bash')
-            >>> proc.corefile.read(proc.elf.address, 4)
+            >>> proc.corefile.vdso.data[:4]
             'LOLELF'
         """
         import pwnlib.gdb

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -820,7 +820,7 @@ class process(tube):
 
             >>> proc = process('bash')
             >>> proc.corefile.read(proc.elf.address, 4)
-            '\x7fELF'
+            'LOLELF'
         """
         import pwnlib.gdb
         return pwnlib.gdb.corefile(self)

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -819,7 +819,7 @@ class process(tube):
         return pwnlib.elf.corefile.Core(filename)
 
     def leak(self, address, count=1):
-        """Leaks memory within the process at the specified address.
+        r"""Leaks memory within the process at the specified address.
 
         Arguments:
             address(int): Address to leak memory at

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -852,6 +852,13 @@ if %(setuid)r is False:
         sys.stdout.write("Could not disable setuid: prctl(PR_SET_NO_NEW_PRIVS) failed")
         sys.exit(-1)
 
+try:
+    PR_SET_PTRACER = 0x59616d61
+    PR_SET_PTRACER_ANY = -1
+    ctypes.CDLL('libc.so.6').prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0)
+except Exception:
+    pass
+
 if sys.argv[-1] == 'check':
     sys.stdout.write("1\n")
     sys.stdout.write(str(os.getpid()) + "\n")

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -188,7 +188,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
       args (list): Arguments to pass to the terminal
 
     Returns:
-      None
+      PID of the new terminal process
     """
 
     if not terminal:
@@ -223,7 +223,9 @@ def run_in_new_terminal(command, terminal = None, args = None):
 
     log.debug("Launching a new terminal: %r" % argv)
 
-    if os.fork() == 0:
+    pid = os.fork()
+
+    if pid == 0:
         # Closing the file descriptors makes everything fail under tmux on OSX.
         if platform.system() != 'Darwin':
             os.close(0)
@@ -231,6 +233,8 @@ def run_in_new_terminal(command, terminal = None, args = None):
             os.close(2)
         os.execv(argv[0], argv)
         os._exit(1)
+
+    return pid
 
 def parse_ldd_output(output):
     """Parses the output from a run of 'ldd' on a binary.

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -174,18 +174,23 @@ def run_in_new_terminal(command, terminal = None, args = None):
 
     Run a command in a new terminal.
 
-    When `terminal` is not set:
-      - If `context.terminal` is set it will be used.  If it is an iterable then
-        `context.terminal[1:]` are default arguments.
-      - If X11 is detected (by the presence of the ``DISPLAY`` environment
-        variable), ``x-terminal-emulator`` is used.
-      - If tmux is detected (by the presence of the ``TMUX`` environment
-        variable), a new pane will be opened.
+    When ``terminal`` is not set:
+        - If ``context.terminal`` is set it will be used.
+          If it is an iterable then ``context.terminal[1:]`` are default arguments.
+        - If a ``pwntools-terminal`` command exists in ``$PATH``, it is used
+        - If ``$TERM_PROGRAM`` is set, that is used.
+        - If X11 is detected (by the presence of the ``$DISPLAY`` environment
+          variable), ``x-terminal-emulator`` is used.
+        - If tmux is detected (by the presence of the ``$TMUX`` environment
+          variable), a new pane will be opened.
 
     Arguments:
-      command (str): The command to run.
-      terminal (str): Which terminal to use.
-      args (list): Arguments to pass to the terminal
+        command (str): The command to run.
+        terminal (str): Which terminal to use.
+        args (list): Arguments to pass to the terminal
+
+    Note:
+        The command is opened with ``/dev/null`` for stdin, stdout, stderr.
 
     Returns:
       PID of the new terminal process
@@ -195,6 +200,9 @@ def run_in_new_terminal(command, terminal = None, args = None):
         if context.terminal:
             terminal = context.terminal[0]
             args     = context.terminal[1:]
+        elif which('pwntools-terminal'):
+            terminal = 'pwntools-terminal'
+            args     = []
         elif 'DISPLAY' in os.environ:
             terminal = 'x-terminal-emulator'
             args     = ['-e']
@@ -228,9 +236,10 @@ def run_in_new_terminal(command, terminal = None, args = None):
     if pid == 0:
         # Closing the file descriptors makes everything fail under tmux on OSX.
         if platform.system() != 'Darwin':
-            os.close(0)
-            os.close(1)
-            os.close(2)
+            devnull = open(os.devnull, 'rwb')
+            os.dup2(devnull.fileno(), 0)
+            os.dup2(devnull.fileno(), 1)
+            os.dup2(devnull.fileno(), 2)
         os.execv(argv[0], argv)
         os._exit(1)
 


### PR DESCRIPTION
Using `PR_SET_PTRACER` will avoid running into issues with debugging when kernel YAMA security settings are enabled.

These can be disabled locally, but require root access.  This is a problem for both rootless Travis CI testing, and e.g. debugging Wargame processes.

`PR_SET_PTRACER` should have no negative functional effects, and only side-steps the YAMA mitigations (it does not permit *any* ptracer, UID/GID checks still apply, etc.).

This grants us the ability to do e.g. `process.corefile` on systems with YAMA enforcing, like Travis.