### PR TITLE
Work around appdirs error for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
   - echo $-
 install:
   - pip install --upgrade pip
+  - pip install --upgrade appdirs # https://github.com/ActiveState/appdirs/issues/89#issuecomment-282326570
   - pip install --upgrade --editable .
   - pip install --upgrade --requirement docs/requirements.txt
 before_script:


### PR DESCRIPTION
Closes Gallopsled/pwntools#921

(Note: With the Amazon S3 outage, Travis builds are failing)