### PR TITLE
Improve pwnup template, gdbserver detection

### DIFF
--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -133,7 +133,7 @@ gdbscript = '''
 %if ctx.binary:
 set sysroot
   %if 'main' in ctx.binary.symbols:
-break main
+tbreak main
 continue
   %endif
 %endif

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -160,8 +160,6 @@ continue
 
 io = start()
 
-if args.GDB:
-    log.info(io.recvline())
 %if not quiet:
 # shellcode = asm(shellcraft.sh())
 # payload = fit({

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -134,9 +134,9 @@ gdbscript = '''
 set sysroot
   %if 'main' in ctx.binary.symbols:
 tbreak main
-continue
   %endif
 %endif
+continue
 '''.format(**locals())
 %endif
 

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -133,6 +133,8 @@ gdbscript = '''
 %if ctx.binary:
   %if 'main' in ctx.binary.symbols:
 tbreak main
+  %elif 'DYN' != ctx.binary.elftype:
+tbreak *0x{exe.entry:x}
   %endif
 %endif
 continue

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -131,7 +131,6 @@ def start(argv=[], *a, **kw):
 %endif
 gdbscript = '''
 %if ctx.binary:
-set sysroot
   %if 'main' in ctx.binary.symbols:
 tbreak main
   %endif

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -131,13 +131,12 @@ def start(argv=[], *a, **kw):
 %endif
 gdbscript = '''
 %if ctx.binary:
+set sysroot
   %if 'main' in ctx.binary.symbols:
-break *0x{exe.symbols.main:x}
-  %else:
-break *0x{exe.entry:x}
+break main
+continue
   %endif
 %endif
-continue
 '''.format(**locals())
 %endif
 
@@ -161,6 +160,8 @@ continue
 
 io = start()
 
+if args.GDB:
+    log.info(io.recvline())
 %if not quiet:
 # shellcode = asm(shellcraft.sh())
 # payload = fit({

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -464,9 +464,15 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
 
     # gdbserver outputs a message when a client connects
     garbage = gdbserver.recvline(timeout=1)
+    garbage += gdbserver.recvline(timeout=1)
 
-    if "Remote debugging from host" not in garbage:
-        gdbserver.unrecv(garbage)
+    msgidx = garbage.find("Remote debugging from host ")
+    if msgidx != -1:
+        eolidx = garbage.find('\n', msgidx)
+        if eolidx != -1:
+            garbage = garbage[eolidx+1:]
+
+    gdbserver.unrecv(garbage)
 
     return gdbserver
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -464,15 +464,9 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
 
     # gdbserver outputs a message when a client connects
     garbage = gdbserver.recvline(timeout=1)
-    garbage += gdbserver.recvline(timeout=1)
-
-    msgidx = garbage.find("Remote debugging from host ")
-    if msgidx != -1:
-        eolidx = garbage.find('\n', msgidx)
-        if eolidx != -1:
-            garbage = garbage[eolidx+1:]
-
-    gdbserver.unrecv(garbage)
+    
+    # Some versions of gdbserver output an additional message
+    garbage2 = gdbserver.recvline_startswith("Remote debugging from host ", timeout=1)
 
     return gdbserver
 


### PR DESCRIPTION
I've modified the template that is used when executing `pwn template`. The changes should allow a smoother workflow with GDB.

Using the `set sysroot` command allows gdb to find the `main` on its own, if there are symbols.

The continue was removed as gdb will stop on entry by default, which is the next best thing without symbols.

`log.info(io.recvline())` was added when running with gdb, as gdb will print a line that we want to discard:

```
Remote debugging from host 127.0.0.1
```

Please let me know what you think!


I also ran the docker tests, although I'm not sure if templates are covered by them.

```
$ make -C travis/docker ANDROID=no TARGET=docs/source/tubes/ssh.rst
[...]
docker run -e "ANDROID=no" -e "TARGET=docs/source/tubes/ssh.rst" --rm --init --privileged -it travis
 * Starting OpenBSD Secure Shell server sshd                                                       [ OK ] 
===========================================
  WARNING: Disabling all Android tests !!! 
===========================================
Running Sphinx v1.7.4
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
making output directory...
loading pickled environment... not yet created
loading intersphinx inventory from https://docs.python.org/2.7/objects.inv...
loading intersphinx inventory from https://paramiko-docs.readthedocs.org/en/2.1/objects.inv...
intersphinx inventory has moved: https://paramiko-docs.readthedocs.org/en/2.1/objects.inv -> https://paramiko-docs.readthedocs.io/en/2.1/objects.inv
building [mo]: targets for 0 po files that are specified
building [doctest]: 1 source files given on command line
updating environment: 70 added, 0 changed, 0 removed
reading sources... [100%] util/web                                                                        
/home/travis/pwntools/pwnlib/dynelf.py:docstring of pwnlib.dynelf.DynELF._resolve_symbol_sysv:11: WARNING: Definition list ends without a blank line; unexpected unindent.
/home/travis/pwntools/pwnlib/gdb.py:docstring of pwnlib.gdb.debug_assembly:8: WARNING: Inline strong start-string without end-string.
/home/travis/pwntools/pwnlib/gdb.py:docstring of pwnlib.gdb.debug_assembly:21: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/travis/pwntools/pwnlib/gdb.py:docstring of pwnlib.gdb.debug_shellcode:4: WARNING: Inline strong start-string without end-string.
/home/travis/pwntools/pwnlib/gdb.py:docstring of pwnlib.gdb.debug_shellcode:17: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/travis/pwntools/pwnlib/tubes/ssh.py:docstring of pwnlib.tubes.ssh.ssh._init_remote_platform_info:6: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/travis/pwntools/pwnlib/util/packing.py:docstring of pwnlib.util.packing.flat:2: WARNING: Inline emphasis start-string without end-string.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
running tests...

Document: tubes/ssh
-------------------
1 items passed all tests:
 107 tests in default
107 tests in 1 items.
107 passed and 0 failed.
Test passed.

Doctest summary
===============
  107 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded, 7 warnings.

Testing of doctests in the sources finished, look at the results in docs/build/doctest/output.txt.
Coverage.py warning: Module ~/.pwntools-cache/ was never imported. (module-not-imported)
```
