### PR TITLE
Remove unused tuple unpacking in except statement.

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -687,7 +687,7 @@ class process(tube):
 
         try:
             data = self.proc.stdout.read(numb)
-        except IOError as (err, strerror):
+        except IOError:
             pass
 
         if not data:


### PR DESCRIPTION
Mypy does not like it (maybe a bug) and the unpacked arguments seems to be unused.