### PR TITLE
Add build-essential and pip upgrade to installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Most of the functionality of pwntools is self-contained and Python-only.  You sh
 
 ```sh
 apt-get update
-apt-get install python2.7 python-pip python-dev git libssl-dev libffi-dev
+apt-get install python2.7 python-pip python-dev git libssl-dev libffi-dev build-essential
+pip install --upgrade pip
 pip install --upgrade pwntools
 ```
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,7 +25,8 @@ pwntools is available as a ``pip`` package.
 .. code-block:: bash
 
     $ apt-get update
-    $ apt-get install python2.7 python-pip python-dev git libssl-dev libffi-dev
+    $ apt-get install python2.7 python-pip python-dev git libssl-dev libffi-dev build-essential
+    $ pip install --upgrade pip
     $ pip install --upgrade pwntools
 
 Development


### PR DESCRIPTION
Ubuntu Precise installs the wrong version of pwntools without upgrading pip first.

Ubuntu Precise also doesn't have `make` installed with our set of dependencies, so add `build-essential`.