### PR TITLE
Add pwnlib.config module and documentation

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,0 +1,4 @@
+:mod:`pwnlib.config` --- Pwntools Configuration File
+====================================================
+
+.. automodule:: pwnlib.config

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,6 +48,7 @@ Each of the ``pwntools`` modules is documented here.
    atexception
    atexit
    constants
+   config
    context
    dynelf
    encoders

--- a/pwn/__init__.py
+++ b/pwn/__init__.py
@@ -5,6 +5,7 @@ from pwn.toplevel import *
 
 pwnlib.args.initialize()
 pwnlib.log.install_default_handler()
+pwnlib.config.initialize()
 
 log = pwnlib.log.getLogger('pwnlib.exploit')
 args = pwnlib.args.args

--- a/pwnlib/config.py
+++ b/pwnlib/config.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Allows per-user and per-host configuration of Pwntools settings.
+
+The list of configurable options includes all of the logging symbols
+and colors, as well as all of the default values on the global context
+object.
+
+The configuration file is read from ``~/.pwn.conf`` and ``/etc/pwn.conf``.
+
+The configuration file is only read in ``from pwn import *`` mode, and not
+when used in library mode (``import pwnlib``).  To read the configuration
+file in library mode, invoke :func:`.config.initialize`.
+
+The ``context`` section supports complex types, at least as far as is
+supported by ``pwnlib.util.safeeval.expr``.
+
+::
+
+    [log]
+    success.symbol=😎
+    error.symbol=☠
+    info.color=blue
+
+    [context]
+    adb_port=4141
+    randomize=1
+    timeout=60
+    terminal=['x-terminal-emulator', '-e']
+"""
+from __future__ import absolute_import
+
+import ConfigParser
+import os
+
+registered_configs = {}
+
+def register_config(section, function):
+    """Registers a configuration section.
+
+    Arguments:
+        section(str): Named configuration section
+        function(callable): Function invoked with a dictionary of
+            ``{option: value}`` for the entries in the section.
+    """
+    registered_configs[section] = function
+
+def initialize():
+    """Read the configuration files."""
+    from pwnlib.log import getLogger
+    log = getLogger(__name__)
+
+    c = ConfigParser.ConfigParser()
+    c.read(['/etc/pwn.conf', os.path.expanduser('~/.pwn.conf')])
+
+    for section in c.sections():
+        if section not in registered_configs:
+            log.warn("Unknown configuration section %r" % section)
+            continue
+        settings = dict(c.items(section))
+        registered_configs[section](settings)


### PR DESCRIPTION
This adds functionality for user configuration files at ~/.pwn.conf
and /etc/pwn.conf.  Previously this was only used by the pwnlib.log
module, and was entirely undocumented.

This is now documented, and offers an easy mechanism for other parts
of the code to have extension points.

An example configuration might look like:

```
[log]
success.symbol=😎
error.symbol=☠
info.color=blue

[context]
adb_port=4141
randomize=1
timeout=60
terminal=['x-terminal-emulator', '-e']
```