### PR TITLE
Add 'pwn debug' command-line utility

### DIFF
--- a/pwnlib/commandline/__init__.py
+++ b/pwnlib/commandline/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     'common',
     'constgrep',
     'cyclic',
+    'debug',
     'disasm',
     'elfdiff',
     'elfpatch',

--- a/pwnlib/commandline/debug.py
+++ b/pwnlib/commandline/debug.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python2
+from __future__ import absolute_import
+
+import argparse
+import sys
+
+from pwn import *
+from pwnlib.commandline import common
+
+parser = common.parser_commands.add_parser(
+    'debug',
+    help = 'Debug a binary in GDB'
+)
+parser.add_argument(
+    '-x', metavar='GDBSCRIPT',
+    type=file,
+    help='Execute GDB commands from this file.'
+)
+parser.add_argument(
+    '--pid',
+    type=int,
+    help="PID to attach to"
+)
+parser.add_argument(
+    '-c', '--context',
+    metavar = 'context',
+    action = 'append',
+    type   = common.context_arg,
+    choices = common.choices,
+    help = 'The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: %s' % common.choices,
+)
+parser.add_argument(
+    '--exec', type=file, dest='executable',
+    help='File to debug'
+)
+parser.add_argument(
+    '--process', metavar='PROCESS_NAME',
+    help='Name of the process to attach to (e.g. "bash")'
+)
+
+def main(args):
+    gdbscript = ''
+    if args.x:
+        gdbscript = args.x.read()
+
+    if context.os == 'android':
+        context.device = adb.wait_for_device()
+
+    if args.executable:
+        context.binary = ELF(args.executable.name)
+        target = context.binary.path
+    elif args.pid:
+        target = int(args.pid)
+    elif args.process:
+        if context.os == 'android':
+            target = adb.pidof(process)
+        else:
+            target = pidof(process)
+    else:
+        parser.print_usage()
+        return 1
+
+    if args.pid or args.process:
+        gdb.attach(target, gdbscript=gdbscript)
+    else:
+        gdb.debug(target, gdbscript=gdbscript).interactive()
+
+if __name__ == '__main__':
+    pwnlib.commandline.common.main(__file__)

--- a/pwnlib/commandline/main.py
+++ b/pwnlib/commandline/main.py
@@ -7,6 +7,7 @@ from pwnlib.commandline import checksec
 from pwnlib.commandline import common
 from pwnlib.commandline import constgrep
 from pwnlib.commandline import cyclic
+from pwnlib.commandline import debug
 from pwnlib.commandline import disasm
 from pwnlib.commandline import elfdiff
 from pwnlib.commandline import elfpatch
@@ -26,6 +27,7 @@ commands = {
     'checksec': checksec.main,
     'constgrep': constgrep.main,
     'cyclic': cyclic.main,
+    'debug': debug.main,
     'disasm': disasm.main,
     'elfdiff': elfdiff.main,
     'elfpatch': elfpatch.main,

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -435,6 +435,10 @@ class process(tube):
         # Determine what architecture the binary is, and find the
         # appropriate qemu binary to run it.
         qemu = get_qemu_user(arch=binary.arch)
+
+        if not qemu:
+            raise exception
+
         qemu = which(qemu)
         if qemu:
             self._qemu = qemu


### PR DESCRIPTION
Also fixes a bug in process() which would throw the wrong exception
when qemu-user cannot be located for a non-native binary.
