### PR TITLE
Do not attempt to populate the libraries used by statically-linked binaries

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -55,6 +55,7 @@ from elftools.elf.enums import ENUM_P_TYPE
 from elftools.elf.gnuversions import GNUVerDefSection
 from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import SymbolTableSection
+from elftools.elf.segments import InterpSegment
 
 import intervaltree
 
@@ -605,8 +606,16 @@ class ELF(ELFFile):
         >>> any(map(lambda x: 'libc' in x, bash.libs.keys()))
         True
         """
+
+        # We need a .dynamic section for dynamically linked libraries
         if not self.get_section_by_name('.dynamic'):
             self.libs= {}
+            return
+
+        # We must also specify a 'PT_INTERP', otherwise it's a 'statically-linked'
+        # binary which is also position-independent (and as such has a .dynamic).
+        if self.statically_linked:
+            self.libs = {}
             return
 
         try:


### PR DESCRIPTION
This causes a background instance to be spawned, which is not intended.
