### PR TITLE
Made an error message when a default terminal is not found more verbo…

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -223,7 +223,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
     terminal_path = which(terminal)
 
     if not terminal_path:
-        log.error('Could not find terminal: %s' % terminal)
+        log.error('Could not find terminal: %s. Set context.terminal to your terminal' % terminal)
 
     argv = [terminal_path] + args
 


### PR DESCRIPTION
…se and helpful

When trying to use the GDB module on a distro that does not support x-terminal-emulator, you get a vague error message about not finding x-terminal-emulator. The error message was improved to suggest that the user should try setting context.terminal. This should make it quicker for people that are in the same scenario to resolve it.