### PR TITLE
gdb: Use quiet (-q) option

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -596,7 +596,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
             cmd = ['sshpass', '-p', shell.password] + cmd
         if shell.keyfile:
             cmd += ['-i', shell.keyfile]
-        cmd += ['gdb %r %s -x "%s"' % (target.executable,
+        cmd += ['gdb -q %r %s -x "%s"' % (target.executable,
                                        target.pid,
                                        tmpfile)]
 
@@ -790,7 +790,7 @@ def find_module_addresses(binary, ssh=None, ulimit=False):
     # Get the addresses from GDB
     #
     libs = {}
-    cmd  = "gdb --args %s" % (binary)
+    cmd  = "gdb -q --args %s" % (binary)
     expr = re.compile(r'(0x\S+)[^/]+(.*)')
 
     if ulimit:


### PR DESCRIPTION
Super simple change: Use `-q` in the two spots I've seen where you build a `gdb` command string. This simply removes the copyright crap so your window scrolls less.

```bash
# Without -q
➜  gdb
GNU gdb (Ubuntu 7.11.1-0ubuntu1~16.04) 7.11.1
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word".
(gdb) quit


# With -q
➜  gdb -q
(gdb)
```
