### PR TITLE
Better error message when gdbserver fails on LD_PRELOAD

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -230,6 +230,12 @@ def _gdbserver_port(gdbserver, ssh):
     # Process /bin/bash created; pid = 14366
     # Listening on port 34816
     process_created = gdbserver.recvline()
+
+    if process_created.startswith('ERROR:'):
+        raise ValueError(
+            'Failed to spawn process under gdbserver. gdbserver error message: %s' % process_created
+        )
+
     gdbserver.pid   = int(process_created.split()[-1], 0)
 
     listening_on = ''


### PR DESCRIPTION
This is a fix for https://github.com/Gallopsled/pwntools/issues/1069. I have added a deeper description "what is going on under the hood" below.

When one passes a `env={'LD_PRELOAD': '...'}` to `gdb.debug` which cannot be preloaded [the `process_created` string in `_gdbserver_port`](https://github.com/Gallopsled/pwntools/blob/c3afdd681d24575335c762cd9e930b74e89ae8ab/pwnlib/gdb.py#L251) might end up looking like this:
```
"ERROR: ld.so: object '/bin/bash' from LD_PRELOAD cannot be preloaded (cannot dynamically load executable): ignored.\n"
```

And this makes so that pwndbg ends up showing an unintuitive error:
```
$ python -c 'from pwn import *; gdb.debug("/bin/ls", env={"LD_PRELOAD": "/bin/bash"})'
[+] Starting local process '/usr/bin/gdbserver': pid 20691
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pwnlib/context/__init__.py", line 1349, in setter
    return function(*a, **kw)
  File "pwnlib/gdb.py", line 397, in debug
    port = _gdbserver_port(gdbserver, ssh)
  File "pwnlib/gdb.py", line 234, in _gdbserver_port
    gdbserver.pid   = int(process_created.split()[-1], 0)
ValueError: invalid literal for int() with base 0: 'ignored.'
```

This patch adds a special check whether the `process_created` string starts with `'ERROR:'`. If so, it raises an exception, so things are more clear for the user:
```
$ python -c 'from pwn import *; gdb.debug("/bin/ls", env={"LD_PRELOAD": "/bin/bash"})'
[+] Starting local process '/usr/bin/gdbserver': pid 20863
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pwnlib/context/__init__.py", line 1349, in setter
    return function(*a, **kw)
  File "pwnlib/gdb.py", line 402, in debug
    port = _gdbserver_port(gdbserver, ssh)
  File "pwnlib/gdb.py", line 236, in _gdbserver_port
    'Failed to spawn process under gdbserver. gdbserver error message: %s' % process_created
ValueError: Failed to spawn process under gdbserver. gdbserver error message: ERROR: ld.so: object '/bin/bash' from LD_PRELOAD cannot be preloaded (cannot dynamically load executable): ignored.

[*] Stopped process '/bin/ls' (pid 20863)
```

I assume this is rather an enhancement instead of a super important hotfix, so I am targeting dev branch for now.
If you want, either switch it or tell me to do so (if it cannot be done automatically).
