### PR TITLE
Do not fail with gdb.debug() over ssh when given an absolute path

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -226,7 +226,7 @@ def debug(args, execute=None, exe=None, ssh=None, env=None, **kwargs):
     if not ssh and context.os == 'android':
         host = context.adb_host
 
-    attach((host, port), exe=exe, execute=execute, need_ptrace_scope = False)
+    attach((host, port), exe=exe, execute=execute, need_ptrace_scope = False, ssh=ssh)
 
     # gdbserver outputs a message when a client connects
     garbage = gdbserver.recvline(timeout=1)
@@ -247,8 +247,8 @@ def get_gdb_arch():
 
 
 @LocalContext
-def attach(target, execute = None, exe = None, need_ptrace_scope = True):
-    """attach(target, execute = None, exe = None, arch = None) -> None
+def attach(target, execute = None, exe = None, need_ptrace_scope = True, ssh = None):
+    """attach(target, execute = None, exe = None, arch = None, ssh = None) -> None
 
     Start GDB in a new terminal and attach to `target`.
     :func:`pwnlib.util.proc.pidof` is used to find the PID of `target` except
@@ -401,8 +401,11 @@ def attach(target, execute = None, exe = None, need_ptrace_scope = True):
     cmd += ' -q '
 
     if exe and context.native:
+        if ssh:
+            ssh.download_file(exe)
+            exe = os.path.basename(exe)
         if not os.path.isfile(exe):
-            log.error('no such file: %s' % exe)
+            log.error('No such file: %s' % exe)
         cmd += ' "%s"' % exe
 
     if pid and not context.os == 'android':
@@ -460,7 +463,7 @@ def ssh_gdb(ssh, process, execute = None, arch = None, **kwargs):
     l = tubes.listen.listen(0)
     forwardport = l.lport
 
-    attach(('127.0.0.1', forwardport), execute, local_exe, arch)
+    attach(('127.0.0.1', forwardport), execute, local_exe, arch, ssh=ssh)
     l.wait_for_connection() <> ssh.connect_remote('127.0.0.1', gdbport)
     return c
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -96,7 +96,7 @@ setup_android_emulator()
 
             # However, the file needs to be present or else things break.
             touch 'docs/source/adb.rst'
-            touch 'docs/source/protocols/adb.rst'
+            touch 'docs/source/protocols/adb.rst' || true
 
             echo "Skipping Android emulator install, Android tests disabled."
             return


### PR DESCRIPTION
Fixes Gallopsled/pwntools#885