### PR TITLE
Make Core Files Great Again 🇺🇸🇩🇰

### DIFF
--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -24,7 +24,7 @@ from pwnlib.context import Thread
 from pwnlib.context import context
 from pwnlib.dynelf import DynELF
 from pwnlib.encoders import *
-from pwnlib.elf.corefile import Core, Corefile
+from pwnlib.elf.corefile import Core, Corefile, Coredump
 from pwnlib.elf.elf import ELF, load
 from pwnlib.encoders import *
 from pwnlib.exception import PwnlibException

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -333,6 +333,7 @@ class ContextType(object):
         'binary': None,
         'bits': 32,
         'buffer_size': 4096,
+        'delete_corefiles': False,
         'device': os.getenv('ANDROID_SERIAL', None) or None,
         'endian': 'little',
         'kernel': None,
@@ -340,6 +341,7 @@ class ContextType(object):
         'log_file': _devnull(),
         'log_console': sys.stdout,
         'randomize': False,
+        'rename_corefiles': True,
         'newline': '\n',
         'noptrace': False,
         'os': 'linux',
@@ -1198,6 +1200,32 @@ class ContextType(object):
             return None
 
         return cache
+
+    @_validator
+    def delete_corefiles(self, v):
+        """Whether pwntools automatically deletes corefiles after exiting.
+        This only affects corefiles accessed via :attr:`.process.corefile`.
+
+        Default value is ``False``.
+        """
+        return bool(v)
+
+    @_validator
+    def rename_corefiles(self, v):
+        """Whether pwntools automatically renames corefiles.
+
+        This is useful for two things:
+
+        - Prevent corefiles from being overwritten, if ``kernel.core_pattern``
+          is something simple like ``"core"``.
+        - Ensure corefiles are generated, if ``kernel.core_pattern`` uses ``apport``,
+          which refuses to overwrite any existing files.
+
+        This only affects corefiles accessed via :attr:`.process.corefile`.
+
+        Default value is ``True``.
+        """
+        return bool(v)
 
     #*************************************************************************
     #                               ALIASES

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Read information from Core Dumps.
 
 Core dumps are extremely useful when writing exploits, even outside of
@@ -63,6 +64,13 @@ from __future__ import absolute_import
 
 import collections
 import ctypes
+import glob
+import gzip
+import re
+import os
+import socket
+import StringIO
+import tempfile
 
 import elftools
 from elftools.common.py3compat import bytes2str
@@ -70,17 +78,37 @@ from elftools.common.utils import roundup
 from elftools.common.utils import struct_parse
 from elftools.construct import CString
 
+from pwnlib import atexit
 from pwnlib.context import context
 from pwnlib.elf.datatypes import *
 from pwnlib.elf.elf import ELF
 from pwnlib.log import getLogger
+from pwnlib.tubes.process import process
+from pwnlib.tubes.ssh import ssh_channel
 from pwnlib.tubes.tube import tube
+from pwnlib.util.fiddling import b64d
+from pwnlib.util.fiddling import unhex
+from pwnlib.util.misc import read
+from pwnlib.util.misc import write
+from pwnlib.util.packing import pack
+from pwnlib.util.packing import unpack_many
 
 log = getLogger(__name__)
 
-types = {
+prstatus_types = {
     'i386': elf_prstatus_i386,
     'amd64': elf_prstatus_amd64,
+    'arm': elf_prstatus_arm
+}
+
+prspinfo_types = {
+    32: elf_prspinfo_32,
+    64: elf_prspinfo_64,
+}
+
+siginfo_types = {
+    32: elf_siginfo_32,
+    64: elf_siginfo_64
 }
 
 # Slightly modified copy of the pyelftools version of the same function,
@@ -117,24 +145,30 @@ class Mapping(object):
     def __init__(self, core, name, start, stop, flags):
         self._core=core
 
-        #: Name of the mapping, e.g. ``'/bin/bash'`` or ``'[vdso]'``.
-        self.name=name
+        #: :class:`str`: Name of the mapping, e.g. ``'/bin/bash'`` or ``'[vdso]'``.
+        self.name = name or ''
 
-        #: First mapped byte in the mapping
-        self.start=start
+        #: :class:`int`: First mapped byte in the mapping
+        self.start = start
 
-        #: First byte after the end of hte mapping
-        self.stop=stop
+        #: :class:`int`: First byte after the end of hte mapping
+        self.stop = stop
 
-        #: Size of the mapping, in bytes
-        self.size=stop-start
+        #: :class:`int`: Size of the mapping, in bytes
+        self.size = stop-start
 
-        #: Mapping flags, using e.g. ``PROT_READ`` and so on.
-        self.flags=flags
+        #: :class:`int`: Mapping flags, using e.g. ``PROT_READ`` and so on.
+        self.flags = flags
+
+    @property
+    def path(self):
+        """:class:`str`: Alias for :attr:`.Mapping.name`"""
+        return self.name
 
     @property
     def address(self):
         """:class:`int`: Alias for :data:`Mapping.start`."""
+        return self.start
 
     @property
     def permstr(self):
@@ -164,13 +198,71 @@ class Mapping(object):
         """:class:`str`: Memory of the mapping."""
         return self._core.read(self.start, self.size)
 
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            start = int(item.start or self.start)
+            stop  = int(item.stop or self.stop)
+
+            # Negative slices...
+            if start < 0:
+                start += self.stop
+            if stop < 0:
+                stop += self.stop
+
+            if not (self.start <= start <= stop <= self.stop):
+                log.error("Byte range [%#x:%#x] not within range [%#x:%#x]" \
+                    % (start, stop, self.start, self.stop))
+
+            data = self._core.read(start, stop-start)
+
+            if item.step == 1:
+                return data
+            return data[::item.step]
+
+        return self._core.read(item, 1)
+
+    def __contains__(self, item):
+        return self.start <= item < self.stop
+
+    def find(self, sub, start=None, end=None):
+        """Similar to str.find() but works on our address space"""
+        if start is None:
+            start = self.start
+        if end is None:
+            end = self.stop
+
+        result = self.data.find(sub, start-self.address, end-self.address)
+
+        if result == -1:
+            return result
+
+        return result + self.address
+
+    def rfind(self, sub, start=None, end=None):
+        """Similar to str.rfind() but works on our address space"""
+        if start is None:
+            start = self.start
+        if end is None:
+            end = self.stop
+
+        result = self.data.rfind(sub, start-self.address, end-self.address)
+
+        if result == -1:
+            return result
+
+        return result + self.address
+
 class Corefile(ELF):
-    """Enhances the inforation available about a corefile (which is an extension
+    r"""Enhances the inforation available about a corefile (which is an extension
     of the ELF format) by permitting extraction of information about the mapped
     data segments, and register state.
 
     Registers can be accessed directly, e.g. via ``core_obj.eax`` and enumerated
     via :data:`Corefile.registers`.
+
+    Arguments:
+        core: Path to the core file.  Alternately, may be a :class:`.process` instance,
+              and the core file will be located automatically.
 
     ::
 
@@ -217,10 +309,138 @@ class Corefile(ELF):
          Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7713000, stop=0xf7714000, size=0x1000, flags=0x6),
          Mapping('[stack]', start=0xfff3e000, stop=0xfff61000, size=0x23000, flags=0x6)]
 
+    Example:
+
+        The Linux kernel may not overwrite an existing core-file.
+
+        >>> if os.path.exists('core'): os.unlink('core')
+
+        Let's build an example binary which should eat ``R0=0xdeadbeef``
+        and ``PC=0xcafebabe``.
+
+        If we run the binary and then wait for it to exit, we can get its
+        core file.
+
+        >>> context.clear(arch='arm')
+        >>> shellcode = shellcraft.mov('r0', 0xdeadbeef)
+        >>> shellcode += shellcraft.mov('r1', 0xcafebabe)
+        >>> shellcode += 'bx r1'
+        >>> address = 0x41410000
+        >>> elf = ELF.from_assembly(shellcode, vma=address)
+        >>> io = elf.process(env={'HELLO': 'WORLD'})
+        >>> io.poll(block=True)
+        -11
+
+        You can specify a full path a la ``Corefile('/path/to/core')``,
+        but you can also just access the :attr:`.process.corefile` attribute.
+
+        >>> core = io.corefile
+
+        The core file has a :attr:`.Corefile.exe` property, which is a :class:`.Mapping`
+        object.  Each mapping can be accessed with virtual addresses via subscript, or
+        contents can be examined via the :attr:`.Mapping.data` attribute.
+
+        >>> core.exe.address == address
+        True
+
+        The core file also has registers which can be accessed direclty.
+        Pseudo-registers ``pc`` and ``sp`` are available on all architectures,
+        to make writing architecture-agnostic code more simple.
+
+        >>> core.pc == 0xcafebabe
+        True
+        >>> core.r0 == 0xdeadbeef
+        True
+        >>> core.sp == core.r13
+        True
+
+        We may not always know which signal caused the core dump, or what address
+        caused a segmentation fault.  Instead of accessing registers directly, we
+        can also extract this information from the core dump.
+
+        On QEMU-generated core dumps, this information is unavailable, so we
+        substitute the value of PC.  In our example, that's correct anyway.
+
+        >>> core.fault_addr == 0xcafebabe
+        True
+        >>> core.signal
+        11
+
+        Core files can also be generated from running processes.
+        This requires GDB to be installed, and can only be done with native
+        processes.  Getting a "complete" corefile requires GDB 7.11 or better.
+
+        >>> elf = ELF('/bin/bash')
+        >>> context.clear(binary=elf)
+        >>> io = process(elf.path, env={'HELLO': 'WORLD'})
+        >>> core = io.corefile
+
+        Data can also be extracted directly from the corefile.
+
+        >>> core.exe[elf.address:elf.address+4]
+        '\x7fELF'
+        >>> core.exe.data[:4]
+        '\x7fELF'
+
+        Various other mappings are available by name.  On Linux, 32-bit Intel binaries
+        should have a VDSO section.  Since our ELF is statically linked, there is
+        no libc which gets mapped.
+
+        >>> core.vdso.data[:4]
+        '\x7fELF'
+        >>> core.libc # docteset: +ELLIPSIS
+        Mapping('/lib/x86_64-linux-gnu/libc-...', ...)
+
+        The corefile also contains a :attr:`.Corefile.stack` property, which gives
+        us direct access to the stack contents.  On Linux, the very top of the stack
+        should contain two pointer-widths of NULL bytes, preceded by the NULL-
+        terminated path to the executable (as passed via the first arg to ``execve``).
+
+        >>> stack_end = core.exe.name
+        >>> stack_end += '\x00' * (1+8)
+        >>> core.stack.data.endswith(stack_end)
+        True
+        >>> len(core.stack.data) == core.stack.size
+        True
+
+        We can also directly access the environment variables and arguments.
+
+        >>> 'HELLO' in core.env
+        True
+        >>> core.getenv('HELLO')
+        'WORLD'
+        >>> core.argc
+        1
+        >>> core.argv[0] in core.stack
+        True
+        >>> core.string(core.argv[0]) == core.exe.path
+        True
+
+        Corefiles can also be pulled from remote machines via SSH!
+
+        >>> s = ssh('travis', 'example.pwnme')
+        >>> _ = s.set_working_directory()
+        >>> elf = ELF.from_assembly('int3')
+        >>> path = s.upload(elf.path)
+        >>> _ =s.chmod('+x', path)
+        >>> io = s.process(path)
+        >>> io.wait()
+        -1
+        >>> io.corefile.signal == signal.SIGTRAP # doctest: +SKIP
+        True
     """
+
+    _fill_gaps = False
+
     def __init__(self, *a, **kw):
         #: The NT_PRSTATUS object.
         self.prstatus = None
+
+        #: The NT_PRSPINFO object
+        self.prspinfo = None
+
+        #: The NT_SIGINFO object
+        self.siginfo = None
 
         #: :class:`dict`: Dictionary of memory mappings from ``address`` to ``name``
         self.mappings = []
@@ -233,10 +453,22 @@ class Corefile(ELF):
         #: variable.
         #:
         #: Note: Use with the :meth:`.ELF.string` method to extract them.
-        self.env      = {}
+        self.env = {}
+
+        #: :class:`list`: List of addresses of arguments on the stack.
+        self.argv = []
+
+        #: :class:`int`: Number of arguments passed
+        self.argc = 0
+
+        # Pointer to the executable filename on the stack
+        self.at_execfn = 0
+
+        # Pointer to the entry point
+        self.at_entry = 0
 
         try:
-            super(Core, self).__init__(*a, **kw)
+            super(Corefile, self).__init__(*a, **kw)
         except IOError:
             log.warning("No corefile.  Have you set /proc/sys/kernel/core_pattern?")
             raise
@@ -245,12 +477,14 @@ class Corefile(ELF):
         self._address  = 0
 
         if not self.elftype == 'CORE':
-            log.error("%s is not a valid corefile" % e.file.name)
+            log.error("%s is not a valid corefile" % self.file.name)
 
-        if not self.arch in ('i386','amd64'):
-            log.error("%s does not use a supported corefile architecture" % e.file.name)
+        if not self.arch in prstatus_types.keys():
+            log.warn_once("%s does not use a supported corefile architecture, registers are unavailable" % self.file.name)
 
-        prstatus_type = types[self.arch]
+        prstatus_type = prstatus_types.get(self.arch, None)
+        prspinfo_type = prspinfo_types.get(self.bits, None)
+        siginfo_type = siginfo_types.get(self.bits, None)
 
         with log.waitfor("Parsing corefile...") as w:
             self._load_mappings()
@@ -261,10 +495,24 @@ class Corefile(ELF):
                 for note in iter_notes(segment):
                     # Try to find NT_PRSTATUS.  Note that pyelftools currently
                     # mis-identifies the enum name as 'NT_GNU_ABI_TAG'.
-                    if note.n_descsz == ctypes.sizeof(prstatus_type) and \
+                    if prstatus_type and \
+                       note.n_descsz == ctypes.sizeof(prstatus_type) and \
                        note.n_type == 'NT_GNU_ABI_TAG':
                         self.NT_PRSTATUS = note
                         self.prstatus = prstatus_type.from_buffer_copy(note.n_desc)
+
+                    # Try to find NT_PRPSINFO
+                    # Note that pyelftools currently mis-identifies the enum name
+                    # as 'NT_GNU_BUILD_ID'
+                    if note.n_descsz == ctypes.sizeof(prspinfo_type) and \
+                       note.n_type == 'NT_GNU_BUILD_ID':
+                        self.NT_PRSPINFO = note
+                        self.prspinfo = prspinfo_type.from_buffer_copy(note.n_desc)
+
+                    # Try to find NT_SIGINFO so we can see the fault
+                    if note.n_type == 0x53494749:
+                        self.NT_SIGINFO = note
+                        self.siginfo = siginfo_type.from_buffer_copy(note.n_desc)
 
                     # Try to find the list of mapped files
                     if note.n_type == constants.NT_FILE:
@@ -276,6 +524,9 @@ class Corefile(ELF):
                     if note.n_type == constants.NT_AUXV:
                         with context.local(bytes=self.bytes):
                             self._parse_auxv(note)
+
+            if not self.stack and self.mappings:
+                self.stack = self.mappings[-1]
 
             if self.stack and self.mappings:
                 for mapping in self.mappings:
@@ -290,6 +541,8 @@ class Corefile(ELF):
                     # If there are no environment variables, we die by running
                     # off the end of the stack.
                     pass
+
+            self._describe_core()
 
     def _parse_nt_file(self, note):
         t = tube()
@@ -364,8 +617,15 @@ class Corefile(ELF):
     @property
     def libc(self):
         """:class:`Mapping`: First mapping for ``libc.so``"""
+        expr = r'libc\b.*so$'
+
         for m in self.mappings:
-            if m.name and m.name.startswith('libc') and m.name.endswith('.so'):
+            if not m.name:
+                continue
+
+            basename = os.path.basename(m.name)
+
+            if re.match(expr, basename):
                 return m
 
     @property
@@ -373,7 +633,99 @@ class Corefile(ELF):
         """:class:`Mapping`: First mapping for the executable file."""
         for m in self.mappings:
             if self.at_entry and m.start <= self.at_entry <= m.stop:
+
+                if not m.name and self.at_execfn:
+                    m.name = self.string(self.at_execfn)
+
                 return m
+
+    @property
+    def pid(self):
+        """:class:`int`: PID of the process which created the core dump."""
+        if self.prstatus:
+            return int(self.prstatus.pr_pid)
+
+    @property
+    def ppid(self):
+        """:class:`int`: Parent PID of the process which created the core dump."""
+        if self.prstatus:
+            return int(self.prstatus.pr_ppid)
+
+    @property
+    def signal(self):
+        """:class:`int`: Signal which caused the core to be dumped."""
+        if self.siginfo:
+            return int(self.siginfo.si_signo)
+        if self.prstatus:
+            return int(self.prstatus.pr_cursig)
+
+    @property
+    def fault_addr(self):
+        """:class:`int`: Address which generated the fault, for the signals
+            SIGILL, SIGFPE, SIGSEGV, SIGBUS.  This is only available in native
+            core dumps created by the kernel.  If the information is unavailable,
+            this returns the address of the instruction pointer."""
+        if self.siginfo:
+            return int(self.siginfo.sigfault_addr)
+
+        return self.pc
+
+    @property
+    def _pc_register(self):
+        name = {
+            'i386': 'eip',
+            'amd64': 'rip',
+        }.get(self.arch, 'pc')
+        return name
+
+    @property
+    def pc(self):
+        """:class:`int`: The program counter for the Corefile
+
+        This is a cross-platform way to get e.g. ``core.eip``, ``core.rip``, etc.
+        """
+        return self.registers.get(self._pc_register, None)
+
+    @property
+    def _sp_register(self):
+        name = {
+            'i386': 'esp',
+            'amd64': 'rsp',
+        }.get(self.arch, 'sp')
+        return name
+
+    @property
+    def sp(self):
+        """:class:`int`: The program counter for the Corefile
+
+        This is a cross-platform way to get e.g. ``core.esp``, ``core.rsp``, etc.
+        """
+        return self.registers.get(self._sp_register, None)
+
+    def _describe(self):
+        pass
+
+    def _describe_core(self):
+        gnu_triplet = '-'.join(map(str, (self.arch, self.bits, self.endian)))
+
+        fields = [
+            repr(self.path),
+            '%-10s %s' % ('Arch:', gnu_triplet),
+            '%-10s %#x' % ('%s:' % self._pc_register.upper(), self.pc),
+            '%-10s %#x' % ('%s:' % self._sp_register.upper(), self.sp),
+        ]
+
+        if self.exe and self.exe.name:
+            fields += [
+                '%-10s %s' % ('Exe:', '%r (%#x)' % (self.exe.name, self.exe.address))
+            ]
+
+        if self.fault_addr:
+            fields += [
+                '%-10s %#x' % ('Fault:', self.fault_addr)
+            ]
+
+        log.info_once('\n'.join(fields))
 
     def _load_mappings(self):
         for s in self.segments:
@@ -421,54 +773,86 @@ class Corefile(ELF):
                 self.at_sysinfo_ehdr = value
 
     def _parse_stack(self):
+        # Get a copy of the stack mapping
+        stack = self.stack
+
+        if not stack:
+            return
+
         # AT_EXECFN is the start of the filename, e.g. '/bin/sh'
         # Immediately preceding is a NULL-terminated environment variable string.
         # We want to find the beginning of it
-        address = self.at_execfn-1
+        if self.at_execfn:
+            address = self.at_execfn-1
+        else:
+            log.debug('No AT_EXECFN')
+            address = stack.stop
+            address -= 2*self.bytes
+            address -= 1
+            address = stack.rfind('\x00', None, address)
+            address += 1
 
         # Sanity check!
         try:
-            assert self.u8(address) == 0
+            assert stack[address] == '\x00'
         except AssertionError:
             # Something weird is happening.  Just don't touch it.
+            log.debug("Something is weird")
             return
         except ValueError:
             # If the stack is not actually present in the coredump, we can't
             # read from the stack.  This will fail as:
             # ValueError: 'seek out of range'
+            log.debug("ValueError")
             return
 
-        # Find the next NULL, which is 1 byte past the environment variable.
-        while self.u8(address-1) != 0:
-            address -= 1
+        # address is currently set to the NULL terminator of the last
+        # environment variable.
+        address = stack.rfind('\x00', None, address)
 
         # We've found the beginning of the last environment variable.
         # We should be able to search up the stack for the envp[] array to
         # find a pointer to this address, followed by a NULL.
-        last_env_addr = address
-        address &= ~(context.bytes-1)
+        last_env_addr = address + 1
+        p_last_env_addr = stack.find(pack(last_env_addr), None, last_env_addr)
 
-        while self.unpack(address) != last_env_addr:
-            address -= context.bytes
-
-        assert self.unpack(address+context.bytes) == 0
+        # Sanity check that we did correctly find the envp NULL terminator.
+        envp_nullterm = p_last_env_addr+context.bytes
+        assert self.unpack(envp_nullterm) == 0
 
         # We've successfully located the end of the envp[] array.
+        #
         # It comes immediately after the argv[] array, which itself
         # is NULL-terminated.
-        end_of_envp = address+context.bytes
+        #
+        # Now let's find the end of argv
+        p_end_of_argv = stack.rfind(pack(0), None, p_last_env_addr)
 
-        while self.unpack(address - context.bytes) != 0:
-            address -= context.bytes
+        start_of_envp = p_end_of_argv + self.bytes
 
-        start_of_envp = address
+        # Now we can fill in the environment
+        env_pointer_data = stack[start_of_envp:p_last_env_addr+self.bytes]
+        for pointer in unpack_many(env_pointer_data):
+            end = stack.find('=', last_env_addr)
 
-        # Now we can fill in the environment easier.
-        for env in range(start_of_envp, end_of_envp, context.bytes):
-            envaddr = self.unpack(env)
-            value   = self.string(envaddr)
-            name, value = value.split('=', 1)
-            self.env[name] = envaddr + len(name) + 1
+            if pointer in stack and end in stack:
+                name = stack[pointer:end]
+                self.env[name] = pointer
+
+        # May as well grab the arguments off the stack as well.
+        # argc comes immediately before argv[0] on the stack, but
+        # we don't know what argc is.
+        #
+        # It is unlikely that argc is a valid stack address.
+        address = p_end_of_argv - self.bytes
+        while self.unpack(address) in stack:
+            address -= self.bytes
+
+        # address now points at argc
+        self.argc = self.unpack(address)
+
+        # we can extract all of the arguments as well
+        self.argv = unpack_many(stack[address + self.bytes: p_end_of_argv])
 
     @property
     def maps(self):
@@ -514,6 +898,9 @@ class Corefile(ELF):
     @property
     def registers(self):
         """:class:`dict`: All available registers in the coredump."""
+        if not self.prstatus:
+            return {}
+
         rv = {}
 
         for k in dir(self.prstatus.pr_reg):
@@ -527,6 +914,14 @@ class Corefile(ELF):
 
         return rv
 
+    def debug(self, *a, **kw):
+        """Open the corefile under a debugger."""
+        if a or kw:
+            log.error("Arguments are not supported for %s.debug()" % self.__class__.__name__)
+
+        import pwnlib.gdb
+        pwnlib.gdb.attach(self, exe=self.exe.path)
+
     def __getattr__(self, attribute):
         if self.prstatus:
             if hasattr(self.prstatus, attribute):
@@ -535,6 +930,362 @@ class Corefile(ELF):
             if hasattr(self.prstatus.pr_reg, attribute):
                 return getattr(self.prstatus.pr_reg, attribute)
 
-        return super(Core, self).__getattribute__(attribute)
+        return super(Corefile, self).__getattribute__(attribute)
 
-Core = Corefile
+class Core(Corefile):
+    """Alias for :class:`.Corefile`"""
+
+class Coredump(Corefile):
+    """Alias for :class:`.Corefile`"""
+
+class CorefileFinder(object):
+    def __init__(self, proc):
+        if proc.poll() is None:
+            log.error("Process %i has not exited" % (process.pid))
+
+        self.process = proc
+        self.pid = proc.pid
+        self.uid = proc.suid
+        self.gid = proc.sgid
+        self.exe = proc.executable
+        self.basename = os.path.basename(self.exe)
+        self.cwd = proc.cwd
+
+        # XXX: Should probably break out all of this logic into
+        #      its own class, so that we can support "file ops"
+        #      locally, via SSH, and over ADB, in a transparent way.
+        if isinstance(proc, process):
+            self.read = read
+            self.unlink = os.unlink
+        elif isinstance(proc, ssh_channel):
+            self.read = proc.parent.read
+            self.unlink = proc.parent.unlink
+
+        self.kernel_core_pattern = self.read('/proc/sys/kernel/core_pattern').strip()
+        self.kernel_core_uses_pid = bool(int(self.read('/proc/sys/kernel/core_uses_pid')))
+
+        log.debug("core_pattern: %r" % self.kernel_core_pattern)
+        log.debug("core_uses_pid: %r" % self.kernel_core_uses_pid)
+
+        self.interpreter = self.binfmt_lookup()
+
+        log.debug("interpreter: %r" % self.interpreter)
+
+        # If we have already located the corefile, we will
+        # have renamed it to 'core.<pid>'
+        core_path = 'core.%i' % (proc.pid)
+        self.core_path = None
+
+        if os.path.isfile(core_path):
+            log.debug("Found core immediately: %r" % core_path)
+            self.core_path = core_path
+
+        # Check for native coredumps if we don't 100% know the target
+        # is running under qemu-user emulation.
+        if not self.core_path:
+            log.debug("Looking for native corefile")
+            self.core_path = self.native_corefile()
+
+        # If we still have not found the corefile, the process may have
+        # been running under qemu-user emulation and we just can't tell
+        # (e.g. can't enumerate binfmt_misc in a Docker container).
+        if not self.core_path:
+            log.debug("Looking for QEMU corefile")
+            self.core_path = self.qemu_corefile()
+
+        if not self.core_path:
+            return
+
+        core_pid = self.load_core_check_pid()
+
+        # Move the corefile if we're configured that way
+        if context.rename_corefiles:
+            new_path = 'core.%i' % core_pid
+            if core_pid > 0 and new_path != self.core_path:
+                write(new_path, self.read(self.core_path))
+                self.core_path = new_path
+
+        # Check the PID
+        if core_pid != self.pid:
+            log.warn("Corefile PID does not match! (got %i)" % core_pid)
+
+        # Register the corefile for removal only if it's an exact match
+        elif context.delete_corefiles:
+            atexit.register(lambda: os.unlink(self.core_path))
+
+
+    def load_core_check_pid(self):
+        """Test whether a Corefile matches our process
+
+        Speculatively load a Corefile without informing the user, so that we
+        can check if it matches the process we're looking for.
+
+        Arguments:
+            path(str): Path to the corefile on disk
+
+        Returns:
+            `bool`: ``True`` if the Corefile matches, ``False`` otherwise.
+        """
+
+        try:
+            with context.quiet:
+                with tempfile.NamedTemporaryFile() as tmp:
+                    tmp.write(self.read(self.core_path))
+                    tmp.flush()
+                    return Corefile(tmp.name).pid
+        except Exception:
+            pass
+
+        return -1
+
+    def apport_corefile(self):
+        """Find the apport crash for the process, and extract the core file.
+
+        Arguments:
+            process(process): Process object we're looking for.
+
+        Returns:
+            `str`: Raw core file contents
+        """
+        crash_data = self.apport_read_crash_data()
+
+        log.debug("Apport Crash Data:\n%s" % crash_data)
+
+        if crash_data:
+            return self.apport_crash_extract_corefile(crash_data)
+
+    def apport_crash_extract_corefile(self, crashfile_data):
+        """Extract a corefile from an apport crash file contents.
+
+        Arguments:
+            crashfile_data(str): Crash file contents
+
+        Returns:
+            `str`: Raw binary data for the core file, or ``None``.
+        """
+        file = StringIO.StringIO(crashfile_data)
+
+        # Find the pid of the crashfile
+        for line in file:
+            if line.startswith(' Pid:'):
+                pid = int(line.split()[-1])
+
+                if pid == self.pid:
+                    break
+        else:
+            # Could not find a " Pid:" line
+            return
+
+        # Find the CoreDump section
+        for line in file:
+            if line.startswith('CoreDump: base64'):
+                break
+        else:
+            # Could not find the coredump data
+            return
+
+        # Get all of the base64'd lines
+        chunks = []
+        for line in file:
+            if not line.startswith(' '):
+                break
+            chunks.append(b64d(line))
+
+        # Smush everything together, then extract it
+        compressed_data = ''.join(chunks)
+        compressed_file = StringIO.StringIO(compressed_data)
+        gzip_file = gzip.GzipFile(fileobj=compressed_file)
+        core_data = gzip_file.read()
+
+        return core_data
+
+    def apport_read_crash_data(self):
+        """Find the apport crash for the process
+
+        Returns:
+            `str`: Raw contents of the crash file or ``None``.
+        """
+        uid = self.uid
+        crash_name = self.exe.replace('/', '_')
+
+        crash_path = '/var/crash/%s.%i.crash' % (crash_name, uid)
+
+        try:
+            log.debug("Looking for Apport crash at %r" % crash_path)
+            data = self.read(crash_path)
+        except Exception:
+            return None
+
+        # Remove the crash file, so that future crashes will be captured
+        try:
+            self.unlink(crash_path)
+        except Exception:
+            pass
+
+        return data
+
+    def native_corefile(self):
+        """Find the corefile for a native crash.
+
+        Arguments:
+            process(process): Process whose crash we should find.
+
+        """
+        if self.kernel_core_pattern.startswith('|'):
+            log.debug("Checking for corefile (piped)")
+            return self.native_corefile_pipe()
+
+        log.debug("Checking for corefile (pattern)")
+        return self.native_corefile_pattern()
+
+    def native_corefile_pipe(self):
+        """native_corefile_pipe(self) -> str
+        """
+        # We only support apport
+        if '/apport' not in self.kernel_core_pattern:
+            log.warn_once("Unsupported core_pattern: %r" % self.kernel_core_pattern)
+            return None
+
+        apport_core = self.apport_corefile()
+
+        if apport_core:
+            # Write the corefile to the local directory
+            filename = 'core.%s.%i.apport' % (self.basename, self.pid)
+            with open(filename, 'wb+') as f:
+                f.write(apport_core)
+            return filename
+
+        # Pretend core_pattern was just 'core', and see if we come up with anything
+        self.kernel_core_pattern = 'core'
+        return self.native_corefile_pattern()
+
+    def native_corefile_pattern(self):
+        """
+        %%  a single % character
+        %c  core file size soft resource limit of crashing process (since Linux 2.6.24)
+        %d  dump mode—same as value returned by prctl(2) PR_GET_DUMPABLE (since Linux 3.7)
+        %e  executable filename (without path prefix)
+        %E  pathname of executable, with slashes ('/') replaced by exclamation marks ('!') (since Linux 3.0).
+        %g  (numeric) real GID of dumped process
+        %h  hostname (same as nodename returned by uname(2))
+        %i  TID of thread that triggered core dump, as seen in the PID namespace in which the thread resides (since Linux 3.18)
+        %I  TID of thread that triggered core dump, as seen in the initial PID namespace (since Linux 3.18)
+        %p  PID of dumped process, as seen in the PID namespace in which the process resides
+        %P  PID of dumped process, as seen in the initial PID namespace (since Linux 3.12)
+        %s  number of signal causing dump
+        %t  time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC)
+        %u  (numeric) real UID of dumped process
+        """
+        replace = {
+            '%%': '%',
+            '%e': self.basename,
+            '%E': self.exe.replace('/', '!'),
+            '%g': str(self.gid),
+            '%h': socket.gethostname(),
+            '%i': str(self.pid),
+            '%I': str(self.pid),
+            '%p': str(self.pid),
+            '%P': str(self.pid),
+            '%s': str(-self.process.poll()),
+            '%u': str(self.uid)
+        }
+        replace = dict((re.escape(k), v) for k, v in replace.iteritems())
+        pattern = re.compile("|".join(replace.keys()))
+        core_pattern = self.kernel_core_pattern
+        corefile_path = pattern.sub(lambda m: replace[re.escape(m.group(0))], core_pattern)
+
+        if self.kernel_core_uses_pid:
+            corefile_path += '.%i' % self.pid
+
+        if os.pathsep not in corefile_path:
+            corefile_path = os.path.join(self.cwd, corefile_path)
+
+        log.debug("Trying corefile_path: %r" % corefile_path)
+
+        try:
+            self.read(corefile_path)
+            return corefile_path
+        except Exception as e:
+            log.debug("No dice: %s" % e)
+
+    def qemu_corefile(self):
+        """qemu_corefile() -> str
+
+        Retrieves the path to a QEMU core dump.
+        """
+
+        # QEMU doesn't follow anybody else's rules
+        # https://github.com/qemu/qemu/blob/stable-2.6/linux-user/elfload.c#L2710-L2744
+        #
+        #     qemu_<basename-of-target-binary>_<date>-<time>_<pid>.core
+        #
+        # Note that we don't give any fucks about the date and time, since the PID
+        # should be unique enough that we can just glob.
+        corefile_name = 'qemu_{basename}_*_{pid}.core'
+
+        # Format the name
+        corefile_name = corefile_name.format(basename=self.basename,
+                                             pid=self.pid)
+
+        # Get the full path
+        corefile_path = os.path.join(self.cwd, corefile_name)
+
+        log.debug("Trying corefile_path: %r" % corefile_path)
+
+        # Glob all of them, return the *most recent* based on numeric sort order.
+        for corefile in sorted(glob.glob(corefile_path), reverse=True):
+            return corefile
+
+    def binfmt_lookup(self):
+        """Parses /proc/sys/fs/binfmt_misc to find the interpreter for a file"""
+
+        binfmt_misc = '/proc/sys/fs/binfmt_misc'
+
+        if not isinstance(self.process, process):
+            log.debug("Not a process")
+            return ''
+
+        if self.process._qemu:
+            return self.process._qemu
+
+        if not os.path.isdir(binfmt_misc):
+            log.debug("No binfmt_misc dir")
+            return ''
+
+        exe_data = bytearray(self.read(self.exe))
+
+        for entry in os.listdir(binfmt_misc):
+            keys = {}
+
+            path = os.path.join(binfmt_misc, entry)
+
+            try:
+                data = self.read(path)
+            except Exception:
+                continue
+
+            for line in data.splitlines():
+                try:
+                    k,v = line.split(None)
+                except ValueError:
+                    continue
+
+                keys[k] = v
+
+            if 'magic' not in keys:
+                continue
+
+            magic = bytearray(unhex(keys['magic']))
+            mask  = bytearray('\xff' * len(magic))
+
+            if 'mask' in keys:
+                mask = bytearray(unhex(keys['mask']))
+
+            for i, mag in enumerate(magic):
+                if exe_data[i] & mask[i] != mag:
+                    break
+            else:
+                return keys['interpreter']
+
+        return ''
+


### PR DESCRIPTION
Adds a large amount of functionality around Corefiles, to support smarter exploitation

Adds a ".corefile" property to both local and remote (ssh) processes.  See the
documentation for the corefile module for extensive examples and tests.

Additionally, context.delete_corefiles and context.rename_corefiles have been added,
to control the behavior of the ".corefile" property.
