### PR TITLE
QEMU-related enhancements

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,6 +61,7 @@ Each of the ``pwntools`` modules is documented here.
    log
    memleak
    protocols
+   qemu
    replacements
    rop
    rop/*

--- a/docs/source/qemu.rst
+++ b/docs/source/qemu.rst
@@ -1,0 +1,10 @@
+.. testsetup:: *
+
+   from pwn import *
+
+
+:mod:`pwnlib.qemu` --- QEMU Utilities
+==========================================
+
+.. automodule:: pwnlib.qemu
+   :members:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -100,6 +100,7 @@ import time
 from pwnlib import adb
 from pwnlib import atexit
 from pwnlib import elf
+from pwnlib import qemu
 from pwnlib import tubes
 from pwnlib.asm import _bfdname
 from pwnlib.asm import make_elf
@@ -107,7 +108,6 @@ from pwnlib.asm import make_elf_from_assembly
 from pwnlib.context import LocalContext
 from pwnlib.context import context
 from pwnlib.log import getLogger
-from pwnlib.qemu import get_qemu_user
 from pwnlib.util import misc
 from pwnlib.util import proc
 
@@ -374,7 +374,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, **kwargs):
         args = _gdbserver_args(args=args, which=which)
     else:
         qemu_port = random.randint(1024, 65535)
-        qemu_user = get_qemu_user()
+        qemu_user = qemu.user_path()
         if not qemu_user:
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
         args = [qemu_user, '-g', str(qemu_port)] + args

--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -140,7 +140,7 @@ def ld_prefix(path=None, env=None):
         path = user_path()
 
     # Did we explicitly specify the path in an environment variable?
-    if 'QEMU_LD_PREFIX' in env:
+    if env and 'QEMU_LD_PREFIX' in env:
         return env['QEMU_LD_PREFIX']
 
     if 'QEMU_LD_PREFIX' in os.environ:

--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -1,3 +1,29 @@
+"""Run foreign-architecture binaries
+
+So you want to exploit ARM binaries on your Intel PC?
+
+Pwntools has a good level of integration with QEMU user-mode emulation,
+in order to run, debug, and pwn foreign architecture binaries.
+
+In general, everything magic happens "behind the scenes", and pwntools
+attempts to make your life easier.
+
+When using :class:`.process.process`, pwntools will attempt to blindly
+execute the binary, in case your system is configured to use ``binfmt-misc``.
+
+If this fails, pwntools will attempt to manually launch the binary under
+qemu user-mode emulation.  Preference is given to statically-linked variants,
+i.e. ``qemu-arm-static`` will be selected before ``qemu-arm``.
+
+When debugging binaries with :func:`.gdb.debug`, pwntools automatically adds
+the appropriate command-line flags to QEMU to start its GDB stub, and
+automatically informs GDB of the correct architecture and sysroot.
+
+You can override the default sysroot by setting the ``QEMU_LD_PREFIX``
+environment variable.  This affects where ``qemu`` will look for files when
+``open()`` is called, e.g. when the linker is attempting to resolve ``libc.so``.
+
+"""
 from __future__ import absolute_import
 
 import os

--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -137,7 +137,7 @@ def ld_prefix(path=None, env=None):
     '/etc/qemu-binfmt/arm'
     """
     if path is None:
-        path = get_qemu_user()
+        path = user_path()
 
     # Did we explicitly specify the path in an environment variable?
     if 'QEMU_LD_PREFIX' in env:

--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -10,14 +10,14 @@ from pwnlib.util import misc
 log = getLogger(__name__)
 
 @LocalContext
-def get_qemu_arch():
+def archname():
     """
     Returns the name which QEMU uses for the currently selected
     architecture.
 
-    >>> get_qemu_arch()
+    >>> pwnlib.qemu.archname()
     'i386'
-    >>> get_qemu_arch(arch='powerpc')
+    >>> pwnlib.qemu.archname(arch='powerpc')
     'ppc'
     """
     return {
@@ -33,17 +33,17 @@ def get_qemu_arch():
     }.get((context.arch, context.endian), context.arch)
 
 @LocalContext
-def get_qemu_user():
+def user_path():
     """
     Returns the path to the QEMU-user binary for the currently
     selected architecture.
 
-    >>> get_qemu_user()
+    >>> pwnlib.qemu.user_path()
     'qemu-i386-static'
-    >>> get_qemu_user(arch='thumb')
+    >>> pwnlib.qemu.user_path(arch='thumb')
     'qemu-arm-static'
     """
-    arch   = get_qemu_arch()
+    arch   = archname()
     normal = 'qemu-' + arch
     static = normal + '-static'
 
@@ -56,10 +56,10 @@ def get_qemu_user():
     log.warn_once("Neither %r nor %r are available" % (normal, static))
 
 @LocalContext
-def qemu_ld_prefix(path=None, env=None):
+def ld_prefix(path=None, env=None):
     """Returns the linker prefix for the selected qemu-user binary
 
-    >>> qemu_ld_prefix(arch='arm')
+    >>> pwnlib.qemu.ld_prefix(arch='arm')
     '/etc/qemu-binfmt/arm'
     """
     if path is None:
@@ -82,3 +82,4 @@ def qemu_ld_prefix(path=None, env=None):
     name, libpath = line.split('=', 1)
 
     return libpath.strip()
+

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -432,21 +432,21 @@ class process(tube):
 
         # Determine what architecture the binary is, and find the
         # appropriate qemu binary to run it.
-        qemu = qemu.user_path(arch=binary.arch)
+        qemu_path = qemu.user_path(arch=binary.arch)
 
         if not qemu:
             raise exception
 
-        qemu = which(qemu)
+        qemu_path = which(qemu_path)
         if qemu:
-            self._qemu = qemu
+            self._qemu = qemu_path
 
-            args = [qemu]
+            args = [qemu_path]
             if self.argv:
                 args += ['-0', self.argv[0]]
             args += ['--']
 
-            return [args, qemu]
+            return [args, qemu_path]
 
         # If we get here, we couldn't run the binary directly, and
         # we don't have a qemu which can run it.

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -16,9 +16,9 @@ import subprocess
 import time
 import tty
 
+from pwnlib import qemu
 from pwnlib.context import context
 from pwnlib.log import getLogger
-from pwnlib.qemu import get_qemu_user
 from pwnlib.timeout import Timeout
 from pwnlib.tubes.tube import tube
 from pwnlib.util.hashes import sha256file
@@ -432,7 +432,7 @@ class process(tube):
 
         # Determine what architecture the binary is, and find the
         # appropriate qemu binary to run it.
-        qemu = get_qemu_user(arch=binary.arch)
+        qemu = qemu.user_path(arch=binary.arch)
 
         if not qemu:
             raise exception


### PR DESCRIPTION
This refactors some of the QEMU-related code, adds documentation, and adds support for discovering the default `QEMU_LD_PREFIX` value.

`QEMU_LD_PREFIX` is an environment variable that determines where `qemu` user-mode emulation will attempt to resolve file paths if the "real" file doesn't exist.  On Ubuntu, this is e.g. `/etc/qemu-binfmt/arm`, which is then generally symlinked to e.g. `/usr/arm-linux-gnueabihf`.

Previously, we hard-coded logic to expect `/etc/qemu-binfmt`.  Other distros use other paths, and in fact vanilla (non-Ubuntu-maintained) QEMU uses a different path.

We now detect the path appropriately by checking the environment, and extract the compiled-into-QEMU default value by running e.g. `qemu-arm --help`.  The help message contains a lines that look like:

```
Defaults:
QEMU_LD_PREFIX  = /etc/qemu-binfmt/arm
QEMU_STACK_SIZE = 8388608 byte
```

This goes all the way back to at least qemu 2.0.0, which is probably sufficient.