### PR TITLE
Make DynELF more robust to different base addresses

### DIFF
--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -155,6 +155,7 @@ class DynELF(object):
             elf(str,ELF):  Path to the ELF file on disk, or a loaded :class:`pwnlib.elf.ELF`.
         '''
         self._elfclass = None
+        self._elftype  = None
         self._link_map = None
         self._waitfor  = None
         self._bases    = {}
@@ -201,6 +202,22 @@ class DynELF(object):
             self._elfclass =  {constants.ELFCLASS32: 32,
                               constants.ELFCLASS64: 64}[elfclass]
         return self._elfclass
+
+    @property
+    def elftype(self):
+        """e_type from the elf header. In practice the value will almost always
+        be 'EXEC' or 'DYN'. If the value is architecture-specific (between
+        ET_LOPROC and ET_HIPROC) or invalid, KeyError is raised.
+        """
+        if not self._elftype:
+            Ehdr  = {32: elf.Elf32_Ehdr, 64: elf.Elf64_Ehdr}[self.elfclass]
+            elftype = self.leak.field(self.libbase, Ehdr.e_type)
+            self._elftype = {constants.ET_NONE: 'NONE',
+                             constants.ET_REL: 'REL',
+                             constants.ET_EXEC: 'EXEC',
+                             constants.ET_DYN: 'DYN',
+                             constants.ET_CORE: 'CORE'}[elftype]
+        return self._elftype
 
     @property
     def link_map(self):
@@ -354,9 +371,7 @@ class DynELF(object):
         dynamic = leak.field(phead, Phdr.p_vaddr)
         self.status("PT_DYNAMIC @ %#x" % dynamic)
 
-        #Sometimes this is an offset instead of an address
-        if 0 < dynamic < 0x400000:
-            dynamic += base
+        dynamic = self._make_absolute_ptr(dynamic)
 
         return dynamic
 
@@ -390,9 +405,7 @@ class DynELF(object):
         self.status("Found %s at %#x" % (name, dynamic))
         ptr = leak.field(dynamic, Dyn.d_ptr)
 
-        # Sometimes this is an offset rather than an actual pointer.
-        if 0 < ptr < 0x400000:
-            ptr += self.libbase
+        ptr = self._make_absolute_ptr(ptr)
 
         return ptr
 
@@ -436,8 +449,7 @@ class DynELF(object):
             w.failure("Could not find DT_PLTGOT or DT_DEBUG")
             return None
 
-        if 0 < result < 0x400000:
-            result += self.libbase
+        result = self._make_absolute_ptr(result)
 
         w.success('%#x' % result)
         return result
@@ -670,11 +682,9 @@ class DynELF(object):
         if not all([strtab, symtab, hshtab]):
             self.failure("Could not find all tables")
 
-        # glibc pointers are relocated but uclibc are not
-        if 0 < strtab < 0x400000:
-            strtab  += self.libbase
-            symtab  += self.libbase
-            hshtab  += self.libbase
+        strtab = self._make_absolute_ptr(strtab)
+        symtab = self._make_absolute_ptr(symtab)
+        hshtab = self._make_absolute_ptr(hshtab)
 
         #
         # Perform the hash lookup
@@ -840,6 +850,29 @@ class DynELF(object):
             else:
                 self.status("Magic did not match")
                 pass
+
+    def _make_absolute_ptr(self, ptr_or_offset):
+        """For shared libraries (or PIE executables), many ELF fields may
+        contain offsets rather than actual pointers. If the ELF type is 'DYN',
+        the argument may be an offset. It will not necessarily be an offset,
+        because the run-time linker may have fixed it up to be a real pointer
+        already. In this case an educated guess is made, and the ELF base
+        address is added to the value if it is determined to be an offset.
+        """
+        if_ptr = ptr_or_offset
+        if_offset = ptr_or_offset + self.libbase
+
+        # if the ELF type is not DYN, the value is a pointer
+
+        if self.elftype != 'DYN':
+            return if_ptr
+
+        # if the ELF type may be DYN, guess
+
+        if 0 < ptr_or_offset < self.libbase:
+            return if_offset
+        else:
+            return if_ptr
 
     def stack(self):
         """Finds a pointer to the stack via __environ, which is an exported


### PR DESCRIPTION
The semantics of some fields in ELF headers (notable examples are the entry point, p_vaddr for PHDRs, and d_ptr in Elf{32,64}_Dyn, but there are probably more) depend on the ELF Type. 'EXEC' type ELFs (non-PIE executables) will use actual addresses, while 'DYN' type ELFs (shared libraries or PIE executables) will use offsets from the ELF base address. However, the run-time linker may then fix up these offsets to be real addresses. Currently DynELF checks for this by decreeing that values smaller than 0x400000 are offsets, while above that the value is likely to be an actual virtual address.

This works for executables produced with gcc, as the default linker script that comes with the GNU linker, ld, sets the image base address to 0x400000 (or 0x8048000 for 32 bit). However, other linkers might choose different values. For example when linking with the LLVM linker, lld, and using its default linker script the base address is 0x10000.

The result in the lld example is that DynELF adds the base address to pointer values again, ending up with addresses in the 0x20000-0x30000 range, and so my exploit goes into some sort of quasi-infinite loop trying to leak from addresses which are not mapped.

The proposed change instead determines when to add the base address to the value read from these fields by looking at the Type field in the ELF header, and if that indicates that the value may be an offset, making a similar guess as before, but instead of hard-coding the value 0x400000, it uses the library base address.

My current understanding is that the fields mentioned above may contain offsets if and only if the ELF Type is 'DYN'. I am basing this on some superficial reading and a few experiments, so I may easily be wrong.

Testing this change does not seem straightforward to me. I have cooked up a very simple example, for which the new version seems to work with all combinations of PIE, RELRO, and linker. My simple test case can be seen [here](https://gist.github.com/gsx/37639fa13a704fc42432dfe77e524573).

To me this feels like a bugfix and so the pull request is against the stable branch, but I would understand if someone was to argue that the nature of this fix is such that it should be considered an enhancement instead.