### PR TITLE
Input parsing encoding fix for asm util

### DIFF
--- a/pwnlib/commandline/asm.py
+++ b/pwnlib/commandline/asm.py
@@ -45,14 +45,14 @@ parser.add_argument(
 parser.add_argument(
     '-v', '--avoid',
     action='append',
-    help = 'Encode the shellcode to avoid the listed bytes (provided as hex; default: 000a)'
+    help = 'Encode the shellcode to avoid the listed bytes (provided as hex)'
 )
 
 parser.add_argument(
     '-n', '--newline',
     dest='avoid',
     action='append_const',
-    const='\n',
+    const='0a',
     help = 'Encode the shellcode to avoid newlines'
 )
 
@@ -60,7 +60,7 @@ parser.add_argument(
     '-z', '--zero',
     dest='avoid',
     action='append_const',
-    const='\x00',
+    const='00',
     help = 'Encode the shellcode to avoid NULL bytes'
 )
 
@@ -106,7 +106,8 @@ def main(args):
     formatters = {'r':str, 'h':enhex, 's':repr}
 
     if args.avoid:
-        output = encode(output, args.avoid)
+        avoid = unhex(''.join(args.avoid))
+        output = encode(output, avoid)
 
     if args.debug:
         proc = gdb.debug_shellcode(output, arch=context.arch)


### PR DESCRIPTION
`asm` command line util: There is an omission in argument (`-v`) encoding parsing.

```shell
% pwn asm -h
[...]
  -v AVOID, --avoid AVOID
                        Encode the shellcode to avoid the listed bytes
                        (provided as hex; default: 000a)
  -n, --newline         Encode the shellcode to avoid newlines
  -z, --zero            Encode the shellcode to avoid NULL bytes
[...]
```

The bytes for `--avoid` must be provided as hex, but there is no hex-decode in the code.

```shell
% pwn shellcraft i386.linux.sh -f assembly > binsh
% pwn asm -i binsh -f hex
6a68682f2f2f73682f62696e89e368010101018134247269010131c9516a045901e15189e131d26a0b58cd80
% pwn asm -i binsh -f hex --avoid cd
6a68682f2f2f73682f62696e89e368010101018134247269010131c9516a045901e15189e131d26a0b58cd80
% pwn asm -i binsh -f hex --avoid `echo -en "\xcd"`
d9d0fcd97424f45e83c61889f7ac93ac28d8aa80ebac75f5f55f51b91880cbfa92c1709f9104f55d4978bd1f97004bb94bd4dfc271d92223c0c116172c2d32b3e31755799c0e016ad4d5c0c1f425bc85cc1d1d87989cbc159a9b7859fe4ff17a745591c294661f895964a1f9ab780282ac5c
```

```python-console
>>> "\xcd" in "d9d0fcd97424f45e83c61889f7ac93ac28d8aa80ebac75f5f55f51b91880cbfa92c1709f9104f55d4978bd1f97004bb94bd4dfc271d92223c0c116172c2d32b3e31755799c0e016ad4d5c0c1f425bc85cc1d1d87989cbc159a9b7859fe4ff17a745591c294661f895964a1f9ab780282ac5c".decode('hex')
False
```

## After this fix

```bash
ubuntu@ubuntu-xenial:~$ pwn shellcraft i386.linux.sh -f assembly > binsh
ubuntu@ubuntu-xenial:~$ pwn asm -i binsh -f hex
6a68682f2f2f73682f62696e89e368010101018134247269010131c9516a045901e15189e131d26a0b58cd80
ubuntu@ubuntu-xenial:~$ pwn asm -i binsh -f hex --avoid cd
d9d0d97424f45efc6a0b5983c61989f7ad93ad31d8ab4975f7000000006a68682f000000002f2f7368000000002f62696e0000000089e368010000000001010181000000003424726900000000010131c900000000516a04590000000001e1518900000000e131d26a000001000b58cc80
```

```python-console
>>> "\xcd" in "d9d0d97424f45efc6a0b5983c61989f7ad93ad31d8ab4975f7000000006a68682f000000002f2f7368000000002f62696e0000000089e368010000000001010181000000003424726900000000010131c900000000516a04590000000001e1518900000000e131d26a000001000b58cc80".decode('hex')
False
```