### PR TITLE
Implemented the dump() feature in the DynELF.

### DIFF
--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -910,3 +910,73 @@ class DynELF(object):
         self.success('*curbrk: %#x' % brk)
 
         return brk
+
+    def _find_mapped_pages(self, page_size = 0x1000):
+        """
+        A generator of all mapped pages, as found using the Program Headers.
+
+        Yields tuples of the form: (virtual address, memory size)
+        """
+        leak  = self.leak
+        base  = self.libbase
+
+        Ehdr  = {32: elf.Elf32_Ehdr, 64: elf.Elf64_Ehdr}[self.elfclass]
+        Phdr  = {32: elf.Elf32_Phdr, 64: elf.Elf64_Phdr}[self.elfclass]
+
+        phead = base + leak.field(base, Ehdr.e_phoff)
+        phnum = leak.field(base, Ehdr.e_phnum)
+
+        for i in range(phnum):
+            if leak.field_compare(phead, Phdr.p_type, constants.PT_LOAD) :
+                # the interesting pages are those that are aligned to PAGE_SIZE
+                if leak.field_compare(phead, Phdr.p_align, page_size) :
+                    vaddr = leak.field(phead, Phdr.p_vaddr)
+                    memsz = leak.field(phead, Phdr.p_memsz)
+                    # fix relative offsets
+                    if vaddr < base :
+                        vaddr += base
+                    yield vaddr, memsz
+            phead += sizeof(Phdr)
+
+    def dump(self, libs = False):
+        """dump(libs = False)
+
+        Dumps the ELF's memory pages to allow further analysis.
+
+        Arguments:
+            libs(bool, optional): True if should dump the libraries too (False by default)
+
+        Returns:
+            a list of tuples of the form:
+            [(
+                <virtual address base:     0x804a000>,
+                <ELF's virtual address:    0x804af08>,
+                <ELF's memory size:            0x144>,
+                <binary memory content: '\x7fELF...'>,
+             ),
+            ]
+        """
+        leak      = self.leak
+        page_size = 0x1000
+        pages     = []
+
+        for vaddr, memsz in self._find_mapped_pages(page_size) :
+            print hex(vaddr), hex(memsz)
+            offset    = vaddr % page_size
+            leak_addr = vaddr
+            leak_size = memsz
+            if offset != 0 :
+                leak_size = memsz + offset
+                leak_addr = vaddr - offset
+            leak_size += (page_size - (leak_size % page_size)) % page_size
+            pages.append((leak_addr, vaddr, memsz, leak.n(leak_addr, leak_size)))
+
+        if libs :
+            for lib_name in self.bases() :
+                if len(lib_name) == 0 :
+                    continue
+                dyn_lib = self._dynamic_load_dynelf(lib_name)
+                if dyn_lib is not None :
+                    pages += dyn_lib.dump()
+
+        return pages


### PR DESCRIPTION
Added a new feature to the DynELF class, the ability to dump the main memory pages of the leaked ELF: .text, .rodata, .data, ...

Here is the function's documentation:
```
   dump(libs = False)

   Dumps the ELF's memory pages to allow further analysis.

   Arguments:
        libs(bool, optional): True if should dump the libraries too (False by default)

   Returns:
       a list of tuples of the form:
       [(
           <virtual address base:     0x804a000>,
           <ELF's virtual address:    0x804af08>,
           <ELF's memory size:            0x144>,
           <binary memory content: '\x7fELF...'>,
        ),
       ]
```

This feature allows researchers to easily extract a remote "blackbox" ELF once an information leak vulnerability was found, so they could RE the program.