### PR TITLE
sh_string should return '' for empty strings

### DIFF
--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -389,6 +389,9 @@ def sh_string(s):
     if '\x00' in s:
         log.error("sh_string(): Cannot create a null-byte")
 
+    if s == '':
+        return "''"
+
     chars = set(s)
     very_good = set(string.ascii_letters + string.digits + "_+.,/")
 


### PR DESCRIPTION
The current logic returns an empty string, which is technically correct (the best kind of correct), but in practice it's needed to pass empty strings on `argv`.