### PR TITLE
Make concat_all faster while also simplifying it's logic

### DIFF
--- a/pwnlib/util/lists.py
+++ b/pwnlib/util/lists.py
@@ -114,17 +114,15 @@ def concat_all(*args):
        [0, 1, 2, 3, 4, 5, 6]
     """
 
-    if len(args) != 1:
-        return concat_all(list(args))
+    def go(arg, output):
+        if isinstance(arg, (tuple, list)):
+            for e in arg:
+                go(e, output)
+        else:
+            output.append(arg)
+        return output
 
-    if not isinstance(args[0], (tuple, list)):
-        return [args[0]]
-
-    res = []
-    for k in args[0]:
-        res.extend(concat_all(k))
-
-    return res
+    return go(args, [])
 
 def ordlist(s):
     """ordlist(s) -> list


### PR DESCRIPTION
I was writing some code using `concat_all` and I was wondering if it was actually efficiently implemented (not that it really mattered for my use-case). I saw that it wasn't efficient or easy to read. I decided to fix that.

As a fun-fact: I did some searching and it turns out that the original implementation was done by me in e0afe04 from 2012 and except for some formatting and expansion to support tuples, it's the exact same version as originally introduced.