### PR TITLE
Copy env using .copy method to preserve order (OrderedDict)

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -565,7 +565,7 @@ class process(tube):
         #
 
         # Create a duplicate so we can modify it safely
-        env = dict(os.environ if env is None else env)
+        env = (os.environ if env is None else env).copy()
 
         for k,v in env.items():
             if not isinstance(k, (str, unicode)):

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -874,6 +874,8 @@ os.chdir(%(cwd)r)
 if env is not None:
     os.environ.clear()
     os.environ.update(env)
+else:
+    env = os.environ
 
 def is_exe(path):
     return os.path.isfile(path) and os.access(path, os.X_OK)
@@ -961,7 +963,7 @@ except Exception:
 %(func_src)s
 apply(%(func_name)s, %(func_args)r)
 
-os.execve(exe, argv, os.environ)
+os.execve(exe, argv, env)
 """ % locals()
 
         script = script.strip()


### PR DESCRIPTION
See #1060 

Copy env in the process constructor using .copy() method of dict/OrderedDict instead of creating a new dict, to preserve order in the case OrderedDict is used for passing environment variables.