### PR TITLE
Overhaul ROP.setRegisters to support more complex cases needed by AMD64

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -713,7 +713,7 @@ class ROP(object):
                 # properly, but likely also need to adjust the stack past the
                 # arguments.
                 if slot.abi.returns:
-                    if remaining:
+                    if remaining or stackArguments:
                         nextGadgetAddr = stack.next
 
                         if len(stackArguments) > 0:
@@ -726,7 +726,7 @@ class ROP(object):
 
                             nextGadgetAddr += adjust.move
 
-                            stack.describe('<adjust: %s>' % self.describe(adjust))
+                            stack.describe('<adjust %#x: %s>' % (fix_bytes, self.describe(adjust)))
                             stack.append(adjust.address)
 
                             for pad in range(fix_bytes, adjust.move, context.bytes):

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -40,7 +40,7 @@ standard Linux ABIs.
     0x0004:       0x64636261
     0x0008:              0x2
     0x000c:       0xdeadbeef read(4, 5, 6)
-    0x0010:           'eaaa' <pad>
+    0x0010:           'eaaa' <return address>
     0x0014:              0x4 arg0
     0x0018:              0x5 arg1
     0x001c:              0x6 arg2
@@ -55,13 +55,13 @@ The stack is automatically adjusted for the next frame
     0x0004:       0x64636261
     0x0008:              0x2
     0x000c:       0xdeadbeef read(4, 5, 6)
-    0x0010:       0x10000000 <adjust: add esp, 0x10; ret>
+    0x0010:       0x10000000 <adjust @0x24> add esp, 0x10; ret
     0x0014:              0x4 arg0
     0x0018:              0x5 arg1
     0x001c:              0x6 arg2
     0x0020:           'iaaa' <pad>
     0x0024:       0xdecafbad write(7, 8, 9)
-    0x0028:       0x10000000 <adjust: add esp, 0x10; ret>
+    0x0028:       0x10000000 <adjust @0x3c> add esp, 0x10; ret
     0x002c:              0x7 arg0
     0x0030:              0x8 arg1
     0x0034:              0x9 arg2
@@ -107,7 +107,7 @@ Finally, let's build our ROP stack
     >>> rop.exit()
     >>> print rop.dump()
     0x0000:       0x10000012 write(STDOUT_FILENO, 268435494, 8)
-    0x0004:       0x1000000e <adjust: add esp, 0x10; ret>
+    0x0004:       0x1000000e <adjust @0x18> add esp, 0x10; ret
     0x0008:              0x1 arg0
     0x000c:       0x10000026 flag
     0x0010:              0x8 arg2
@@ -202,7 +202,7 @@ That's all there is to it.
 
     >>> print rop.dump()
     0x0000:       0x1000000e pop eax; ret
-    0x0004:             0x77
+    0x0004:             0x77 [arg0] eax = SYS_sigreturn
     0x0008:       0x1000000b int 0x80
     0x000c:              0x0 gs
     0x0010:              0x0 fs
@@ -351,16 +351,16 @@ class ROP(object):
     >>> r.execve(4, 5, 6)
     >>> print r.dump()
     0x0000:       0x10001234 funcname(1, 2)
-    0x0004:       0x10000003 <adjust: add esp, 0x10; ret>
+    0x0004:       0x10000003 <adjust @0x18> add esp, 0x10; ret
     0x0008:              0x1 arg0
     0x000c:              0x2 arg1
     0x0010:           'eaaa' <pad>
     0x0014:           'faaa' <pad>
     0x0018:       0x10001234 funcname(3)
-    0x001c:       0x10000007 <adjust: pop eax; ret>
+    0x001c:       0x10000007 <adjust @0x24> pop eax; ret
     0x0020:              0x3 arg0
     0x0024:       0x10000007 pop eax; ret
-    0x0028:             0x77
+    0x0028:             0x77 [arg0] eax = SYS_sigreturn
     0x002c:       0x10000000 int 0x80
     0x0030:              0x0 gs
     0x0034:              0x0 fs
@@ -389,13 +389,13 @@ class ROP(object):
     >>> r.execve(4, 5, 6)
     >>> print r.dump()
     0x8048000:       0x10001234 funcname(1, 2)
-    0x8048004:       0x10000003 <adjust: add esp, 0x10; ret>
+    0x8048004:       0x10000003 <adjust @0x8048018> add esp, 0x10; ret
     0x8048008:              0x1 arg0
     0x804800c:              0x2 arg1
     0x8048010:           'eaaa' <pad>
     0x8048014:           'faaa' <pad>
     0x8048018:       0x10001234 funcname(3)
-    0x804801c:       0x10000007 <adjust: pop eax; ret>
+    0x804801c:       0x10000007 <adjust @0x8048024> pop eax; ret
     0x8048020:              0x3 arg0
     0x8048024:       0x10000007 pop eax; ret
     0x8048028:             0x77

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -128,6 +128,48 @@ Let's try it out!
     >>> print p.recvall(timeout=5)
     The flag
 
+ROP Example (amd64)
+-------------------
+
+For amd64 binaries, the registers are loaded off the stack.  Pwntools can do
+basic reasoning about simple "pop; pop; add; ret"-style gadgets, and satisfy
+requirements so that everything "just works".
+
+    >>> context.clear(arch='amd64')
+    >>> assembly = 'pop rdx; pop rdi; pop rsi; add rsp, 0x20; ret; target: ret'
+    >>> binary = ELF.from_assembly(assembly)
+    >>> rop = ROP(binary)
+    >>> rop.target(1,2,3)
+    >>> print rop.dump()
+    0x0000:       0x10000000 pop rdx; pop rdi; pop rsi; add rsp, 0x20; ret
+    0x0008:              0x3 [arg2] rdx = 3
+    0x0010:              0x1 [arg0] rdi = 1
+    0x0018:              0x2 [arg1] rsi = 2
+    0x0020:       'iaaajaaa' <pad 0x20>
+    0x0028:       'kaaalaaa' <pad 0x18>
+    0x0030:       'maaanaaa' <pad 0x10>
+    0x0038:       'oaaapaaa' <pad 0x8>
+    0x0040:       0x10000008 target
+    >>> rop.target(1)
+    >>> print rop.dump()
+    0x0000:       0x10000000 pop rdx; pop rdi; pop rsi; add rsp, 0x20; ret
+    0x0008:              0x3 [arg2] rdx = 3
+    0x0010:              0x1 [arg0] rdi = 1
+    0x0018:              0x2 [arg1] rsi = 2
+    0x0020:       'iaaajaaa' <pad 0x20>
+    0x0028:       'kaaalaaa' <pad 0x18>
+    0x0030:       'maaanaaa' <pad 0x10>
+    0x0038:       'oaaapaaa' <pad 0x8>
+    0x0040:       0x10000008 target
+    0x0048:       0x10000001 pop rdi; pop rsi; add rsp, 0x20; ret
+    0x0050:              0x1 [arg0] rdi = 1
+    0x0058:       'waaaxaaa' <pad rsi>
+    0x0060:       'yaaazaab' <pad 0x20>
+    0x0068:       'baabcaab' <pad 0x18>
+    0x0070:       'daabeaab' <pad 0x10>
+    0x0078:       'faabgaab' <pad 0x8>
+    0x0080:       0x10000008 target
+
 ROP + Sigreturn
 -----------------------
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -672,20 +672,23 @@ class ROP(object):
                 # arguments.
                 if slot.abi.returns:
                     if remaining:
-                        fix_size  = (1 + len(stackArguments))
-                        fix_bytes = fix_size * context.bytes
-                        adjust   = self.search(move = fix_bytes)
+                        nextGadgetAddr = stack.next
 
-                        if not adjust:
-                            log.error("Could not find gadget to adjust stack by %#x bytes" % fix_bytes)
+                        if len(stackArguments) > 0:
+                            fix_size  = (1 + len(stackArguments))
+                            fix_bytes = fix_size * context.bytes
+                            adjust   = self.search(move = fix_bytes)
 
-                        nextGadgetAddr = stack.next + adjust.move
+                            if not adjust:
+                                log.error("Could not find gadget to adjust stack by %#x bytes" % fix_bytes)
 
-                        stack.describe('<adjust: %s>' % self.describe(adjust))
-                        stack.append(adjust.address)
+                            nextGadgetAddr += adjust.move
 
-                        for pad in range(fix_bytes, adjust.move, context.bytes):
-                            stackArguments.append(Padding())
+                            stack.describe('<adjust: %s>' % self.describe(adjust))
+                            stack.append(adjust.address)
+
+                            for pad in range(fix_bytes, adjust.move, context.bytes):
+                                stackArguments.append(Padding())
 
                 for i, argument in enumerate(stackArguments):
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -729,7 +729,7 @@ class ROP(object):
                         if adjust:
                             nextGadgetAddr += adjust.move
 
-                            stack.describe('<adjust %#x: %s>' % (fix_bytes, self.describe(adjust)))
+                            stack.describe('<adjust @%#x> %s' % (nextGadgetAddr, self.describe(adjust)))
                             stack.append(adjust.address)
 
                             for pad in range(fix_bytes, adjust.move, context.bytes):

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -721,12 +721,14 @@ class ROP(object):
                     # If there were arguments on the stack, we need to stick something
                     # in the slot where the return address goes.
                     if len(stackArguments) > 0:
-                        fix_size  = (1 + len(stackArguments))
-                        fix_bytes = fix_size * context.bytes
-                        adjust   = self.search(move = fix_bytes)
+                        if remaining:
+                            fix_size  = (1 + len(stackArguments))
+                            fix_bytes = fix_size * context.bytes
+                            adjust   = self.search(move = fix_bytes)
 
-                        # If we were unable to find an adjustment, use it
-                        if adjust:
+                            if not adjust:
+                                log.error("Could not find gadget to adjust stack by %#x bytes" % fix_bytes)
+
                             nextGadgetAddr += adjust.move
 
                             stack.describe('<adjust @%#x> %s' % (nextGadgetAddr, self.describe(adjust)))
@@ -736,12 +738,8 @@ class ROP(object):
                                 stackArguments.append(Padding())
 
                         # We could not find a proper "adjust" gadget, but also didn't need one.
-                        elif not remaining:
-                            stack.append(Padding())
-
-                        # We really needed the adjustment to proceed
                         else:
-                            log.error("Could not find gadget to adjust stack by %#x bytes" % fix_bytes)
+                            stack.append(Padding())
 
 
                 for i, argument in enumerate(stackArguments):

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -501,6 +501,10 @@ class ROP(object):
         best_gadgets = {}
 
         for gadget in self.gadgets.values():
+            # Do not use gadgets which end in e.g. "int 0x80"
+            if gadget.insns[-1] != 'ret':
+                continue
+
             touched = tuple(regset & set(gadget.regs))
 
             if not touched:

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -739,7 +739,7 @@ class ROP(object):
 
                         # We could not find a proper "adjust" gadget, but also didn't need one.
                         else:
-                            stack.append(Padding())
+                            stack.append(Padding("<return address>"))
 
 
                 for i, argument in enumerate(stackArguments):

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -67,7 +67,6 @@ The stack is automatically adjusted for the next frame
     0x0034:              0x9 arg2
     0x0038:           'oaaa' <pad>
     0x003c:       0xfeedface exit()
-    0x0040:           'qaaa' <pad>
 
 ROP Example
 -------------------
@@ -113,13 +112,12 @@ Finally, let's build our ROP stack
     0x0010:              0x8 arg2
     0x0014:           'faaa' <pad>
     0x0018:       0x1000002f exit()
-    0x001c:           'haaa' <pad>
 
 The raw data from the ROP stack is available via `str`.
 
     >>> raw_rop = str(rop)
     >>> print enhex(raw_rop)
-    120000100e000010010000002600001008000000666161612f00001068616161
+    120000100e000010010000002600001008000000666161612f000010
 
 Let's try it out!
 
@@ -399,7 +397,7 @@ class ROP(object):
     0x804801c:       0x10000007 <adjust @0x8048024> pop eax; ret
     0x8048020:              0x3 arg0
     0x8048024:       0x10000007 pop eax; ret
-    0x8048028:             0x77
+    0x8048028:             0x77 [arg0] eax = SYS_sigreturn
     0x804802c:       0x10000000 int 0x80
     0x8048030:              0x0 gs
     0x8048034:              0x0 fs
@@ -1154,7 +1152,8 @@ class ROP(object):
         regs = set(regs or ())
 
         for addr, gadget in self.gadgets.items():
-            if gadget.move < move:          continue
+            if gadget.insns[-1] != 'ret':        continue
+            if gadget.move < move:               continue
             if not (regs <= set(gadget.regs)):   continue
             yield gadget
 


### PR DESCRIPTION
Additionally, have a separate cache for ROPs composed of multiple ELF files

The old version would only work if there was a dumb `pop reg` register for every register we need.

This version will find the best combination of gadgets to cover any set of registers.

Given a simple AMD64 ELF:

```py
>>> context.arch = 'amd64'
>>> asm = 'pop rdx; pop rdi; pop rsi; add rsp, 0x20; ret; target: ret'
>>> e = ELF.from_assembly(asm)
```

The most simple case is to just get to a give naddress.  This uses the `ROP.call` mechanism underneath.

```py
>>> r = ROP(e)
>>> r.target()
>>> print r.dump()
0x0000:       0x10000008 target()
```

When we make a single-argument call, Pwntools knows it needs to populate RDI.  Previously, this would only work when a `pop rdi` gadget was present.

```py
>>> r = ROP(e)
>>> r.target(1)
>>> print r.dump()
0x0000:       0x10000001 pop rdi; pop rsi; add rsp, 0x20; ret
0x0008:              0x1 [arg0] rdi = 1
0x0010:       'eaaafaaa' <pad rsi>
0x0018:       'gaaahaaa' <pad 0x20>
0x0020:       'iaaajaaa' <pad 0x18>
0x0028:       'kaaalaaa' <pad 0x10>
0x0030:       'maaanaaa' <pad 0x8>
0x0038:       0x10000008 target
```

We can also populate multiple registers.  Everything works out correctly.

```py
>>> r = ROP(e)
>>> r.target(1,2,3)
>>> print r.dump()
0x0000:       0x10000000 pop rdx; pop rdi; pop rsi; add rsp, 0x20; ret
0x0008:              0x3 [arg2] rdx = 3
0x0010:              0x1 [arg0] rdi = 1
0x0018:              0x2 [arg1] rsi = 2
0x0020:       'iaaajaaa' <pad 0x20>
0x0028:       'kaaalaaa' <pad 0x18>
0x0030:       'maaanaaa' <pad 0x10>
0x0038:       'oaaapaaa' <pad 0x8>
0x0040:       0x10000008 target
```

There is no perceptible delay at runtime.  Loading a random `libc.so.6` from Ubuntu, we can make up-to-4-argument calls (it can't find `pop r8` or `pop r9` anywhere in any gadgets).

This fixes #1019 