### PR TITLE
Enhance adb.process(), Fix Android Debugging under GDB

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -779,7 +779,7 @@ def process(argv, shell=False, executable=None, env=None, *a, **kw):
 
     # Determine the full path to the executable
     if not executable:
-        executable = which(argv[0]) or './' + argv[0]
+        executable = argv[0] # which(argv[0]) or './' + argv[0]
 
     # If we're doing shell expansion, we need to feed it back into 'sh'
     # Yes, this is a little convoluted.
@@ -805,9 +805,16 @@ def process(argv, shell=False, executable=None, env=None, *a, **kw):
     #
     # This avoids weird side-effects where execute(['sh'])
     # would actually create two "sh" processes.
+    #
+    # The Toolbox version does not support '-a'
     argv0 = sh_string(argv[0])
     argv_str = ' '.join(map(sh_string, argv))
-    cmd += 'exec -a %s %s' % (argv0, argv_str)
+    cmd += 'exec '
+
+    if argv0 != os.path.basename(executable):
+        cmd += '-a %s '
+
+    cmd += argv_str
 
     message = "Starting %s process %r" % ('Android', argv[0])
 

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -949,7 +949,7 @@ def getprop(name=None):
     with context.quiet:
         if name:
             io = process(['getprop', name], executable='/system/bin/getprop')
-            return ui.recvall().strip()
+            return io.recvall().strip()
 
         result = process(['getprop'], executable='/system/bin/getprop').recvall()
 

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -749,7 +749,7 @@ def unlink(path, recursive=False):
 
         flags = '-rf' if recursive else '-r'
 
-        output = c.execute(['rm', flags, path]).recvall()
+        output = process(['rm', flags, path]).recvall()
 
         if output:
             log.error(output)
@@ -822,7 +822,7 @@ def process(argv, shell=False, executable=None, env=None, *a, **kw):
         if argv != [argv[0]]: message += ' argv=%r ' % argv
 
     with log.progress(message) as p:
-        result = AdbClient().execute(argv)
+        result = AdbClient().execute(cmd)
 
     result.argv = saved_argv
     result.pid  = int(result.recvline())

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -67,6 +67,7 @@ from pwnlib.context import context
 from pwnlib.device import Device
 from pwnlib.log import getLogger
 from pwnlib.protocols.adb import AdbClient
+from pwnlib.util.sh_string import sh_string
 from pwnlib.util import misc
 
 log = getLogger(__name__)
@@ -337,7 +338,7 @@ class AdbDevice(Device):
         """Wrapps a callable in a scope which selects the current device."""
         @functools.wraps(function)
         def wrapper(*a, **kw):
-            with context.local(device=self):
+            with context.local(device=self.serial):
                 return function(*a,**kw)
         return wrapper
 
@@ -350,7 +351,7 @@ class AdbDevice(Device):
         >>> adb.getprop(property) == device.getprop(property)
         True
         """
-        with context.local(device=self):
+        with context.local(device=self.serial):
             g = globals()
 
             if name not in g:
@@ -402,7 +403,7 @@ def wait_for_device(kick=False):
         else:
             log.error("Could not find any devices")
 
-        with context.local(device=device):
+        with context.local(device=device.serial):
             # There may be multiple devices, so context.device is
             # insufficient.  Pick the first device reported.
             w.success('%s (%s %s %s)' % (device,
@@ -754,7 +755,7 @@ def unlink(path, recursive=False):
             log.error(output)
 
 @with_device
-def process(argv, *a, **kw):
+def process(argv, shell=False, executable=None, env=None, *a, **kw):
     """Execute a process on the device.
 
     See :class:`pwnlib.tubes.process.process` documentation for more info.
@@ -768,8 +769,45 @@ def process(argv, *a, **kw):
         >>> print adb.process(['cat','/proc/version']).recvall() # doctest: +ELLIPSIS
         Linux version ...
     """
+
     if isinstance(argv, (str, unicode)):
         argv = [argv]
+
+    # Save off a copy of the original argv array, which is stashed
+    # on the object.
+    saved_argv = list(argv)
+
+    # Determine the full path to the executable
+    if not executable:
+        executable = which(argv[0]) or './' + argv[0]
+
+    # If we're doing shell expansion, we need to feed it back into 'sh'
+    # Yes, this is a little convoluted.
+    if shell:
+        argv = ['sh', '-c'] + argv
+
+    # If we are *setting* the environment, prepent the "env -i" ...
+    if env:
+        # Build the command-line for env iteself
+        env_cmd = ['env', '-i']
+        for k,v in env.items():
+            env_cmd += ['%s=%s' % (k,v)]
+
+        argv = env_cmd + argv
+
+    # Echo the PID of our shell, so we know our own PID.
+    #
+    # This must be performed in this routine, since the '$' are escaped
+    # otherwise.
+    cmd = 'echo $$;'
+
+    # Actually "exec" the command, rather than fork-and-exec
+    #
+    # This avoids weird side-effects where execute(['sh'])
+    # would actually create two "sh" processes.
+    argv0 = sh_string(argv[0])
+    argv_str = ' '.join(map(sh_string, argv))
+    cmd += 'exec -a %s %s' % (argv0, argv_str)
 
     message = "Starting %s process %r" % ('Android', argv[0])
 
@@ -777,7 +815,13 @@ def process(argv, *a, **kw):
         if argv != [argv[0]]: message += ' argv=%r ' % argv
 
     with log.progress(message) as p:
-        return AdbClient().execute(argv)
+        result = AdbClient().execute(argv)
+
+    result.argv = saved_argv
+    result.pid  = int(result.recvline())
+    result.executable = executable or saved_argv[0]
+
+    return result
 
 @with_device
 def interactive(**kw):
@@ -843,7 +887,6 @@ done
 
     return None
 
-
 @with_device
 def whoami():
     return process(['sh','-ic','echo $USER']).recvall().strip()
@@ -905,10 +948,10 @@ def getprop(name=None):
     """
     with context.quiet:
         if name:
-            return process(['getprop', name]).recvall().strip()
+            io = process(['getprop', name], executable='/system/bin/getprop')
+            return ui.recvall().strip()
 
-
-        result = process(['getprop']).recvall()
+        result = process(['getprop'], executable='/system/bin/getprop').recvall()
 
     expr = r'\[([^\]]+)\]: \[(.*)\]'
 
@@ -1066,7 +1109,7 @@ class Kernel(object):
                 return
 
             # Need to be root
-            with context.local(device=context.device):
+            with context.local(device=context.device.serial):
                 # Save off the command line before rebooting to the bootloader
                 cmdline = kernel.cmdline
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -69,6 +69,23 @@ a direct parent-child relationship.
 This causes some issues with the normal Pwntools workflow, since the process
 heirarchy looks like this:
 
+Android Debugging
+~~~~~~~~~~~~~~~~~
+
+All of the functionality described here also works on Android devices, given:
+
+1. Your ``gdb`` can debug the device's binaries
+2. The device has a ``gdbserver`` binary
+3. You have properly set ``context.os`` and ``context.arch``
+
+.. code-block:: python
+
+    # set context.os, context.arch, context.bits, and context.device
+    context.device = adb.wait_for_device()
+
+    # launch a process
+    p = adb.process('sh')
+
 ::
 
     python ---> target
@@ -602,6 +619,11 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
 
         misc.run_in_new_terminal(' '.join(cmd))
         return
+
+    elif isinstance(target, tubes.sock.sock) and context.os == 'android':
+        # Android processes are really just sockets connected to
+        # the ADB server.
+        pass
 
     elif isinstance(target, tubes.sock.sock):
         pids = proc.pidof(target)

--- a/pwnlib/protocols/adb/__init__.py
+++ b/pwnlib/protocols/adb/__init__.py
@@ -239,8 +239,11 @@ class AdbClient(Logger):
 
     @_autoclose
     @_with_transport
-    def execute(self, argv):
+    def execute(self, string):
         r"""Executes a program on the device.
+
+        Arguments:
+            string(str): Raw string fed directly to the system shell.
 
         Returns:
             A :class:`pwnlib.tubes.tube.tube` which is connected to the process.
@@ -251,11 +254,11 @@ class AdbClient(Logger):
             'hello\n'
         """
         self.transport(context.device)
-        if isinstance(argv, str):
-            argv = [argv]
-        argv = list(map(sh_string, argv))
-        cmd = 'exec:%s' % (' '.join(argv))
-        if OKAY == self.send(cmd):
+
+        if not isinstance(string, str):
+            log.error("Not a string: %r", string)
+
+        if OKAY == self.send('exec:' + string):
             rv = self._c
             self._c = None
             return rv

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -281,7 +281,7 @@ class process(tube):
                 self.executable = which(self.argv[0])
 
         #: Environment passed on envp
-        self.env = os.environ if env is None else env
+        self.env = env if env is not None else dict(os.environ)
 
         self._cwd = os.path.realpath(cwd or os.path.curdir)
 


### PR DESCRIPTION
The code for `adb.process()` doesn't set many convenience variables on the object it returns, which other `tubes.process` code *does* do.

- `.argv`
- `.env`
- `.executable`
- `.pid`

Additionally, at some point all of the GDB debugging stuff broke and nobody noticed, because nobody ever used it except me.

Note that this has #833 cherry-picked and squashed, so that I could test with those changes.