### PR TITLE
Defer attempts to start ADB server until we actually fail to connect

### DIFF
--- a/pwnlib/adb/protocol.py
+++ b/pwnlib/adb/protocol.py
@@ -142,7 +142,17 @@ class Client(Logger):
 
     @_autoclose
     def kill(self):
-        """Kills the remote ADB server"""
+        """Kills the remote ADB server"
+
+        >>> c=adb.protocol.Client()
+        >>> c.kill()
+
+        The server is automatically re-started on the next request,
+        if the default host/port are used.
+
+        >>> c.version() > (4,0)
+        True
+        """
         try:
             self.send('host:kill')
         except EOFError:

--- a/pwnlib/adb/protocol.py
+++ b/pwnlib/adb/protocol.py
@@ -92,7 +92,7 @@ class Client(Logger):
                 # as long as it's the *default* port.
                 if self.host == context.defaults['adb_host'] \
                 and self.port == context.defaults['adb_port']:
-                    log.info("Could not connect to ADB server, trying to start it")
+                    log.warn("Could not connect to ADB server, trying to start it")
                     process(context.adb + ['start-server']).recvall()
                 else:
                     log.exception('Could not connect to ADB server')
@@ -148,6 +148,7 @@ class Client(Logger):
         except EOFError:
             pass
 
+    @_autoclose
     def version(self):
         """
         Returns:


### PR DESCRIPTION
The `adb.protocol` code attempts to be kind and start the ADB server if the user had not already done so (e.g. on a freshly-booted machine).

However, it attempts to do this on *every* connection.  Because of the way that ADB works, this shouldn't actually cause any issues, since the new server process will just fail to bind the port and exit silently.

This adds a bit of overhead (lots of spawned processes) and takes up time in tight loops.

Defer attempting to kick-start the ADB server until we actually fail a connection attempt.