### PR TITLE
Remove pypandoc as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import glob
 import os
 import platform
+import subprocess
 import sys
 import traceback
 from distutils.command.install import INSTALL_SCHEMES
@@ -54,7 +55,6 @@ install_requires     = ['paramiko>=1.15.2',
                         'pygments>=2.0',
                         'pysocks',
                         'python-dateutil',
-                        'pypandoc',
                         'packaging',
                         'psutil>=3.3.0',
                         'intervaltree',
@@ -70,18 +70,10 @@ if not os.path.exists(PythonH):
 # Convert README.md to reStructuredText for PyPI
 long_description = ''
 try:
-    import pypandoc
-    try:
-        pypandoc.get_pandoc_path()
-    except OSError:
-        pypandoc.download_pandoc()
-    long_description = pypandoc.convert_file('README.md', 'rst')
-except ImportError:
-    pass
+    long_description = subprocess.check_output(['pandoc', 'README.md', '--to=rst'])
 except Exception as e:
     print >>sys.stderr, "Failed to convert README.md through pandoc, proceeding anyway"
     traceback.print_exc()
-
 
 setup(
     name                 = 'pwntools',


### PR DESCRIPTION
The project is pretty much unmaintained, and it is much more sane to
assume that the packager has pandoc installed.