### PR TITLE
Fix PLT addresses

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -858,7 +858,7 @@ class ELF(ELFFile):
                                                 section.data(),
                                                 inv_symbols)
 
-                for address, target in reversed(sorted(res.items())):
+                for address, target in sorted(res.items()):
                     self.plt[inv_symbols[target]] = address
 
         for a,n in sorted({v:k for k,v in self.plt.items()}.items()):


### PR DESCRIPTION
Currently, pwntools use emulation to find PLT addresses.  If instructions start from one address in PLT section can jump to one GOT address, it will be considered as the GOT's corresponding PLT address.

But if there is an extra instruction before the actual jump instructions, which won't affect the jump action, it will also be recorded, and finally its address will be considered as the PLT address.

For example:
```
>>> e=ELF('./test-x64')
[DEBUG] PLT 0x40054c __stack_chk_fail
[DEBUG] PLT 0x400560 __libc_start_main
[DEBUG] PLT 0x400570 srand
[DEBUG] PLT 0x400580 strtol
[DEBUG] PLT 0x400590 __printf_chk
[DEBUG] PLT 0x4005a0 __isoc99_scanf
[DEBUG] PLT 0x4005b0 __gmon_start__
```

While the real PLT address of `__stack_chk_fail` should be `0x400550`.

I think we can easily solve it by using the last possible address as PLT address.

After this patch:
```
>>> e=ELF('./test-x64')
[DEBUG] PLT 0x400550 __stack_chk_fail
[DEBUG] PLT 0x400560 __libc_start_main
[DEBUG] PLT 0x400570 srand
[DEBUG] PLT 0x400580 strtol
[DEBUG] PLT 0x400590 __printf_chk
[DEBUG] PLT 0x4005a0 __isoc99_scanf
[DEBUG] PLT 0x4005b0 __gmon_start__
```

By the way, I think this pull request also solves #1105 . At least for the test MIPS binary.

Before:
```
>>> e=ELF('./test-mips-big')
[DEBUG] PLT 0x400bb0 printf
[DEBUG] PLT 0x400bbc __stack_chk_fail
[DEBUG] PLT 0x400bcc __libc_start_main
[DEBUG] PLT 0x400bdc __isoc99_scanf
[DEBUG] PLT 0x400bec atoi
```
After:
```
>>> e=ELF('./test-mips-big')
[DEBUG] PLT 0x400bb0 printf
[DEBUG] PLT 0x400bc0 __stack_chk_fail
[DEBUG] PLT 0x400bd0 __libc_start_main
[DEBUG] PLT 0x400be0 __isoc99_scanf
[DEBUG] PLT 0x400bf0 atoi
```