### PR TITLE
Remove tuple parameters unpacking due to PEP-3113

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinxcontrib-napoleon
-sphinxcontrib-autoprogram==0.1.2
+sphinxcontrib-autoprogram==0.1.4
 isort
 paramiko>=1.15.2
 mako>=1.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,29 +24,6 @@ sys.path.insert(0, os.path.abspath('../..'))
 
 import pwnlib
 
-# -- WORK-AROUNDS FOR DEPRECATION ----------------------------------------------
-# Deprecated
-# 1.6b1
-# sphinx.util.compat.Directive class is now deprecated.
-# Please use instead docutils.parsers.rst.Directive
-#
-# Pwntools Note:
-#   Can't just "do the right thing" since we have dependencies that
-#   are also affected by this, specifically sphinxcontrib.autoprogram
-try:
-    import sphinx.util.compat
-except ImportError:
-    import sys
-    import types
-    import sphinx.util
-    import docutils.parsers.rst
-    class compat(types.ModuleType):
-        Directive = docutils.parsers.rst.Directive
-    sphinx.util.compat = compat('sphinx.util.compat')
-    sys.modules['sphinx.util.compat'] = sphinx.util.compat
-
-# -- General configuration -----------------------------------------------------
-
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 

--- a/pwnlib/internal/dochelper.py
+++ b/pwnlib/internal/dochelper.py
@@ -3,7 +3,7 @@ from os.path import basename
 
 from docutils import nodes
 from docutils import statemachine
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 try:
     from StringIO import StringIO

--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -164,7 +164,7 @@ def do(c, *args):
     if s:
         put(s)
 
-def goto((r, c)):
+def goto(r, c):
     do('cup', r - scroll + height - 1, c)
 
 cells = []
@@ -435,10 +435,10 @@ def render_from(i, force = False, clear_after = False):
     # check it and just do nothing if something went wrong.
     if i < 0 or i >= len(cells):
         return
-    goto(cells[i].start)
+    goto(*cells[i].start)
     for c in cells[i:]:
         if not force and c.start == e:
-            goto(cells[-1].end)
+            goto(*cells[-1].end)
             break
         elif e:
             c.start = e


### PR DESCRIPTION
As a step towards python3 compatibility, removed tuple parameters
in `pwnlib.term.term`. They are now replaced with * unpacking.
See https://www.python.org/dev/peps/pep-3113/