### PR TITLE
Fix typo in pwnlib.elf.elf

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1499,7 +1499,7 @@ class ELF(ELFFile):
         if not dt_runpath:
             return None
 
-        return self.dynamic_string(dt_rpath.entry.d_ptr)
+        return self.dynamic_string(dt_runpath.entry.d_ptr)
 
     def checksec(self, banner=True):
         """checksec(banner=True)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/xiami/.local/bin/checksec", line 11, in <module>
    sys.exit(main())
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/commandline/common.py", line 32, in main
    pwnlib.commandline.main.main()
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/commandline/main.py", line 51, in main
    commands[args.command](args)
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/commandline/checksec.py", line 37, in main
    e = ELF(f.name)
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/elf/elf.py", line 328, in __init__
    self._describe()
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/elf/elf.py", line 415, in _describe
    self.checksec())))
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/elf/elf.py", line 1558, in checksec
    if self.runpath:
  File "/home/xiami/.local/lib64/python2.7/site-packages/pwnlib/elf/elf.py", line 1502, in runpath
    return self.dynamic_string(dt_rpath.entry.d_ptr)
NameError: global name 'dt_rpath' is not defined
```