### PR TITLE
Enable setting context.os via context.binary

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -777,6 +777,7 @@ class ContextType(object):
         self.arch   = binary.arch
         self.bits   = binary.bits
         self.endian = binary.endian
+        self.os     = binary.os
 
         return binary
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -183,6 +183,7 @@ class ELF(ELFFile):
     functions = {}
     endian = 'little'
     address = 0x400000
+    linker = None
 
     # Whether to fill gaps in memory with zeroed pages
     _fill_gaps = True
@@ -308,7 +309,19 @@ class ELF(ELFFile):
 
         for seg in self.iter_segments_by_type('PT_INTERP'):
             self.executable = True
+
+            #: ``True`` if the ELF is statically linked
             self.statically_linked = False
+
+            #: Path to the linker for the ELF
+            self.linker = self.read(seg.header.p_vaddr, seg.header.p_memsz)
+            self.linker = self.linker.rstrip('\x00')
+
+        #: Operating system of the ELF
+        self.os = 'linux'
+
+        if self.linker and self.linker.startswith('/system/bin/linker'):
+            self.os = 'android'
 
         #: ``True`` if the ELF is a shared library
         self.library = not self.executable and self.elftype == 'DYN'


### PR DESCRIPTION
In order to support this, we detect the interpreter used via PT_INTERP

Currently, Linux is the default and Android is detected based on the path
