### PR TITLE
Adding non-default gdb handling

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -478,7 +478,7 @@ def binary():
         >>> gdb.binary() # doctest: +SKIP
         '/usr/bin/gdb'
     """
-    gdb = misc.which('gdb')
+    gdb = misc.which('pwntools-gdb') or misc.which('gdb')
 
     if not context.native:
         multiarch = misc.which('gdb-multiarch')


### PR DESCRIPTION
Ref  #1071 -- this minor change allows users to override the default gdb front-end with something else. I have tested it with a simple python wrapper that instead connects up with radare2. Works pretty slick.