### PR TITLE
Fix hexdump regression in 3.3.1

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -673,6 +673,7 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
 
         # Chunk is unique, no longer skipping
         skipping = False
+        last_unique = chunk
 
         # Generate contents for line
         hexbytes = ''


### PR DESCRIPTION
Whoops.  Fixed on regression, added another.  Accidentally removed code folding entirely.  Not sure if I'm just dumb, or some .pyc weirdness made things appear to work.

This is why we need tests, I just don't want to rewrite hexdump (again!) to make them viable.