### PR TITLE
Android bootldr extraction, gdb fixes

### DIFF
--- a/pwnlib/adb/bootloader.py
+++ b/pwnlib/adb/bootloader.py
@@ -1,0 +1,103 @@
+from __future__ import unicode_literals
+
+import ctypes
+import io
+import os
+import sys
+
+class img_info(ctypes.Structure):
+    _fields_ = [
+        ('name', ctypes.c_char * 64),
+        ('size', ctypes.c_uint32)
+    ]
+
+class bootloader_images_header(ctypes.Structure):
+    _fields_ = [
+        ('magic', ctypes.c_char * 8),
+        ('num_images', ctypes.c_uint32),
+        ('start_offset', ctypes.c_uint32),
+        ('bootldr_size', ctypes.c_uint32),
+    ]
+
+    def __init__(self, *a, **kw):
+        super(bootloader_images_header, self).__init__(*a, **kw)
+        if self.magic != self.MAGIC:
+            raise ValueError("Incorrect magic (%r, expected %r)" % (self.magic, self.MAGIC))
+    MAGIC = 'BOOTLDR!'
+
+class BootloaderImage(object):
+    def __init__(self, data):
+        """Android Bootloader image
+
+        Arguments:
+            data(str): Binary data from the image file.
+        """
+        self.data = data
+        self.header = bootloader_images_header.from_buffer_copy(data)
+
+        imgarray = ctypes.ARRAY(img_info, self.header.num_images)
+        self.img_info = imgarray.from_buffer_copy(data, ctypes.sizeof(self.header))
+
+    def extract(self, index_or_name):
+        """extract(index_or_name) -> bytes
+
+        Extract the contents of an image.
+
+        Arguments:
+            index_or_name(str,int): Either an image index or name.
+
+        Returns:
+            Contents of the image.
+        """
+        if isinstance(index_or_name, int):
+            index = index_or_name
+        else:
+            for i in range(len(self.img_info)):
+                if self.img_info[i].name == index_or_name:
+                    index = i
+                    break
+            else:
+                raise ValueError("Invalid img name: %r" % index_or_name)
+
+        if index >= len(self.img_info):
+            raise ValueError("index out of range (%s, max %s)" % (index, len(self.img_info)))
+
+        offset = self.header.start_offset
+
+        for i in range(index):
+            offset += self.img_info[i].size
+
+        return self.data[offset:offset + self.img_info[index].size]
+
+    def extract_all(self, path):
+        """extract_all(path)
+
+        Extracts all images to the provided path.  The filenames are taken
+        from the image name, with '.img' appended.
+        """
+        if not os.path.isdir(path):
+            raise ValueError("%r does not exist or is not a directory" % path)
+
+        for img in self.img_info:
+            imgpath = os.path.join(path, img.name + '.img')
+            with open(imgpath, 'wb+') as f:
+                data = self.extract(img.name)
+                f.write(data)
+
+    def __str__(self):
+        rv = []
+        rv.append("Bootloader")
+        rv.append("  Magic:  %r" % self.header.magic)
+        rv.append("  Offset: %#x" % self.header.start_offset)
+        rv.append("  Size:   %#x" % self.header.bootldr_size)
+        rv.append("  Images: %s" % self.header.num_images)
+        for img in self.img_info:
+            rv.append("    Name: %s" % img.name)
+            rv.append("    Size: %#x" % img.size)
+            rv.append("    Data: %r..." % self.extract(img.name)[:32])
+        return '\n'.join(rv)
+
+if __name__ == '__main__':
+    # Easy sanity checking
+    b = BootloaderImage(open(sys.argv[1]).read())
+    print(b)

--- a/pwnlib/commandline/debug.py
+++ b/pwnlib/commandline/debug.py
@@ -43,6 +43,12 @@ parser.add_argument(
     '--process', metavar='PROCESS_NAME',
     help='Name of the process to attach to (e.g. "bash")'
 )
+parser.add_argument(
+    '--sysroot', metavar='SYSROOT',
+    type=str,
+    default='',
+    help="GDB sysroot path"
+)
 
 def main(args):
     gdbscript = ''
@@ -78,7 +84,7 @@ def main(args):
         return 1
 
     if args.pid or args.process:
-        pid = gdb.attach(target, gdbscript=gdbscript)
+        pid = gdb.attach(target, gdbscript=gdbscript, sysroot=args.sysroot)
 
         # Since we spawned the gdbserver process, and process registers an
         # atexit handler to close itself, gdbserver will be terminated when
@@ -87,7 +93,7 @@ def main(args):
         log.info("GDB connection forwarding will terminate when you press enter")
         pause()
     else:
-        gdb.debug(target, gdbscript=gdbscript).interactive()
+        gdb.debug(target, gdbscript=gdbscript, sysroot=args.sysroot).interactive()
 
 if __name__ == '__main__':
     pwnlib.commandline.common.main(__file__)

--- a/pwnlib/commandline/debug.py
+++ b/pwnlib/commandline/debug.py
@@ -60,7 +60,7 @@ def main(args):
 
     if args.executable:
         if os.path.exists(args.executable):
-            context.binary = ELF(args.executable.name)
+            context.binary = ELF(args.executable)
             target = context.binary.path
 
         # This path does nothing, but avoids the "print_usage()"

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -287,7 +287,7 @@ def _get_runner(ssh=None):
     else:                          return tubes.process.process
 
 @LocalContext
-def debug(args, gdbscript=None, exe=None, ssh=None, env=None, **kwargs):
+def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kwargs):
     """debug(args) -> tube
 
     Launch a GDB server with the specified command line,
@@ -299,6 +299,8 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, **kwargs):
         exe(str): Path to the executable on disk
         env(dict): Environment to start the binary in
         ssh(:class:`.ssh`): Remote ssh session to use to launch the process.
+        sysroot(str): Foreign-architecture sysroot, used for QEMU-emulated binaries
+            and Android targets.
 
     Returns:
         :class:`.process` or :class:`.ssh_channel`: A tube connected to the target process
@@ -404,7 +406,6 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, **kwargs):
 
     runner = _get_runner(ssh)
     which  = _get_which(ssh)
-    sysroot = None
     gdbscript = gdbscript or ''
 
     if context.noptrace:
@@ -416,10 +417,14 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, **kwargs):
     else:
         qemu_port = random.randint(1024, 65535)
         qemu_user = qemu.user_path()
-        sysroot = qemu.ld_prefix(env)
+        sysroot = sysroot or qemu.ld_prefix(env)
         if not qemu_user:
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
         args = [qemu_user, '-g', str(qemu_port)] + args
+
+    # Use a sane default sysroot for Android
+    if not sysroot and context.os == 'android':
+        sysroot = 'remote:/'
 
     # Make sure gdbserver/qemu is installed
     if not which(args[0]):
@@ -508,6 +513,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
           detect the architechture automatically (if it is supported).
         gdb_args(list): List of additional arguments to pass to GDB.
         sysroot(str): Foreign-architecture sysroot, used for QEMU-emulated binaries
+            and Android targets.
 
     Returns:
         PID of the GDB process (or the window which it is running in).
@@ -606,6 +612,10 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
     # enable gdb.attach(p, 'continue')
     if gdbscript and not gdbscript.endswith('\n'):
         gdbscript += '\n'
+
+    # Use a sane default sysroot for Android
+    if not sysroot and context.os == 'android':
+        sysroot = 'remote:/'
 
     # gdb script to run before `gdbscript`
     pre = ''

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -689,7 +689,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
             # new inferiors (tldr; follow-fork-mode child) unless it is run
             # in extended-remote mode.
             pre += 'target extended-remote %s:%d\n' % (host, port)
-            pre += 'set detach-on-fork off'
+            pre += 'set detach-on-fork off\n'
 
         def findexe():
             for spid in proc.pidof(target):

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -717,7 +717,8 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
         log.error('could not find target process')
 
     if exe:
-        pre += 'file %s\n' % exe
+        # The 'file' statement should go first
+        pre = 'file %s\n%s' % (exe, pre)
 
     cmd = binary()
 


### PR DESCRIPTION
Support extracting Android `boot.img` bootloader images

Also adds support for `pwn debug --sysroot` and a few other minor changes to the default `gdbscript` to make Android debugging better / easier.

Specifically:

- Sets `remote:/` as the default sysroot when using Android
- Fixes a missing newline in `detach-on-fork`
- Ensure 'file /path/to/file` is the first command