### PR TITLE
bandit.labs.overthewire.org SSH is now on port 2220

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -72,7 +72,7 @@ a ``process`` tube.
 
 ::
 
-    >>> shell = ssh('bandit0', 'bandit.labs.overthewire.org', password='bandit0')
+    >>> shell = ssh('bandit0', 'bandit.labs.overthewire.org', password='bandit0', port=2220)
     >>> shell['whoami']
     'bandit0'
     >>> shell.download_file('/etc/motd')

--- a/examples/ssh.py
+++ b/examples/ssh.py
@@ -4,7 +4,7 @@ Example showing how to use the ssh class.
 
 from pwn import *
 
-shell = ssh(host='bandit.labs.overthewire.org',user='bandit0',password='bandit0')
+shell = ssh(host='bandit.labs.overthewire.org',user='bandit0',password='bandit0', port=2220)
 
 # Show basic command syntax
 log.info("username: %s" % shell.whoami())

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -524,7 +524,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
         .. code-block:: python
 
             # Connect to the SSH server
-            shell = ssh('bandit0', 'bandit.labs.overthewire.org', password='bandit0')
+            shell = ssh('bandit0', 'bandit.labs.overthewire.org', password='bandit0', port=2220)
 
             # Start a process on the server
             cat = shell.process(['cat'])
@@ -763,7 +763,7 @@ def find_module_addresses(binary, ssh=None, ulimit=False):
     Example:
 
     >>> with context.local(log_level=9999): # doctest: +SKIP
-    ...     shell = ssh(host='bandit.labs.overthewire.org',user='bandit0',password='bandit0')
+    ...     shell = ssh(host='bandit.labs.overthewire.org',user='bandit0',password='bandit0', port=2220)
     ...     bash_libs = gdb.find_module_addresses('/bin/bash', shell)
     >>> os.path.basename(bash_libs[0].path) # doctest: +SKIP
     'libc.so.6'


### PR DESCRIPTION
OverTheWire is changing its SSH service for the bandit game from port 22 to port 2220.
This pull request makes sure the pwntools documentation is up-to-date so that the
examples keep working.