### PR TITLE
Switch server to ftp.ubuntu.org

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -27,7 +27,7 @@ This exposes a standard interface to talk to processes, sockets, serial ports,
 and all manner of things, along with some nifty helpers for common tasks.
 For example, remote connections via :mod:`pwnlib.tubes.remote`.
 
-    >>> conn = remote('ftp.debian.org',21)
+    >>> conn = remote('ftp.ubuntu.org',21)
     >>> conn.recvline() # doctest: +ELLIPSIS
     '220 ...'
     >>> conn.send('USER anonymous\r\n')


### PR DESCRIPTION
Currently ftp.debian.org is down on port 21

(cherry picked from commit ec5185c0c48c0c3ffa3d61fc5411e328ee7d57b9)
