### PR TITLE
switch to trusty build in travis ci and fix some test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 language: python
 addons:
   apt:
@@ -19,6 +19,7 @@ cache:
         - usr
         - /home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/
         - /home/travis/virtualenv/python2.7.13/bin/
+sudo: required
 python:
   - "2.7"
 before_install:

--- a/pwnlib/shellcraft/registers.py
+++ b/pwnlib/shellcraft/registers.py
@@ -40,6 +40,8 @@ mips = {
     '$31': 31, '$ra': 31,
 }
 
+mips_list = list(mips)
+
 arm = map('r{}'.format, range(13))
 arm += ["sp", "lr", "pc", "cpsr"]
 
@@ -211,7 +213,7 @@ def current():
         'arm': arm,
         'thumb': arm,
         'aarch64': aarch64,
-        'mips': mips,
+        'mips': mips_list,
         'powerpc': powerpc
     }[context.arch]
 

--- a/pwnlib/shellcraft/templates/mips/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sh.asm
@@ -1,4 +1,13 @@
 <% from pwnlib.shellcraft import mips %>
-<%docstring>Execute /bin/sh</%docstring>
+<%docstring>Execute /bin/sh
+
+Example:
+
+    >>> p = run_assembly(shellcraft.mips.linux.sh())
+    >>> p.sendline('echo Hello')
+    >>> p.recv()
+    'Hello\n'
+
+</%docstring>
 
 ${mips.execve('//bin/sh', ['sh'], {})}

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -931,7 +931,7 @@ class process(tube):
 
         Example:
 
-            >>> e = ELF('/bin/sh')
+            >>> e = ELF('/bin/bash')
             >>> p = process(e.path)
 
             In order to make sure there's not a race condition against

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -11,7 +11,7 @@ local_deb_extract()
 
 install_deb()
 {
-    version=${2:-zesty}
+    version=${2:-artful}
     package=$1
     echo "Installing $package"
     INDEX="http://packages.ubuntu.com/en/$version/amd64/$package/download"


### PR DESCRIPTION
For #1133 , #1021 and #1022 .

This PR including switching travis build to trusty ( Ubuntu 14.04 ) and some fixes to make the build pass all the test cases. The build works on the latest `stable` branch ( [build log](https://travis-ci.org/bruce30262/pwntools/builds/383601080) )  

Note that this also works on the latest `dev` branch, for details check out my [fix-travis branch](https://github.com/bruce30262/pwntools/tree/fix-travis)( which base on the `dev` branch) and its [build log](https://travis-ci.org/bruce30262/pwntools/builds/383588679)  

Hope this fix will let us make a big step forward to the release of pwntools 3.13 :)