### PR TITLE
Do not attempt to populate GOT and PLT symbols for Corefiles

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -943,6 +943,10 @@ class Corefile(ELF):
 
         return super(Corefile, self).__getattribute__(attribute)
 
+    # Override routines which don't make sense for Corefiles
+    def _populate_got(*a): pass
+    def _populate_plt(*a): pass
+
 class Core(Corefile):
     """Alias for :class:`.Corefile`"""
 


### PR DESCRIPTION
Closes Gallopsled/pwntools#946
