### PR TITLE
Add mako files to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ graft examples
 graft extra
 include *.md *.txt *.sh *.yml MANIFEST.in
 recursive-include docs   *.rst *.png Makefile *.py *.txt
-recursive-include pwnlib *.py *.asm *.rst *.md *.txt *.sh __doc__
+recursive-include pwnlib *.py *.asm *.rst *.md *.txt *.sh __doc__ *.mako
 recursive-include pwn    *.py *.asm *.rst *.md *.txt *.sh
 recursive-exclude *.pyc


### PR DESCRIPTION
The `pwn template` command was broken because the `.mako` file was not included in the manifest.  This meant installs from `pip install pwntools` were broken and could not use this command.

After doing this, I get:

```
$ tar -tf dist/pwntools-3.6.0.tar.gz | grep mako
pwntools-3.6.0/pwnlib/data/templates/pwnup.mako
```