### PR TITLE
Replace string format char

### DIFF
--- a/pwnlib/rop/call.py
+++ b/pwnlib/rop/call.py
@@ -234,7 +234,7 @@ class Call(object):
             else:
                 args.append(arg)
 
-        name = self.name or fmt & self.target
+        name = self.name or fmt % self.target
         arg_str = []
         for arg in args:
             if isinstance(arg, (int,long)) and arg > 0x100:

--- a/pwnlib/rop/call.py
+++ b/pwnlib/rop/call.py
@@ -234,7 +234,7 @@ class Call(object):
             else:
                 args.append(arg)
 
-        name = self.name or fmt % self.target
+        name = self.name or (fmt % self.target)
         arg_str = []
         for arg in args:
             if isinstance(arg, (int,long)) and arg > 0x100:


### PR DESCRIPTION
Fixes the following error when dump is called on a ROP object:
```
Traceback (most recent call last):
  File "myrop.py", line 17, in <module>
    print rop.dump()
  File "/usr/local/lib/python2.7/dist-packages/pwnlib/rop/rop.py", line 831, in dump
    return self.build().dump()
  File "/usr/local/lib/python2.7/dist-packages/pwnlib/rop/rop.py", line 705, in build
    stack.describe(self.describe(slot))
  File "/usr/local/lib/python2.7/dist-packages/pwnlib/rop/rop.py", line 632, in describe
    return str(object)
  File "/usr/local/lib/python2.7/dist-packages/pwnlib/rop/call.py", line 238, in __str__
    name = self.name or fmt & self.target
TypeError: unsupported operand type(s) for &: 'str' and 'int'
```