### PR TITLE
Fix call from `gdb.debug` to `qemu.ld_prefix`

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -423,7 +423,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     else:
         qemu_port = random.randint(1024, 65535)
         qemu_user = qemu.user_path()
-        sysroot = sysroot or qemu.ld_prefix(env)
+        sysroot = sysroot or qemu.ld_prefix(env=env)
         if not qemu_user:
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
         args = [qemu_user, '-g', str(qemu_port)] + args


### PR DESCRIPTION
`gdb.debug` calls `qemu.ld_prefix` with `env` as first parameter. The signature of `ld_trace` is 

```python
def ld_prefix(path=None, env=None):
```

So `env` is passed as `path`. This results in `path` being an enironment dictionary, which is breaking launching `qemu --help` to get the `LD_PREFIX` [in this line.](https://github.com/f0rki/pwntools/blob/stable/pwnlib/qemu.py#L153)