### PR TITLE
Implement fit.Label() and associated plumbing

### DIFF
--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -490,7 +490,7 @@ def _flat(args, preprocessor, packer, address):
     for arg in args:
         address = initial_address + out.tell()
 
-        while isinstance(arg, type(lambda:0)):
+        while callable(arg) and not isinstance(arg, FitLabel):
             arg = arg()
 
         if not isinstance(arg, (list, tuple)):

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -712,18 +712,18 @@ def fit(pieces=None, **kwargs):
         ...     0x40: lambda: a("Pretend this is some shellcode."),
         ...     0x80: lambda: [b("Pointer to a."), a.address, c(build_fmtstr())]
         ... }, address=address)
-        >>> print(hexdump(result))
-        00000000  54 68 65 20  66 6f 72 6d  61 74 20 73  74 72 69 6e  │The │form│at s│trin│
-        00000010  67 20 69 73  20 35 20 62  79 74 65 73  20 6c 6f 6e  │g is│ 5 b│ytes│ lon│
-        00000020  67 20 61 74  20 30 78 64  65 61 64 30  30 39 31 2e  │g at│ 0xd│ead0│091.│
-        00000030  6d 61 61 61  6e 61 61 61  6f 61 61 61  70 61 61 61  │maaa│naaa│oaaa│paaa│
-        00000040  50 72 65 74  65 6e 64 20  74 68 69 73  20 69 73 20  │Pret│end │this│ is │
-        00000050  73 6f 6d 65  20 73 68 65  6c 6c 63 6f  64 65 2e 61  │some│ she│llco│de.a│
-        00000060  79 61 61 61  7a 61 61 62  62 61 61 62  63 61 61 62  │yaaa│zaab│baab│caab│
-        00000070  64 61 61 62  65 61 61 62  66 61 61 62  67 61 61 62  │daab│eaab│faab│gaab│
-        00000080  50 6f 69 6e  74 65 72 20  74 6f 20 61  2e 40 00 ad  │Poin│ter │to a│.@··│
-        00000090  de 25 33 33  24 6e                                  │·%33│$n│
-        00000096
+        >>> print(hexdump(result, begin=address))
+        dead0000  54 68 65 20  66 6f 72 6d  61 74 20 73  74 72 69 6e  │The │form│at s│trin│
+        dead0010  67 20 69 73  20 35 20 62  79 74 65 73  20 6c 6f 6e  │g is│ 5 b│ytes│ lon│
+        dead0020  67 20 61 74  20 30 78 64  65 61 64 30  30 39 31 2e  │g at│ 0xd│ead0│091.│
+        dead0030  6d 61 61 61  6e 61 61 61  6f 61 61 61  70 61 61 61  │maaa│naaa│oaaa│paaa│
+        dead0040  50 72 65 74  65 6e 64 20  74 68 69 73  20 69 73 20  │Pret│end │this│ is │
+        dead0050  73 6f 6d 65  20 73 68 65  6c 6c 63 6f  64 65 2e 61  │some│ she│llco│de.a│
+        dead0060  79 61 61 61  7a 61 61 62  62 61 61 62  63 61 61 62  │yaaa│zaab│baab│caab│
+        dead0070  64 61 61 62  65 61 61 62  66 61 61 62  67 61 61 62  │daab│eaab│faab│gaab│
+        dead0080  50 6f 69 6e  74 65 72 20  74 6f 20 61  2e 40 00 ad  │Poin│ter │to a│.@··│
+        dead0090  de 25 33 33  24 6e                                  │·%33│$n│
+        dead0096
     """
     # HACK: To avoid circular imports we need to delay the import of `cyclic`
     from pwnlib.util import cyclic

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -504,6 +504,8 @@ def _flat(args, preprocessor, packer, address):
             out.append(packer(arg))
         elif isinstance(arg, bytearray):
             out.append(str(arg))
+        elif hasattr(arg, '__call__'):
+            out.append(arg(address))
         else:
             raise ValueError("flat(): Flat does not support values of type %s" % type(arg))
 

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -486,8 +486,9 @@ def make_unpacker(word_size = None, endianness = None, sign = None, **kwargs):
 
 def _flat(args, preprocessor, packer, address):
     out = io.BytesIO()
+    initial_address = address
     for arg in args:
-        address = address + out.tell()
+        address = initial_address + out.tell()
 
         while isinstance(arg, type(lambda:0)):
             arg = arg()
@@ -714,7 +715,7 @@ def fit(pieces=None, **kwargs):
         >>> print(hexdump(result))
         00000000  54 68 65 20  66 6f 72 6d  61 74 20 73  74 72 69 6e  │The │form│at s│trin│
         00000010  67 20 69 73  20 35 20 62  79 74 65 73  20 6c 6f 6e  │g is│ 5 b│ytes│ lon│
-        00000020  67 20 61 74  20 30 78 64  65 61 64 30  30 39 65 2e  │g at│ 0xd│ead0│09e.│
+        00000020  67 20 61 74  20 30 78 64  65 61 64 30  30 39 31 2e  │g at│ 0xd│ead0│091.│
         00000030  6d 61 61 61  6e 61 61 61  6f 61 61 61  70 61 61 61  │maaa│naaa│oaaa│paaa│
         00000040  50 72 65 74  65 6e 64 20  74 68 69 73  20 69 73 20  │Pret│end │this│ is │
         00000050  73 6f 6d 65  20 73 68 65  6c 6c 63 6f  64 65 2e 61  │some│ she│llco│de.a│
@@ -722,6 +723,7 @@ def fit(pieces=None, **kwargs):
         00000070  64 61 61 62  65 61 61 62  66 61 61 62  67 61 61 62  │daab│eaab│faab│gaab│
         00000080  50 6f 69 6e  74 65 72 20  74 6f 20 61  2e 40 00 ad  │Poin│ter │to a│.@··│
         00000090  de 25 33 33  24 6e                                  │·%33│$n│
+        00000096
     """
     # HACK: To avoid circular imports we need to delay the import of `cyclic`
     from pwnlib.util import cyclic


### PR DESCRIPTION
# Label Examples


Let's start by inspecting the three important attributes of a :class:`.Label`,
``address``, ``contents``, and ``length``.


```py
>>> a = fit.Label("Static label contents")
>>> a.contents
"Static label contents"
>>> len(a) == len("Static label contents")
True
>>> a.address
0
```

When used inside of a `fit()` expression behind a ``lambda``, these fields
can be automatically updated.

```py
>>> a = fit.Label()
>>> offset = lambda: (len(a) / 4)
>>> contents = lambda: a("Dynamic contents.  Offset %i, Length %i" % (a.address, len(a)))
>>> fit({offset: contents})
'aaaabaaacDynamic contents.  Offset 9, Length 38'
```

After ``fit`` completes the packing, the values can be extracted from the label.

```py
>>> a.contents, a.address, len(a)
('Dynamic contents.  Offset 9, Length 38', 9, 38)
```

The above example only makes use of one label, but you can build more complicated
constructs fairly easy.

```py
>>> a = fit.Label()
>>> b = fit.Label()
>>> c = fit.Label()
>>> address = 0xdead0000
>>> build_fmtstr = lambda: '%%%d$n' % (1 + ((b.address - address) / 4))
>>> result = fit({
...     0:    lambda: "The format string is %d bytes long at %#x." % (len(build_fmtstr()), c.address),
...     0x40: lambda: a("Pretend this is some shellcode."),
...     0x80: lambda: [b("Pointer to a."), a.address, c(build_fmtstr())]
... }, address=address)
>>> print(hexdump(result))
```
```
00000000  54 68 65 20  66 6f 72 6d  61 74 20 73  74 72 69 6e  │The │form│at s│trin│
00000010  67 20 69 73  20 35 20 62  79 74 65 73  20 6c 6f 6e  │g is│ 5 b│ytes│ lon│
00000020  67 20 61 74  20 30 78 64  65 61 64 30  30 39 31 2e  │g at│ 0xd│ead0│091.│
00000030  6d 61 61 61  6e 61 61 61  6f 61 61 61  70 61 61 61  │maaa│naaa│oaaa│paaa│
00000040  50 72 65 74  65 6e 64 20  74 68 69 73  20 69 73 20  │Pret│end │this│ is │
00000050  73 6f 6d 65  20 73 68 65  6c 6c 63 6f  64 65 2e 61  │some│ she│llco│de.a│
00000060  79 61 61 61  7a 61 61 62  62 61 61 62  63 61 61 62  │yaaa│zaab│baab│caab│
00000070  64 61 61 62  65 61 61 62  66 61 61 62  67 61 61 62  │daab│eaab│faab│gaab│
00000080  50 6f 69 6e  74 65 72 20  74 6f 20 61  2e 40 00 ad  │Poin│ter │to a│.@··│
00000090  de 25 33 33  24 6e                                  │·%33│$n│
00000096
```
