### PR TITLE
Fix two bugs in flag

### DIFF
--- a/pwnlib/flag/flag.py
+++ b/pwnlib/flag/flag.py
@@ -4,10 +4,13 @@ from __future__ import absolute_import
 
 import os
 
-from pwnlib.args import args
+import pwnlib.args
 from pwnlib.log import getLogger
 from pwnlib.tubes.remote import remote
+from pwnlib.util.misc import write
 
+pwnlib.args.initialize()
+args = pwnlib.args.args
 env_server  = args.get('FLAG_HOST', 'flag-submission-server').strip()
 env_port    = args.get('FLAG_PORT', '31337').strip()
 env_proto   = args.get('FLAG_PROTO', 'tcp').strip()


### PR DESCRIPTION
# Pwntools Pull Request

Fix `write` not being imported.

Fix module not getting args. `args` was being imported but not being
initialized, which made it empty.

## How to reproduce

### args not working
```sh
export PWNLIB_FLAG_HOST=example.com
```

```python
from pwn import *
submit_flag('flag{fake}')
```

It will error with `Opening connection to flag-submission-server` instead of the expected `Opening connection to example.com`

### write not working

```sh
export PWNLIB_FLAG_FILE=test_file;
touch $PWNLIB_FLAG_FILE
```

```python
import pwnlib
pwnlib.args.initialize()

from pwn import *
submit_flag('flag{fake}')
```

This bypasses the first error by calling `pwnlib.args.initialize()`. It will error with `NameError: global name 'write' is not defined`

## Testing

I don't know a good way to test either of these issues from doctest.

## Target Branch

stable because bugfix