### PR TITLE
Handle debugging under Android better with 'pwn debug'

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -820,6 +820,7 @@ echo $PATH | while read -d: directory; do
     [ -x "$directory/{name}" ] || continue;
     echo -n "$directory/{name}\\x00";
 done
+[ -x "{name}" ] && echo -n "$PWD/{name}\\x00"
 '''.format(name=name)
 
     which_cmd = which_cmd.strip()

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -116,7 +116,7 @@ def current_device(any=False):
         >>> device
         AdbDevice(serial='emulator-5554', type='device', port='emulator', product='sdk_phone_armv7', model='sdk phone armv7', device='generic')
         >>> device.port
-        'XXXXXXX'
+        'emulator'
     """
     all_devices = devices()
     for device in all_devices:

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -116,7 +116,7 @@ def current_device(any=False):
         >>> device
         AdbDevice(serial='emulator-5554', type='device', port='emulator', product='sdk_phone_armv7', model='sdk phone armv7', device='generic')
         >>> device.port
-        'emulator'
+        'XXXXXXX'
     """
     all_devices = devices()
     for device in all_devices:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -673,7 +673,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
         gdbserver = runner(gdb_cmd)
         port    = _gdbserver_port(gdbserver, None)
         host    = context.adb_host
-        pre    += 'target remote %s:%i' % (context.adb_host, port)
+        pre    += 'target remote %s:%i\n' % (context.adb_host, port)
 
     gdbscript = pre + (gdbscript or '')
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -675,6 +675,11 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
         host    = context.adb_host
         pre    += 'target remote %s:%i\n' % (context.adb_host, port)
 
+        # gdbserver doesn't handle following forks unless it's started in
+        # '--multi' mode.  Since we don't do multi mode (yet?) try to prevent
+        # following the child.
+        pre += 'set follow-fork-mode parent\n'
+
     gdbscript = pre + (gdbscript or '')
 
     if gdbscript:


### PR DESCRIPTION
Previously, when using `--process` or `--pid`, we would terminate the gdbserver instance
when pwntools exited.  Now we wait for the user to tell us to exit.

Also fixes a minor bug preventing `adb.which` from finding things when given an absolute path.  `which("/bin/sh")` should return `"/bin/sh"`.