### PR TITLE
Prevent crash from not existed cache file in ssh.checksec()

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1994,8 +1994,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         if value is not None:
             with open(path, 'w+') as f:
                 f.write(value)
-        
-        if os.path.exists(path):
+        elif os.path.exists(path):
             with open(path, 'r+') as f:
                 return f.read()
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1995,8 +1995,11 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             with open(path, 'w+') as f:
                 f.write(value)
         else:
-            with open(path, 'r+') as f:
-                return f.read()
+            try:
+                with open(path, 'r+') as f:
+                    return f.read()
+            except IOError: # file not exists
+                return None
 
     def checksec(self, banner=True):
         """checksec()

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1994,12 +1994,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         if value is not None:
             with open(path, 'w+') as f:
                 f.write(value)
-        else:
-            try:
-                with open(path, 'r+') as f:
-                    return f.read()
-            except IOError: # file not exists
-                return None
+        
+        if os.path.exists(path):
+            with open(path, 'r+') as f:
+                 return f.read()
 
     def checksec(self, banner=True):
         """checksec()

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1997,7 +1997,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         
         if os.path.exists(path):
             with open(path, 'r+') as f:
-                 return f.read()
+                return f.read()
 
     def checksec(self, banner=True):
         """checksec()


### PR DESCRIPTION
[`ssh.checksec`](https://github.com/Gallopsled/pwntools/blob/67473560c77786a149de127a56ccd7cf37b781c6/pwnlib/tubes/ssh.py#L1997-L1999) tried to read cached data, but did't check if cache file exist or not.