### PR TITLE
Fixing error when setuid=True

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -11,6 +11,7 @@ import pty
 import resource
 import select
 import signal
+import stat
 import subprocess
 import time
 import tty


### PR DESCRIPTION
Importing stat module to fix some errors on lines 361 to 364. The errors are caused when using the parameter setuid=True.
