### PR TITLE
Faster compare in MemLeak

### DIFF
--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -538,10 +538,7 @@ class MemLeak(object):
         return self.n(start, stop-start)[::step]
 
     def compare(self, address, bytes):
-        for i, byte in enumerate(bytes):
-            if self.n(address + i, 1) != byte:
-                return False
-        return True
+        return self.n(address, len(bytes)) == bytes
 
     @staticmethod
     def NoNulls(function):


### PR DESCRIPTION
Instead of reading byte by byte, use the already existing functionality of reading many bytes at once.