### PR TITLE
Prevent Python3 installation via "pip3 install pwntools"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ except Exception as e:
 
 setup(
     name                 = 'pwntools',
+    python_requires      = '~=2.7',
     packages             = find_packages(),
     version              = '3.13.0dev',
     data_files           = [('',


### PR DESCRIPTION
Pwntools does not work on Python3, so that it installs successfully is misleading.

More information on 'python_requires' can be found here:

    https://packaging.python.org/tutorials/distributing-packages/#python-requires

Specifically, it requires pip 9.0 or better -- but this is the 'official' way to do this.

Fixes Gallopsled/pwntools#1092
