### PR TITLE
Adding GNU Screen Support

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -190,6 +190,8 @@ def run_in_new_terminal(command, terminal = None, args = None):
           variable), ``x-terminal-emulator`` is used.
         - If tmux is detected (by the presence of the ``$TMUX`` environment
           variable), a new pane will be opened.
+        - If GNU Screen is detected (by the presence of the ``$STY`` environment
+          variable), a new screen will be opened.
 
     Arguments:
         command (str): The command to run.

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -219,6 +219,9 @@ def run_in_new_terminal(command, terminal = None, args = None):
         elif 'TMUX' in os.environ and which('tmux'):
             terminal = 'tmux'
             args     = ['splitw']
+        elif 'STY' in os.environ and which('screen'):
+            terminal = 'screen'
+            args     = ['-t','pwntools-gdb','bash','-c']
 
     if not terminal:
         log.error('Could not find a terminal binary to use. Set context.terminal to your terminal.')


### PR DESCRIPTION
Accidentally killed the other PR, so opening this one.

Added a default handler for GNU Screen users (such as myself). The net result is that it will open a new GNU Screen window if you are running within GNU Screen. I have tested this with gdb.debug and it behaves as one would expect.