### PR TITLE
Find the relocation section with .rela.dyn

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -576,7 +576,9 @@ class ELF(ELFFile):
                             isinstance(s, RelocationSection))
         except StopIteration:
             # Evidently whatever android-ndk uses to build binaries zeroes out sh_info for rel.plt
-            rel_plt = self.get_section_by_name('.rel.plt') or self.get_section_by_name('.rela.plt')
+            rel_plt = self.get_section_by_name('.rel.plt') or \
+                self.get_section_by_name('.rela.plt') or \
+                self.get_section_by_name('.rela.dyn')
 
         if not rel_plt:
             log.warning("Couldn't find relocations against PLT to get symbols")


### PR DESCRIPTION
- Relocation section will be named '.rela.dyn' after gcc 5.0.
