### PR TITLE
Add terminal_args

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -683,7 +683,6 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
 
     log.info('running in new terminal: %s' % cmd)
 
-    
     gdb_pid = misc.run_in_new_terminal(cmd, args=terminal_args)
 
     if pid and context.native:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -443,7 +443,7 @@ def binary():
     return gdb
 
 @LocalContext
-def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_args = None, ssh = None):
+def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_args = None, ssh = None, terminal_args = None):
     """attach(target, gdbscript = None, exe = None, arch = None, ssh = None) -> None
 
     Start GDB in a new terminal and attach to `target`.
@@ -455,6 +455,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
         arch(str): Architechture of the target binary.  If `exe` known GDB will
           detect the architechture automatically (if it is supported).
         gdb_args(list): List of additional arguments to pass to GDB.
+        terminal_args(list): List of additional arguments to pass to Terminal. e.g.) tmux.
 
     Returns:
         PID of the GDB process (or the window which it is running in).
@@ -682,7 +683,8 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
 
     log.info('running in new terminal: %s' % cmd)
 
-    gdb_pid = misc.run_in_new_terminal(cmd)
+    
+    gdb_pid = misc.run_in_new_terminal(cmd, args=terminal_args)
 
     if pid and context.native:
         proc.wait_for_debugger(pid)

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -204,6 +204,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
     """
 
     if not terminal:
+        tmp_args = args
         if context.terminal:
             terminal = context.terminal[0]
             args     = context.terminal[1:]
@@ -219,6 +220,9 @@ def run_in_new_terminal(command, terminal = None, args = None):
         elif 'TMUX' in os.environ and which('tmux'):
             terminal = 'tmux'
             args     = ['splitw']
+
+        if isinstance(tmp_args, list):
+            args.extend(tmp_args)
 
     if not terminal:
         log.error('Could not find a terminal binary to use. Set context.terminal to your terminal.')


### PR DESCRIPTION
When I use tmux, pwntools only supports `splitw` options.  
I want to use gdb with `-h` option.

```python
gdb.attach(r, '', terminal_args=['-h'])
```

result:
![image](https://cloud.githubusercontent.com/assets/8079733/26767471/4b45345a-49db-11e7-895d-f7c3340c1018.png)
