### PR TITLE
Improved hexdump output

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -602,7 +602,7 @@ def hexdump_iter(fd, width=16, groupsize=4, skip=True, hexii=False, begin=0,
         >>> tmp.flush()
         >>> tmp.seek(4)
         >>> print '\n'.join(hexdump_iter(tmp))
-        00000000  48 45 4c 4c  4f 2c 20 57  4f 52 4c 44               │HELL│O, W│ORLD││
+        00000000  48 45 4c 4c  4f 2c 20 57  4f 52 4c 44               │HELL│O, W│ORLD│
         0000000c
 
         >>> t = tube()

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -573,9 +573,9 @@ def update_cyclic_pregenerated(size):
     while size > len(cyclic_pregen):
         cyclic_pregen += de_bruijn_gen.next()
 
-def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
-                 highlight=None, cyclic=False):
-    r"""hexdump_iter(s, width = 16, skip = True, hexii = False, begin = 0,
+def hexdump_iter(fd, width=16, groupsize=4, skip=True, hexii=False, begin=0,
+                 style=None, highlight=None, cyclic=False):
+    r"""hexdump_iter(s, width = 16, groupsize=4, skip = True, hexii = False, begin = 0,
                     style = None, highlight = None, cyclic = False) -> str generator
 
     Return a hexdump-dump of a string as a generator of lines.  Unless you have
@@ -584,6 +584,7 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
     Arguments:
         fd(file): File object to dump.  Use :meth:`StringIO.StringIO` or :meth:`hexdump` to dump a string.
         width(int): The number of characters per line
+        groupsize(int): The number of characters per group
         skip(bool): Set to True, if repeated lines should be replaced by a "*"
         hexii(bool): Set to True, if a hexii-dump should be returned instead of a hexdump.
         begin(int):  Offset of the first byte to print in the left column
@@ -613,6 +614,9 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
     style     = style or {}
     highlight = highlight or []
 
+    if groupsize < 1:
+        groupsize = width
+
     for b in highlight:
         if isinstance(b, str):
             b = ord(b)
@@ -625,15 +629,10 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
     lines       = []
     last_unique = ''
     byte_width  = len('00 ')
-    column_sep  = '  '
-    line_fmt    = '%%(offset)08x  %%(hexbytes)-%is │%%(printable)s│' % (len(column_sep)+(width*byte_width))
     spacer      = ' '
     marker      = (style.get('marker') or (lambda s:s))('│')
 
-    if hexii:
-        column_sep = ''
-        line_fmt   = '%%(offset)08x  %%(hexbytes)-%is│' % (len(column_sep)+(width*byte_width))
-    else:
+    if not hexii:
         def style_byte(b):
             hbyte = '%02x' % ord(b)
             abyte = b if isprint(b) else '·'
@@ -696,31 +695,38 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
         # Generate contents for line
         hexbytes = ''
         printable = ''
+        color_chars = 0
+        abyte = abyte_previous = ''
         for i, b in enumerate(chunk):
             if not hexii:
+                abyte_previous = abyte
                 hbyte, abyte = cache[ord(b)]
+                color_chars += len(hbyte) - 2
             else:
                 hbyte, abyte = _hexiichar(b), ''
 
-            if i % 4 == 3 and i < width - 1:
+            if (i + 1) % groupsize == 0 and i < width - 1:
                 hbyte += spacer
-                abyte += marker
+                abyte_previous += abyte
+                abyte = marker
 
             hexbytes += hbyte + ' '
+            printable += abyte_previous
+
+        if abyte != marker:
             printable += abyte
 
-        if i + 1 < width:
-            delta = width - i - 1
+        dividers_per_line = (width // groupsize)
+        if width % groupsize == 0:
+            dividers_per_line -= 1
 
-            # How many hex-bytes would we have printed?
-            count = byte_width * delta
-
-            # How many dividers do we need to fill out the line?
-            dividers_per_line = (width // 4) - (1 if width % 4 == 0 else 0)
-            dividers_printed = (i // 4) + (1 if i % 4 == 3 else 0)
-            count += dividers_per_line - dividers_printed
-
-            hexbytes += ' ' * count
+        if hexii:
+            line_fmt = '%%(offset)08x  %%(hexbytes)-%is│' % (width*byte_width)
+        else:
+            line_fmt = '%%(offset)08x  %%(hexbytes)-%is │%%(printable)s│' % (
+                 (width * byte_width)
+                + color_chars
+                + dividers_per_line )
 
         line = line_fmt % {'offset': offset, 'hexbytes': hexbytes, 'printable': printable}
         yield line
@@ -728,16 +734,17 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
     line = "%08x" % (begin + numb)
     yield line
 
-def hexdump(s, width=16, skip=True, hexii=False, begin=0,
-            style=None, highlight=None, cyclic=False):
-    r"""hexdump(s, width = 16, skip = True, hexii = False, begin = 0,
-               style = None, highlight = None, cyclic = False) -> str generator
+def hexdump(s, width=16, groupsize=4, skip=True, hexii=False,
+            begin=0, style=None, highlight=None, cyclic=False):
+    r"""hexdump(s, width = 16, groupsize=4, skip = True, hexii = False,
+               begin = 0, style = None, highlight = None, cyclic = False) -> str generator
 
     Return a hexdump-dump of a string.
 
     Arguments:
         s(str): The data to hexdump.
         width(int): The number of characters per line
+        groupsize(int): The number of characters per group
         skip(bool): Set to True, if repeated lines should be replaced by a "*"
         hexii(bool): Set to True, if a hexii-dump should be returned instead of a hexdump.
         begin(int):  Offset of the first byte to print in the left column
@@ -760,7 +767,7 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0,
         00000020
 
         >>> print hexdump('A'*32, width=8)
-        00000000  41 41 41 41  41 41 41 41   │AAAA│AAAA│
+        00000000  41 41 41 41  41 41 41 41  │AAAA│AAAA│
         *
         00000020
 
@@ -880,7 +887,7 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0,
         00000010
         >>> print hexdump('A'*16, width=12)
         00000000  41 41 41 41  41 41 41 41  41 41 41 41  │AAAA│AAAA│AAAA│
-        0000000c  41 41 41 41                            │AAAA││
+        0000000c  41 41 41 41                            │AAAA│
         00000010
         >>> print hexdump('A'*16, width=13)
         00000000  41 41 41 41  41 41 41 41  41 41 41 41  41  │AAAA│AAAA│AAAA│A│
@@ -894,10 +901,20 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0,
         00000000  41 41 41 41  41 41 41 41  41 41 41 41  41 41 41  │AAAA│AAAA│AAAA│AAA│
         0000000f  41                                               │A│
         00000010
+
+        >>> print hexdump('A'*24, width=16, groupsize=8)
+        00000000  41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41  │AAAAAAAA│AAAAAAAA│
+        00000010  41 41 41 41 41 41 41 41                           │AAAAAAAA│
+        00000018
+        >>> print hexdump('A'*24, width=16, groupsize=-1)
+        00000000  41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41  │AAAAAAAAAAAAAAAA│
+        00000010  41 41 41 41 41 41 41 41                          │AAAAAAAA│
+        00000018
     """
     s = packing.flat(s)
     return '\n'.join(hexdump_iter(StringIO.StringIO(s),
                                   width,
+                                  groupsize,
                                   skip,
                                   hexii,
                                   begin,

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -573,8 +573,8 @@ def update_cyclic_pregenerated(size):
     while size > len(cyclic_pregen):
         cyclic_pregen += de_bruijn_gen.next()
 
-def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0,
-                 style=None, highlight=None, cyclic=False, groupsize=4):
+def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
+                 highlight=None, cyclic=False, groupsize=4):
     r"""hexdump_iter(s, width = 16, skip = True, hexii = False, begin = 0,
                     style = None, highlight = None, cyclic = False, groupsize=4) -> str generator
 

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -573,10 +573,10 @@ def update_cyclic_pregenerated(size):
     while size > len(cyclic_pregen):
         cyclic_pregen += de_bruijn_gen.next()
 
-def hexdump_iter(fd, width=16, groupsize=4, skip=True, hexii=False, begin=0,
-                 style=None, highlight=None, cyclic=False):
-    r"""hexdump_iter(s, width = 16, groupsize=4, skip = True, hexii = False, begin = 0,
-                    style = None, highlight = None, cyclic = False) -> str generator
+def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0,
+                 style=None, highlight=None, cyclic=False, groupsize=4):
+    r"""hexdump_iter(s, width = 16, skip = True, hexii = False, begin = 0,
+                    style = None, highlight = None, cyclic = False, groupsize=4) -> str generator
 
     Return a hexdump-dump of a string as a generator of lines.  Unless you have
     massive amounts of data you probably want to use :meth:`hexdump`.
@@ -734,10 +734,10 @@ def hexdump_iter(fd, width=16, groupsize=4, skip=True, hexii=False, begin=0,
     line = "%08x" % (begin + numb)
     yield line
 
-def hexdump(s, width=16, groupsize=4, skip=True, hexii=False,
-            begin=0, style=None, highlight=None, cyclic=False):
-    r"""hexdump(s, width = 16, groupsize=4, skip = True, hexii = False,
-               begin = 0, style = None, highlight = None, cyclic = False) -> str generator
+def hexdump(s, width=16, skip=True, hexii=False, begin=0,
+            style=None, highlight=None, cyclic=False, groupsize=4):
+    r"""hexdump(s, width = 16, skip = True, hexii = False, begin = 0,
+               style = None, highlight = None, cyclic = False, groupsize=4) -> str generator
 
     Return a hexdump-dump of a string.
 
@@ -914,13 +914,13 @@ def hexdump(s, width=16, groupsize=4, skip=True, hexii=False,
     s = packing.flat(s)
     return '\n'.join(hexdump_iter(StringIO.StringIO(s),
                                   width,
-                                  groupsize,
                                   skip,
                                   hexii,
                                   begin,
                                   style,
                                   highlight,
-                                  cyclic))
+                                  cyclic,
+                                  groupsize))
 
 def negate(value, width = None):
     """


### PR DESCRIPTION
I refactored some code of `hexdump_iter` function.
The output is now better and also added the group size option.

# Before

```python-console
>>> print hexdump('A'*20)
00000000  41 41 41 41  41 41 41 41  41 41 41 41  41 41 41 41  │AAAA│AAAA│AAAA│AAAA│
00000010  41 41 41 41                                         │AAAA││
00000014
>>> 
>>> s = 'A'*9 + '\x00'+'B'
>>> print hexdump(s, width=8)
00000000  41 41 41 41  41 41 41 41   │AAAA│AAAA│
00000008  41 00 42                  │A·B│
0000000b
>>> print hexdump('A' + s, width=8)
00000000  41 41 41 41  41 41 41 41   │AAAA│AAAA│
00000008  41 41 00 42               │AA·B││
0000000c
>>> 
>>> print hexdump('ABCDEFGH', width=2)
00000000  41 42    │AB│
00000002  43 44    │CD│
00000004  45 46    │EF│
00000006  47 48    │GH│
00000008
```

# After

```python-console
>>> print hexdump('A'*20)
00000000  41 41 41 41  41 41 41 41  41 41 41 41  41 41 41 41  │AAAA│AAAA│AAAA│AAAA│
00000010  41 41 41 41                                         │AAAA│
00000014
>>> 
>>> s = 'A'*9 + '\x00'+'B'
>>> print hexdump(s, width=8)
00000000  41 41 41 41  41 41 41 41  │AAAA│AAAA│
00000008  41 00 42                  │A·B│
0000000b
>>> print hexdump('A' + s, width=8)
00000000  41 41 41 41  41 41 41 41  │AAAA│AAAA│
00000008  41 41 00 42               │AA·B│
0000000c
>>> 
>>> print hexdump('ABCDEFGH', width=2)
00000000  41 42  │AB│
00000002  43 44  │CD│
00000004  45 46  │EF│
00000006  47 48  │GH│
00000008
>>> 
>>> s = 'A'*8 + 'B'*8 + 'C'*8
>>> print hexdump(s, width=16, groupsize=8)
00000000  41 41 41 41 41 41 41 41  42 42 42 42 42 42 42 42  │AAAAAAAA│BBBBBBBB│
00000010  43 43 43 43 43 43 43 43                           │CCCCCCCC│
00000018
>>> 
>>> s = 'A'*10 + '\x00'+'B'*4
>>> print hexdump(s, width=9, groupsize=3)
00000000  41 41 41  41 41 41  41 41 41  │AAA│AAA│AAA│
00000009  41 00 42  42 42 42            │A·B│BBB│
0000000f
>>> 
>>> with open('/dev/urandom', 'r') as f:
...     print hexdump(f.read(8*16), groupsize=-1)
... 
00000000  91 e7 7b d9 99 64 ae 97 be 6a 19 02 a8 31 fb 62  │··{··d···j···1·b│
00000010  24 e2 ad 57 4b a0 a7 a3 05 14 7c 64 80 a7 c1 43  │$··WK·····|d···C│
00000020  5a b2 d7 20 bb 2d 0f e0 68 93 fb 76 92 b6 13 c5  │Z·· ·-··h··v····│
00000030  2f 5d c8 9b 53 84 45 c4 10 cc 8d 3d 64 48 0b 49  │/]··S·E····=dH·I│
00000040  98 f8 7e d7 d4 cb 5e 39 94 46 bb 2b 69 6f fc c9  │··~···^9·F·+io··│
00000050  b8 72 27 da ef bf d4 86 1e 3e 2c 97 f3 4d ba f0  │·r'······>,··M··│
00000060  6a 80 a2 08 2f ba d9 1a 73 de 42 a1 b3 ca 2c 24  │j···/···s·B···,$│
00000070  23 20 80 47 87 24 68 77 54 c4 32 d5 81 8f bc c0  │# ·G·$hwT·2·····│
00000080
```
