### PR TITLE
Fix register usage in execve shellcode

### DIFF
--- a/pwnlib/shellcraft/templates/amd64/android/execve.asm
+++ b/pwnlib/shellcraft/templates/amd64/android/execve.asm
@@ -32,16 +32,15 @@ Example:
 if isinstance(envp, dict):
     envp = ['%s=%s' % (k,v) for (k,v) in envp.items()]
 
-args_reg = abi.register_arguments[2]
-env_reg  = abi.register_arguments[3]
+regs = abi.register_arguments
 %>
 % if isinstance(argv, (list, tuple)):
-    ${amd64.pushstr_array(abi.register_arguments[3], argv)}
-    <% argv = abi.register_arguments[3] %>
+    ${amd64.pushstr_array(regs[2], argv)}
+    <% argv = regs[2] %>
 % endif
 % if isinstance(envp, (list, tuple)):
-    ${amd64.pushstr_array(abi.register_arguments[2], envp)}
-    <% envp = abi.register_arguments[2] %>
+    ${amd64.pushstr_array(regs[3], envp)}
+    <% envp = regs[3] %>
 % endif
 % if isinstance(path, str) and not registers.is_register(path):
     ${amd64.pushstr(path)}

--- a/pwnlib/shellcraft/templates/amd64/linux/execve.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/execve.asm
@@ -32,16 +32,15 @@ Example:
 if isinstance(envp, dict):
     envp = ['%s=%s' % (k,v) for (k,v) in envp.items()]
 
-args_reg = abi.register_arguments[2]
-env_reg  = abi.register_arguments[3]
+regs = abi.register_arguments
 %>
 % if isinstance(argv, (list, tuple)):
-    ${amd64.pushstr_array(abi.register_arguments[3], argv)}
-    <% argv = abi.register_arguments[3] %>
+    ${amd64.pushstr_array(regs[2], argv)}
+    <% argv = regs[2] %>
 % endif
 % if isinstance(envp, (list, tuple)):
-    ${amd64.pushstr_array(abi.register_arguments[2], envp)}
-    <% envp = abi.register_arguments[2] %>
+    ${amd64.pushstr_array(regs[3], envp)}
+    <% envp = regs[3] %>
 % endif
 % if isinstance(path, str) and not registers.is_register(path):
     ${amd64.pushstr(path)}

--- a/pwnlib/shellcraft/templates/i386/android/execve.asm
+++ b/pwnlib/shellcraft/templates/i386/android/execve.asm
@@ -31,14 +31,16 @@ Example:
 <%
 if isinstance(envp, dict):
     envp = ['%s=%s' % (k,v) for (k,v) in envp.items()]
+
+regs = abi.register_arguments
 %>
 % if isinstance(argv, (list, tuple)):
-    ${i386.pushstr_array(abi.register_arguments[3], argv)}
-    <% argv = abi.register_arguments[3] %>
+    ${i386.pushstr_array(regs[2], argv)}
+    <% argv = regs[2] %>
 % endif
 % if isinstance(envp, (list, tuple)):
-    ${i386.pushstr_array(abi.register_arguments[2], envp)}
-    <% envp = abi.register_arguments[2] %>
+    ${i386.pushstr_array(regs[3], envp)}
+    <% envp = regs[3] %>
 % endif
 % if isinstance(path, str) and not registers.is_register(path):
     ${i386.pushstr(path)}

--- a/pwnlib/shellcraft/templates/i386/linux/execve.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/execve.asm
@@ -31,14 +31,15 @@ Example:
 <%
 if isinstance(envp, dict):
     envp = ['%s=%s' % (k,v) for (k,v) in envp.items()]
+regs = abi.register_arguments
 %>
 % if isinstance(argv, (list, tuple)):
-    ${i386.pushstr_array(abi.register_arguments[3], argv)}
-    <% argv = abi.register_arguments[3] %>
+    ${i386.pushstr_array(regs[2], argv)}
+    <% argv = regs[2] %>
 % endif
 % if isinstance(envp, (list, tuple)):
-    ${i386.pushstr_array(abi.register_arguments[2], envp)}
-    <% envp = abi.register_arguments[2] %>
+    ${i386.pushstr_array(regs[3], envp)}
+    <% envp = regs[3] %>
 % endif
 % if isinstance(path, str) and not registers.is_register(path):
     ${i386.pushstr(path)}

--- a/pwnlib/shellcraft/templates/mips/linux/execve.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/execve.asm
@@ -31,14 +31,16 @@ Example:
 <%
 if isinstance(envp, dict):
     envp = ['%s=%s' % (k,v) for (k,v) in envp.items()]
+
+regs = abi.register_arguments
 %>
 % if isinstance(argv, (list, tuple)):
-    ${mips.pushstr_array(abi.register_arguments[3], argv)}
-    <% argv = abi.register_arguments[3] %>
+    ${mips.pushstr_array(regs[2], argv)}
+    <% argv = regs[2] %>
 % endif
 % if isinstance(envp, (list, tuple)):
-    ${mips.pushstr_array(abi.register_arguments[2], envp)}
-    <% envp = abi.register_arguments[2] %>
+    ${mips.pushstr_array(regs[3], envp)}
+    <% envp = regs[3] %>
 % endif
 % if isinstance(path, str) and not registers.is_register(path):
     ${mips.pushstr(path)}


### PR DESCRIPTION
The previous code worked, but we emitted a register swap that hid the fact we were using the wrong registers.

Here's the change in emitted code for i386.  Ultimately, the only real difference is that we don't need the `xchg` at the end anymore.

```
$ diff -U100 --word-diff a b
diff --git a/a b/b
index 8df4cedb..bab30d41 100644
--- a/a
+++ b/b
@@ -1,37 +1,36 @@
    /* push argument array ['sh\x00'] */
    /* push 'sh\x00\x00' */
    push 0x1010101
    xor dword ptr [esp], 0x1016972
    xor [-edx, edx-]{+ecx, ecx+}
    push [-edx-]{+ecx+} /* null terminate */
    push 4
    pop [-edx-]{+ecx+}
    add [-edx,-]{+ecx,+} esp
    push [-edx-]{+ecx+} /* 'sh\x00' */
    mov [-edx,-]{+ecx,+} esp

    /* push argument array ['PATH=/usr/bin\x00'] */
    /* push 'PATH=/usr/bin\x00\x00' */
    push 0x6e
    push 0x69622f72
    push 0x73752f3d
    push 0x48544150
    xor [-ecx, ecx-]{+edx, edx+}
    push [-ecx-]{+edx+} /* null terminate */
    push 4
    pop [-ecx-]{+edx+}
    add [-ecx,-]{+edx,+} esp
    push [-ecx-]{+edx+} /* 'PATH=/usr/bin\x00' */
    mov [-ecx,-]{+edx,+} esp

    /* push 'sh\x00' */
    push 0x1010101
    xor dword ptr [esp], 0x1016972

    /* call execve('esp', [-'edx', 'ecx')-]{+'ecx', 'edx')+} */
    push (SYS_execve) /* 0xb */
    pop eax
    mov ebx, esp
[-    xchg ecx, edx-]
    int 0x80
```

Fixes Gallopsled/pwntools#856