### PR TITLE
Make 'pwn template' better

### DIFF
--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -19,6 +19,7 @@ parser.add_argument('--port', help='Remote port / SSH port', type=int)
 parser.add_argument('--user', help='SSH Username')
 parser.add_argument('--pass', help='SSH Password', dest='password')
 parser.add_argument('--path', help='Remote path of file on SSH server')
+parser.add_argument('--quiet', help='Less verbose template comments', action='store_true')
 
 def main(args):
     cache = None
@@ -49,7 +50,8 @@ def main(args):
                              args.port,
                              args.user,
                              args.password,
-                             args.path)
+                             args.path,
+                             args.quiet)
 
     # Fix Mako formatting bs
     output = re.sub('\n\n\n', '\n\n', output)

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -87,9 +87,9 @@ if not args.LOCAL:
 def local(argv=[], *a, **kw):
     '''Execute the target binary locally'''
     if args.GDB:
-        return gdb.debug([exe.path] + argv, gdbscript=gdbscript, *a, **kw)
+        return gdb.debug([${binary_repr}] + argv, gdbscript=gdbscript, *a, **kw)
     else:
-        return process([exe.path] + argv, *a, **kw)
+        return process([${binary_repr}] + argv, *a, **kw)
 
 def remote(argv=[], *a, **kw):
   %if ssh:
@@ -108,9 +108,15 @@ def remote(argv=[], *a, **kw):
 %endif
 
 %if host:
-start = local if args.LOCAL else remote
+def start(argv=[], *a, **kw):
+    '''Start the exploit against the target.'''
+    if args.LOCAL:
+        return local(argv, *a, **kw)
+    else:
+        return remote(argv, *a, **kw)
 %else:
 def start(argv=[], *a, **kw):
+    '''Start the exploit against the target.'''
     if args.GDB:
         return gdb.debug([${binary_repr}] + argv, gdbscript=gdbscript, *a, **kw)
     else:

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -13,7 +13,7 @@ argv[0] = os.path.basename(argv[0])
 
 try:
     if binary:
-        ctx.binary = ELF(binary, checksec=False)
+       ctx.binary = ELF(binary, checksec=False)
 except ELFError:
     pass
 
@@ -141,6 +141,7 @@ continue
 '''.format(**locals())
 %endif
 
+
 %if not quiet:
 #===========================================================
 #                    EXPLOIT GOES HERE
@@ -148,6 +149,16 @@ continue
 %else:
 # -- Exploit goes here --
 %endif
+%if ctx.binary and not quiet:
+# ${'%-10s%s-%s-%s' % ('Arch:',
+                       ctx.binary.arch,
+                       ctx.binary.bits,
+                       ctx.binary.endian)}
+%for line in ctx.binary.checksec(color=False).splitlines():
+# ${line}
+%endfor
+%endif
+
 io = start()
 
 %if not quiet:

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -1,10 +1,16 @@
 <%page args="binary, host=None, port=None, user=None, password=None, remote_path=None"/>\
 <%
+import os
+import sys
+
 from pwnlib.context import context as ctx
 from pwnlib.elf.elf import ELF
+from pwnlib.util.sh_string import sh_string
 from elftools.common.exceptions import ELFError
 
-import os
+argv = list(sys.argv)
+argv[0] = os.path.basename(argv[0])
+
 try:
     if binary:
         ctx.binary = ELF(binary, checksec=False)
@@ -28,6 +34,8 @@ binary_repr = repr(binary)
 %>\
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
+# This exploit template was generated via:
+# $ ${' '.join(map(sh_string, argv))}
 from pwn import *
 
 # Set up pwntools for the correct architecture

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -408,10 +408,10 @@ class ELF(ELFFile):
         import pwnlib.gdb
         return pwnlib.gdb.debug([self.path] + argv, *a, **kw)
 
-    def _describe(self):
+    def _describe(self, *a, **kw):
         log.info_once('\n'.join((repr(self.path),
                                 '%-10s%s-%s-%s' % ('Arch:', self.arch, self.bits, self.endian),
-                                self.checksec())))
+                                self.checksec(*a, **kw))))
 
     def __repr__(self):
         return "ELF(%r)" % self.path
@@ -1490,7 +1490,7 @@ class ELF(ELFFile):
 
         return self.dynamic_string(dt_rpath.entry.d_ptr)
 
-    def checksec(self, banner=True):
+    def checksec(self, banner=True, color=True):
         """checksec(banner=True)
 
         Prints out information in the binary, similar to ``checksec.sh``.
@@ -1498,9 +1498,9 @@ class ELF(ELFFile):
         Arguments:
             banner(bool): Whether to print the path to the ELF binary.
         """
-        red    = text.red
-        green  = text.green
-        yellow = text.yellow
+        red    = text.red if color else str
+        green  = text.green if color else str
+        yellow = text.yellow if color else str
 
         res = []
 

--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -393,7 +393,7 @@ def sh_string(s):
         return "''"
 
     chars = set(s)
-    very_good = set(string.ascii_letters + string.digits + "_+.,/")
+    very_good = set(string.ascii_letters + string.digits + "_+.,/-")
 
     # Alphanumeric can always just be used verbatim.
     if chars <= very_good:


### PR DESCRIPTION
A few minor enhancements to 'pwn template':

- Move the gdbscript out of the middle of the boilerplate code, down toward the exploit
- Add a `--quiet` flag that silences most of the auto-generated comments
- Add `checksec` information directly to the template
- Modify `sh_string` so that the single-dash `-` is a "very good" character and doesn't require single-quoting