### PR TITLE
corefile: don't fail hard if main's stack frame is corrupted

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -795,6 +795,7 @@ class Corefile(ELF):
         # We want to find the beginning of it
         if self.at_execfn:
             address = self.at_execfn-1
+            log.debug("Using AT_EXECFN: {:#x}".format(address))
         else:
             log.debug('No AT_EXECFN')
             address = stack.stop
@@ -829,6 +830,12 @@ class Corefile(ELF):
         if p_last_env_addr < 0:
             # Something weird is happening.  Just don't touch it.
             log.warn_once("Found bad environment at %#x", last_env_addr)
+            return
+
+        # The envp[] array may have been overridden by a stack corruption. Give up if
+        # we cannot find it.
+        if p_last_env_addr == -1:
+            log.warn("Core dump's stack is corrupted past the main frame (could not find envp[] and argv[] arrays)")
             return
 
         # Sanity check that we did correctly find the envp NULL terminator.


### PR DESCRIPTION
When exploiting buffer overflows, it often happens that we overflow the
arguments passed to main. In that case, we may not find the pointer to the
environment variable string that we were looking for. Instead of failing hard,
we now just print out a warning and continue.