### PR TITLE
Add "pwn template" command for generating templates

### DIFF
--- a/pwnlib/__init__.py
+++ b/pwnlib/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     'commandline',
     'constants',
     'context',
+    'data',
     'dynelf',
     'encoders',
     'elf',

--- a/pwnlib/args.py
+++ b/pwnlib/args.py
@@ -51,8 +51,12 @@ import sys
 from pwnlib import term
 from pwnlib.context import context
 
+class PwnlibArgs(collections.defaultdict):
+    def __getattr__(self, attr):
+        return self[attr]
+
+args = PwnlibArgs(str)
 term_mode  = True
-args       = collections.defaultdict(str)
 env_prefix = 'PWNLIB_'
 free_form  = True
 

--- a/pwnlib/commandline/main.py
+++ b/pwnlib/commandline/main.py
@@ -17,6 +17,7 @@ from pwnlib.commandline import phd
 from pwnlib.commandline import pwnstrip
 from pwnlib.commandline import scramble
 from pwnlib.commandline import shellcraft
+from pwnlib.commandline import template
 from pwnlib.commandline import unhex
 from pwnlib.commandline import update
 from pwnlib.commandline.common import parser
@@ -37,6 +38,7 @@ commands = {
     'pwnstrip': pwnstrip.main,
     'scramble': scramble.main,
     'shellcraft': shellcraft.main,
+    'template': template.main,
     'unhex': unhex.main,
     'update': update.main,
 }

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python2
+from __future__ import absolute_import
+
+import re
+
+from pwn import *
+from pwnlib.commandline import common
+
+from mako.lookup import TemplateLookup
+
+parser = common.parser_commands.add_parser(
+    'template',
+    help = 'Generate an exploit template'
+)
+
+parser.add_argument('exe', nargs='?', help='Target binary')
+parser.add_argument('--host', help='Remote host / SSH server')
+parser.add_argument('--port', help='Remote port / SSH port')
+parser.add_argument('--user', help='SSH Username')
+parser.add_argument('--pass', help='SSH Password', dest='password')
+parser.add_argument('--path', help='Remote path of file on SSH server')
+
+def main(args):
+    cache = None
+
+    if cache:
+        cache = os.path.join(context.cache_dir, 'mako')
+
+    lookup = TemplateLookup(
+        directories      = [os.path.join(pwnlib.data.path, 'templates')],
+        module_directory = cache
+    )
+
+    template = lookup.get_template('pwnup.mako')
+    output = template.render(args.exe,
+                             args.host,
+                             args.port,
+                             args.user,
+                             args.password,
+                             args.path)
+
+    # Fix Mako formatting bs
+    output = re.sub('\n\n\n', '\n\n', output)
+
+    print output
+
+    if not sys.stdout.isatty():
+        try: os.fchmod(sys.stdout.fileno(), 0700)
+        except OSError: pass
+
+if __name__ == '__main__':
+    pwnlib.commandline.common.main(__file__)

--- a/pwnlib/data/__init__.py
+++ b/pwnlib/data/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+try:
+    # These files are not distributed with Pwntools, but
+    # are in the source tree and used for testing.
+    from pwnlib.data import elf
+except ImportError:
+    pass
+
+import os
+path = os.path.dirname(__file__)
+

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -1,0 +1,130 @@
+<%page args="binary, host=None, port=None, user=None, password=None, remote_path=None"/>\
+<%
+from pwnlib.context import context as ctx
+from pwnlib.elf.elf import ELF
+from elftools.common.exceptions import ELFError
+
+import os
+try:
+    if binary:
+        ctx.binary = ELF(binary, checksec=False)
+except ELFError:
+    pass
+
+if not binary:
+    binary = './path/to/binary'
+
+exe = os.path.basename(binary)
+
+ssh = user or password
+if ssh and not port:
+    port = 22
+elif host and not port:
+    port = 4141
+
+remote_path = remote_path or exe
+password = password or 'secret1234'
+binary_repr = repr(binary)
+%>\
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+from pwn import *
+
+# Set up pwntools for the correct architecture
+%if ctx.binary:
+exe = context.binary = ELF(${binary_repr})
+<% binary_repr = 'exe.path' %>
+%else:
+context.update(arch='i386')
+exe = ${binary_repr}
+<% binary_repr = 'exe' %>
+%endif
+
+# Many built-in settings can be controlled on the command-line and show up
+# in "args".  For example, to dump all data sent/received, and disable ASLR
+# for all created processes...
+# ./exploit.py DEBUG NOASLR
+%if host or port or user:
+# ./exploit.py GDB HOST=example.com PORT=4141
+%endif
+%if host:
+host = args.HOST or ${repr(host)}
+%endif
+%if port:
+port = int(args.PORT or ${port})
+%endif
+%if user:
+user = args.USER or ${repr(user)}
+password = args.PASSWORD or ${repr(password)}
+%endif
+%if ssh:
+remote_path = ${repr(remote_path)}
+%endif
+
+%if exe or remote_path:
+gdbscript = '''
+%if ctx.binary:
+  %if 'main' in ctx.binary.symbols:
+break *0x{exe.symbols.main:x}
+  %else:
+break *0x{exe.entry:x}
+  %endif
+%endif
+continue
+'''.format(**locals())
+%endif
+
+%if ssh:
+shell = None
+if not args.LOCAL:
+    shell = ssh(user, host, port, password)
+    shell.set_working_directory(symlink=True)
+%endif
+
+%if host:
+def local():
+    if args.GDB:
+        return gdb.debug(exe.path, gdbscript=gdbscript)
+    else:
+        return process(exe.path)
+
+def remote():
+  %if ssh:
+    if args.GDB:
+        return gdb.debug(remote_path, gdbscript=gdbscript, ssh=shell)
+    else:
+        return shell.process(remote_path)
+  %else:
+    return connect(host, port)
+  %endif
+%endif
+
+%if host:
+start = local if args.LOCAL else remote
+
+io = start()
+%else:
+if args.GDB:
+    io = gdb.debug(${binary_repr}, gdbscript=gdbscript)
+else:
+    io = process(${binary_repr})
+%endif
+
+%if host and not ssh:
+if args.GDB and not args.LOCAL:
+    gdb.attach(io, gdbscript=gdbscript)
+%endif
+
+#===========================================================
+#                    EXPLOIT GOES HERE
+#===========================================================
+# shellcode = asm(shellcraft.sh())
+# payload = fit({
+#     32: 0xdeadbeef,
+#     'iaaa': [1, 2, 'Hello', 3]
+# }, length=128)
+# io.send(payload)
+# flag = io.recv(...)
+# log.success(flag)
+
+io.interactive()

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -170,7 +170,7 @@ class ELF(ELFFile):
     _fill_gaps = True
 
 
-    def __init__(self, path):
+    def __init__(self, path, checksec=True):
         # elftools uses the backing file for all reads and writes
         # in order to permit writing without being able to write to disk,
         # mmap() the file.
@@ -293,7 +293,8 @@ class ELF(ELFFile):
         self._populate_functions()
         self._populate_kernel_version()
 
-        self._describe()
+        if checksec:
+            self._describe()
 
     @staticmethod
     @LocalContext

--- a/travis/docker/Dockerfile
+++ b/travis/docker/Dockerfile
@@ -134,5 +134,6 @@ RUN mkdir /home/travis/pwntools
 WORKDIR /home/travis/pwntools
 ADD run.sh .
 ADD pwntools.tar.gz .
+RUN sudo pip install --editable .
 RUN sudo chown -R travis .
 ENTRYPOINT bash run.sh


### PR DESCRIPTION
Super useful for quickly stubbing stuff out, and for introducing people to `pwntools` for the first time.

# Any File

This only happens if we get something not-an-ELF, e.g. perhaps the target is a shell-script wrapper around something else.  Note we set context explicitly here.

```py
$ pwn template not-a-valid-elf
#!/usr/bin/env python2
# -*- coding: utf-8 -*-
from pwn import *

# Set up pwntools for the correct architecture
context.update(arch='i386')

gdbscript = '''
continue
'''.format(**locals())

if args.GDB:
    io = gdb.debug('not-a-valid-elf', gdbscript=gdbscript)
else:
    io = process('not-a-valid-elf')

#===========================================================
#                    EXPLOIT GOES HERE
#===========================================================
# shellcode = asm(shellcraft.sh())
# payload = fit({
#     32: 0xdeadbeef,
#     'iaaa': [1, 2, 'Hello', 3]
# }, length=128)
# io.send(payload)
# flag = io.recv(...)
# log.success(flag)

io.interactive()
```

# ELF File

If a valid ELF file is specified, we set the context, and add a breakpoint on either the entry or `main`.

Additionally, we use `gdb.debug()` instead of `gdb.attach()` in case there is a foreign-architecture binary (can't attach to a QEMU-emulated process), and we avoid the question of "How do I debug from the start?".

```py
#!/usr/bin/env python2
# -*- coding: utf-8 -*-
from pwn import *

# Set up pwntools for the correct architecture
exe = context.binary = ELF('vulnerable')


gdbscript = '''
break *0x{exe.entry:x}
continue
'''.format(**locals())


if args.GDB:
    io = gdb.debug(exe, gdbscript=gdbscript)
else:
    io = process(exe)

#===========================================================
#                    EXPLOIT GOES HERE
#===========================================================
...
```

# Remote TCP exploit

Note that we use `args` and inform the user about their options.

Additionally, note that we use `gdb.attach()` for the remote process.

Finally, we use `connect` instead of `remote`.  This makes it so I don't need a better name for `remote`.

```py
$ pwn template vulnerable --host example.com --port 9999
#!/usr/bin/env python2
# -*- coding: utf-8 -*-
from pwn import *

# Set up pwntools for the correct architecture
exe = context.binary = ELF('vulnerable')

# Change any of these or built-in settings settings when running the exploit
# python exploit.py GDB DEBUG NOASLR HOST=example.com PORT=4141
host = args.HOST or 'example.com'
port = int(args.PORT or 9999)

gdbscript = '''
break *0x{exe.entry:x}
continue
'''.format(**locals())

def local():
    if args.GDB:
        return gdb.debug(exe.path, gdbscript=gdbscript)
    else:
        return process(exe.path)

def remote():
    return connect(host, port)

start = local if args.LOCAL else remote

io = start()

if args.GDB and not args.LOCAL:
    gdb.attach(io, gdbscript=gdbscript)

#===========================================================
#                    EXPLOIT GOES HERE
#===========================================================
...
```

# Secure Shell

Again, we use `gdb.debug()` in favor of `gdb.attach()`.

```py
$ pwn template vulnerable --host example.com --user username --password secret1234
#!/usr/bin/env python2
# -*- coding: utf-8 -*-
from pwn import *

# Set up pwntools for the correct architecture
exe = context.binary = ELF('vulnerable')

# Change any of these or built-in settings settings when running the exploit
# python exploit.py GDB DEBUG NOASLR HOST=example.com PORT=4141
host = args.HOST or 'example.com'
port = int(args.PORT or 22)
user = args.USER or 'username'
password = args.PASSWORD or 'secret1234'
remote_path = 'vulnerable'

gdbscript = '''
break *0x{exe.entry:x}
continue
'''.format(**locals())

shell = None
if not args.LOCAL:
    shell = ssh(user, host, port, password)
    shell.set_working_directory(symlink=True)

def local():
    if args.GDB:
        return gdb.debug(exe.path, gdbscript=gdbscript)
    else:
        return process(exe.path)

def remote():
    if args.GDB:
        return gdb.debug(remote_path, gdbscript=gdbscript, ssh=shell)
    else:
        return shell.process(remote_path)

start = local if args.LOCAL else remote

io = start()

#===========================================================
#                    EXPLOIT GOES HERE
#===========================================================
...
```

Closes #680 
Closes #830 

