### PR TITLE
Allow setting context.device=None, and use context.arch to determine default ABI for adb.compile

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -1197,13 +1197,23 @@ def compile(source):
     if not project:
         # Realistically this should inherit from context.arch, but
         # this works for now.
-        abi = 'armeabi-v7a'
         sdk = '21'
+        abi = {
+            'aarch64': 'arm64-v8a',
+            'amd64':   'x86_64',
+            'arm':     'armeabi-v7a',
+            'i386':    'x86',
+            'mips':    'mips',
+            'mips64':  'mips64',
+        }.get(context.arch, None)
 
         # If we have an attached device, use its settings.
         if context.device:
             abi = str(properties.ro.product.cpu.abi)
             sdk = str(properties.ro.build.version.sdk)
+
+        if abi is None:
+            log.error("Unknown CPU ABI")
 
         project = _generate_ndk_project(source, abi, sdk)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1127,7 +1127,7 @@ class ContextType(object):
             self.os = device.os or self.os
         elif isinstance(device, str):
             device = Device(device)
-        else:
+        elif device is not None:
             raise AttributeError("device must be either a Device object or a serial number as a string")
 
         return device


### PR DESCRIPTION
Fixes a bug in the current `stable` where setting `context.arch` does not have an effect on `adb.compile()` output architecture.