### PR TITLE
Try to cut down on the crazy verbosity of logging

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,14 +52,15 @@ class SphinxPwnlibFilter(logging.Filter):
     def filter(self, record):
         if record.name.startswith('pwn'):
             return False
+        if record.name.startswith('paramiko'):
+            return False
         return True
 
 log_filter = SphinxPwnlibFilter()
 
 for i, handler in enumerate(logging.root.handlers):
-    if isinstance(handler, sphinx.util.logging.NewLineStreamHandler):
-        print("Filtering Sphinx handler", handler)
-        handler.addFilter(log_filter)
+    print("Filtering Sphinx handler", handler)
+    handler.addFilter(log_filter)
 
 # Napoleon settings
 napoleon_use_ivar = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,23 @@ extensions = [
     'sphinxcontrib.napoleon'
 ]
 
+# Disable "info" logging directly to stdout by Sphinx
+import logging
+import sphinx.util.logging
+
+class SphinxPwnlibFilter(logging.Filter):
+    def filter(self, record):
+        if record.name.startswith('pwn'):
+            return False
+        return True
+
+log_filter = SphinxPwnlibFilter()
+
+for i, handler in enumerate(logging.root.handlers):
+    if isinstance(handler, sphinx.util.logging.NewLineStreamHandler):
+        print("Filtering Sphinx handler", handler)
+        handler.addFilter(log_filter)
+
 # Napoleon settings
 napoleon_use_ivar = True
 napoleon_use_rtype = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,6 @@ extensions = [
 
 # Disable "info" logging directly to stdout by Sphinx
 import logging
-import sphinx.util.logging
 
 class SphinxPwnlibFilter(logging.Filter):
     def filter(self, record):


### PR DESCRIPTION
The Travis CI logs are really huge, and *literally everything* is getting logged to the screen.

Try to cut down on the logging verbosity.

I don't think the change was our fault, I'm pretty sure something with one of the dependencies (or Travis itself) changes something regarding the default logging objects.