### PR TITLE
Make some docs warnings go away and add some accessor methods

### DIFF
--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -8,7 +8,7 @@
 :mod:`pwnlib.context` --- Setting runtime variables
 =====================================================
 
-Many settings in ``pwntools`` are controlled via the global variable :data:`.context, such as the selected target operating system, architecture, and bit-width.
+Many settings in ``pwntools`` are controlled via the global variable :data:`.context`, such as the selected target operating system, architecture, and bit-width.
 
 In general, exploits will start with something like:
 

--- a/docs/source/globals.rst
+++ b/docs/source/globals.rst
@@ -13,7 +13,7 @@ Which imports a bazillion things into the global namespace to make your life eas
 
 This is a quick list of most of the objects and routines imported, in rough order of importance and frequency of use.
 
-- :obj:`.context`
+- :mod:`pwnlib.context`
     - :data:`pwnlib.context.context`
     - Responsible for most of the pwntools convenience settings
     - Set `context.log_level = 'debug'` when troubleshooting your exploit

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -429,6 +429,13 @@ class Corefile(ELF):
         -1
         >>> io.corefile.signal == signal.SIGTRAP # doctest: +SKIP
         True
+
+        Some fields are synthesized.  For example, ``fault_addr`` on AMD64 is
+        set to zero if crashing on a ``ret`` instruction under some circumstances.
+        We work around this by populating the field with the expected value.
+
+        >>> context.clear(arch='amd64')
+        >>> elf = ELF.from_assembly('push 0x1234; ret')
     """
 
     _fill_gaps = False

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -127,7 +127,7 @@ def debug_assembly(asm, gdbscript=None, vma=None):
         asm(str): Assembly code to debug
         gdbscript(str): Script to run in GDB
         vma(int): Base address to load the shellcode at
-        **kwargs: Override any :obj:`.context` values.
+        **kwargs: Override any :obj:`pwnlib.context.context` values.
 
     Returns:
         :class:`.process`
@@ -153,7 +153,7 @@ def debug_shellcode(data, gdbscript=None, vma=None):
         data(str): Assembled shellcode bytes
         gdbscript(str): Script to run in GDB
         vma(int): Base address to load the shellcode at
-        **kwargs: Override any :obj:`.context` values.
+        **kwargs: Override any :obj:`pwnlib.context.context` values.
 
     Returns:
         :class:`.process`

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -108,10 +108,6 @@ class process(tube):
         alarm(int):
             Set a SIGALRM alarm timeout on the process.
 
-    Attributes:
-
-        proc(subprocess)
-
     Examples:
 
         >>> p = process('python2')
@@ -238,7 +234,7 @@ class process(tube):
                 raise TypeError('Must provide argv or set context.binary')
 
 
-        #: `subprocess.Popen` object
+        #: :class:`subprocess.Popen` object that backs this process
         self.proc = None
 
         if not shell:
@@ -957,3 +953,25 @@ class process(tube):
         with open('/proc/%i/mem' % self.pid, 'rb') as mem:
             mem.seek(address)
             return mem.read(count) or None
+
+    @property
+    def stdin(self):
+        """Shorthand for ``self.proc.stdin``
+
+        See: :obj:`.process.proc`
+        """
+        return self.proc.stdin
+    @property
+    def stdout(self):
+        """Shorthand for ``self.proc.stdout``
+
+        See: :obj:`.process.proc`
+        """
+        return self.proc.stdout
+    @property
+    def stderr(self):
+        """Shorthand for ``self.proc.stderr``
+
+        See: :obj:`.process.proc`
+        """
+        return self.proc.stderr

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -23,7 +23,7 @@ class remote(sock):
         typ: The string "tcp" or "udp" or an integer to pass to :func:`socket.getaddrinfo`.
         timeout: A positive number, None or the string "default".
         ssl(bool): Wrap the socket with SSL
-        sock(socket): Socket to inherit, rather than connecting
+        sock(socket.socket): Socket to inherit, rather than connecting
 
     Examples:
 

--- a/pwnlib/util/iters.py
+++ b/pwnlib/util/iters.py
@@ -534,8 +534,8 @@ def iter_except(func, exception):
     the end.
 
     Arguments:
-      func:  The function to call.
-      exception(exception):  The exception that signals the end.  Other
+      func(callable): The function to call.
+      exception(Exception):  The exception that signals the end.  Other
         exceptions will not be caught.
 
     Returns:


### PR DESCRIPTION
Specifically, this adds `process.std{in,out,err}` shortcuts.