### PR TITLE
Use hex() for some ROP values

### DIFF
--- a/pwnlib/rop/call.py
+++ b/pwnlib/rop/call.py
@@ -240,5 +240,5 @@ class Call(object):
             if isinstance(arg, (int,long)) and arg > 0x100:
                 arg_str.append(hex(arg))
             else:
-                arg_str.append(arg)
+                arg_str.append(str(arg))
         return '%s(%s)' % (name, ', '.join(arg_str))

--- a/pwnlib/rop/call.py
+++ b/pwnlib/rop/call.py
@@ -233,4 +233,12 @@ class Call(object):
                 args.extend(map(repr, arg.values))
             else:
                 args.append(arg)
-        return '%s(%s)' % (self.name or fmt % self.target, ', '.join(map(str, args)))
+
+        name = self.name or fmt & self.target
+        arg_str = []
+        for arg in args:
+            if isinstance(arg, (int,long)) and arg > 0x100:
+                arg_str.append(hex(arg))
+            else:
+                arg_str.append(arg)
+        return '%s(%s)' % (name, ', '.join(arg_str))

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -105,7 +105,7 @@ Finally, let's build our ROP stack
     >>> rop.write(c.STDOUT_FILENO, binary.symbols['flag'], 8)
     >>> rop.exit()
     >>> print rop.dump()
-    0x0000:       0x10000012 write(STDOUT_FILENO, 268435494, 8)
+    0x0000:       0x10000012 write(STDOUT_FILENO, 0x10000026, 8)
     0x0004:       0x1000000e <adjust @0x18> add esp, 0x10; ret
     0x0008:              0x1 arg0
     0x000c:       0x10000026 flag


### PR DESCRIPTION
Makes the ROP pretty-print (`ROP.dump()`) a bit better when there are calls.

Old:

```
    0x0020:        0x80484e0 system(134524672)
    0x0024:           'oaaa' <return address>
    0x0028:        0x804af00 arg0
```

New:

```
    0x0020:        0x80484e0 system(0x804af00)
    0x0024:           'oaaa' <return address>
    0x0028:        0x804af00 arg0
```
