### PR TITLE
addr isn't a thing for gadget

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1156,7 +1156,7 @@ class ROP(object):
         regs = set(regs or ())
 
         for addr, gadget in self.gadgets.items():
-            addr_bytes = set(pack(gadget.addr))
+            addr_bytes = set(pack(gadget.address))
             if addr_bytes & self._badchars:     continue
             if gadget.insns[-1] != 'ret':        continue
             if gadget.move < move:               continue


### PR DESCRIPTION
Was getting an error from python about ``Gadget`` not having ``addr``. Looking at code this appears to be true, and likely you meant ``address``. Switching this, it seems to run correctly.

You can cause this problem simply by instantiating an ``ELF`` then ``ROP``:

```python
>>> elf = ELF("./file")
>>> rop = ROP(elf)
>>> # Error here
```