### PR TITLE
Fix corefile environment variables and speed up ELF.string()

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1003,8 +1003,7 @@ class Corefile(ELF):
         if name not in self.env:
             log.error("Environment variable %r not set" % name)
 
-        name, value = self.string(self.env[name])
-        return value
+        return self.string(self.env[name])
 
     @property
     def registers(self):

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -458,7 +458,7 @@ class Corefile(ELF):
         ...   pop eax
         ...   jmp LOOP
         ... '''
-        >>> elf = ELF.from_assembly(assembly)
+        >>> elf = ELF.from_assembly(assembly, arch='i386')
         >>> io = elf.process()
         >>> io.wait()
         >>> core = io.corefile

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1125,6 +1125,7 @@ class CorefileFinder(object):
             new_path = 'core.%i' % core_pid
             if core_pid > 0 and new_path != self.core_path:
                 write(new_path, self.read(self.core_path))
+                self.unlink(self.core_path)
                 self.core_path = new_path
 
         # Check the PID

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -452,13 +452,14 @@ class Corefile(ELF):
         Corefile gracefully handles the stack being filled with garbage, including
         argc / argv / envp being overwritten.
 
+        >>> context.clear(arch='i386')
         >>> assembly = '''
         ... LOOP:
         ...   mov dword ptr [esp], 0x41414141
         ...   pop eax
         ...   jmp LOOP
         ... '''
-        >>> elf = ELF.from_assembly(assembly, arch='i386')
+        >>> elf = ELF.from_assembly(assembly)
         >>> io = elf.process()
         >>> io.wait()
         >>> core = io.corefile

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -90,7 +90,7 @@ setup_android_emulator()
         elif [[ -n "$TRAVIS_TAG" ]]; then
             echo "TRAVIS_TAG ($TRAVIS_TAG) indicates a new relase"
             echo "Forcing Android Emulator installation"
-        elif (git log --stat "$TRAVIS_COMMIT_RANGE" | grep -iE "android|adb"); then
+        elif (git log --stat "$TRAVIS_COMMIT_RANGE" | grep -iE "android|adb" | grep -v "commit "); then
             echo "Found Android-related commits, forcing Android Emulator installation"
         else
             # In order to avoid running the doctests that require the Android


### PR DESCRIPTION
I'm not sure how the logic for environment variables was supposed to work, but it was broken.

This fixes the environment, and ensures that embedded `=` bytes in the env value (e.g. `FOO=BAR=BAZ`) work correctly.

A performance enhancement for `ELF.string(...)` which reads a page at a time, rather than a byte at a time.

A change to corefile lifecycles such that if `rename_corefiles=True`, the *original* is deleted.  This is to avoid the issue where `core_pattern=core` and there may be a race condition when two corefiles are created rapidly.

Some doctests were added to test these edge cases, including a corrupted stack.