### PR TITLE
Respect TERM_PROGRAM for run_in_new_terminal.  Fixes #964.

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -212,6 +212,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
             args     = []
         elif 'TERM_PROGRAM' in os.environ:
             terminal = os.environ['TERM_PROGRAM']
+            args     = []
         elif 'DISPLAY' in os.environ:
             terminal = 'x-terminal-emulator'
             args     = ['-e']

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -210,6 +210,8 @@ def run_in_new_terminal(command, terminal = None, args = None):
         elif which('pwntools-terminal'):
             terminal = 'pwntools-terminal'
             args     = []
+        elif 'TERM_PROGRAM' in os.environ:
+            terminal = os.environ['TERM_PROGRAM']
         elif 'DISPLAY' in os.environ:
             terminal = 'x-terminal-emulator'
             args     = ['-e']


### PR DESCRIPTION
This respects TERM_PROGRAM for run_in_new_terminal, as documented in the relevant docstring.  :)

Since this affects stable, I based my change against stable (though beta and dev are affected as well).

Tested locally, though it even seems obviously correct.
