### PR TITLE
RFC: Make interactive more magic.

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -764,7 +764,7 @@ class tube(Timeout, Logger):
         self.send(data + self.newline)
         return self.recvuntil(delim, timeout)
 
-    def interactive(self, prompt = term.text.bold_red('$') + ' '):
+    def interactive(self, prompt = term.text.bold_red('$') + ' ', command_mode=False):
         """interactive(prompt = pwnlib.term.text.bold_red('$') + ' ')
 
         Does simultaneous reading and writing to the tube. In principle this just
@@ -782,7 +782,7 @@ class tube(Timeout, Logger):
             while not go.isSet():
                 try:
                     cur = self.recv(timeout = 0.05)
-                    cur = cur.replace('\r\n', '\n')
+                    cur = cur.replace(self.newline, '\n')
                     if cur:
                         sys.stdout.write(cur)
                         sys.stdout.flush()
@@ -801,7 +801,11 @@ class tube(Timeout, Logger):
                 else:
                     data = sys.stdin.read(1)
 
+                data = data.replace('\n', self.newline)
+
                 if data:
+                    if data[0] == '!' and command_mode:
+                        data = subprocess.check_output(['/bin/bash', '-c', data[1:]])
                     try:
                         self.send(data)
                     except EOFError:


### PR DESCRIPTION
This is not intended to be merged as is but it's a request for comment about possible improvement
around ``interactive()``.

First of all there are some cases where would be awesome to be able to utilize the local
shell to forge input for the other side of the tube: in my case I'm interacting with an
AVR device via a serial connection and I'm trying to build some payloads; with the
normal behaviour is (maybe) impossible to create payload with no ASCII characters, though.

With this patch I can invoke a shell when the first character is ``!`` and using the output
from it as input for the other side of the tube, but would be possible to
create a more powerful interface using escape sequences other then to invoke commands,
for example would be possible to change log level.

If anyone is interested I can produce a more elaborate patch with your feedback.

Another issue I have encountered is the asymmetric handling of the newline between input
and output of the tube: for the input from the remote side is assumed is uses always ``\r\n`` but
the input from our side it's left unchanged (maybe this is more like a bug).