### PR TITLE
Fix chunked reading of ELF files

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -212,8 +212,8 @@ Stop hard-coding things!  Look them up at runtime with :mod:`pwnlib.elf`.
 You can even patch and save the files.
 
     >>> e = ELF('/bin/cat')
-    >>> e.read(e.address+1, 3)
-    'ELF'
+    >>> e.read(e.address, 4)
+    '\x7fELF'
     >>> e.asm(e.address, 'ret')
     >>> e.save('/tmp/quiet-cat')
     >>> disasm(file('/tmp/quiet-cat','rb').read(1))

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ install_requires     = ['paramiko>=1.15.2',
                         'python-dateutil',
                         'pypandoc',
                         'packaging',
-                        'psutil>=3.3.0']
+                        'psutil>=3.3.0',
+                        'intervaltree']
 
 # Check that the user has installed the Python development headers
 PythonH = os.path.join(get_python_inc(), 'Python.h')

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -8,52 +8,43 @@ local_deb_extract()
     rm -f *.tar.* *deb*
 }
 
-get_binutils()
+install_deb()
 {
-    BINUTILS_PREFIX='https://launchpad.net/~pwntools/+archive/ubuntu/binutils/+files/binutils-'
-    BINUTILS_SUFFIX='-linux-gnu_2.22-6ubuntu1.1cross0.11pwntools12~precise_amd64.deb'
-    local_deb_extract "${BINUTILS_PREFIX}${1}${BINUTILS_SUFFIX}"
-}
-
-get_qemu()
-{
-    echo "Installing qemu"
-    QEMU_INDEX='http://packages.ubuntu.com/en/yakkety/amd64/qemu-user-static/download'
-    QEMU_URL=$(curl "$QEMU_INDEX" | grep kernel.org | grep -Eo 'http.*\.deb')
-    local_deb_extract "$QEMU_URL"
+    version=zesty
+    package=$1
+    echo "Installing $package"
+    INDEX="http://packages.ubuntu.com/en/$version/amd64/$package/download"
+    URL=$(curl "$INDEX" | grep -Eo "https?://.*$package.*\.deb" | head -1)
+    local_deb_extract "$URL"
 }
 
 setup_travis()
 {
     export PATH=$PWD/usr/bin:$PATH
-    export LD_LIBRARY_PATH=$PWD/usr/lib
+    export LD_LIBRARY_PATH=$PWD/usr/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$PWD/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
-    # Install libbfd-multiarch and libopcodes-multiarch if not found in the cache
-    if [ ! -f usr/lib/libbfd-2.22-multiarch.so ];
-    then
-        # Install the multiarch binutils
-        local_deb_extract http://mirrors.mit.edu/ubuntu/pool/universe/b/binutils/binutils-multiarch_2.22-6ubuntu1_amd64.deb
-        pushd usr/lib
-        ln -sf libbfd-2.22-multiarch.so libbfd-2.22.so
-        ln -sf libopcodes-2.22-multiarch.so libopcodes-2.22.so
-        popd
-    fi
+    # Install a more modern binutils, which is required for some of the tests
+    [[ -f usr/bin/objcopy ]] || install_deb binutils
 
     # Install/upgrade qemu
-    if ! (which qemu-arm-static && qemu-arm-static -version | grep 2.6.1); then
-        get_qemu
-    fi
+    [[ -f usr/bin/qemu-arm-static ]] || install_deb qemu-user-static
 
-    # Install our custom binutils
-    which arm-linux-gnu-as     || get_binutils arm
-    which mips-linux-gnu-as    || get_binutils mips
-    which powerpc-linux-gnu-as || get_binutils powerpc
+    # Install cross-binutils
+    [[ -f usr/bin/x86_64-linux-gnu-ar ]]    || install_deb binutils-multiarch
+    [[ -f usr/bin/aarch64-linux-gnu-as ]]   || install_deb binutils-aarch64-linux-gnu
+    [[ -f usr/bin/arm-linux-gnueabihf-as ]] || install_deb binutils-arm-linux-gnueabihf
+    [[ -f usr/bin/mips-linux-gnu-as ]]      || install_deb binutils-mips-linux-gnu
+    [[ -f usr/bin/powerpc-linux-gnu-as ]]   || install_deb binutils-powerpc-linux-gnu
 
     # Test that the installs worked
-    which arm-linux-gnu-as
-    which mips-linux-gnu-as
-    which powerpc-linux-gnu-as
-    which qemu-arm-static
+    as                      --version
+    x86_64-linux-gnu-ar     --version
+    aarch64-linux-gnu-as    --version
+    arm-linux-gnueabihf-as  --version
+    mips-linux-gnu-as       --version
+    powerpc-linux-gnu-as    --version
+    qemu-arm-static         --version
 
     # Get rid of files we don't want cached
     rm -rf usr/share


### PR DESCRIPTION
This introduces a new dependency on 'intervaltree', which is used
to automatically select segments which are relevant for a given
virtual-address range.

This also introduces a new ELF.memory attribute, which is the tree
of memory ranges, which point at the segment objects that describe
the memory range.

These are recalculated when ELF.address is adjusted, and we have
tests for that.

This also optimizes some of the other routines to avoid the wrapped
file-seeking, and to just use the mmap.

Fixes Gallopsled/pwntools#864