### PR TITLE
check if ":" exists before index(':')

### DIFF
--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -245,7 +245,7 @@ def status(pid):
     try:
         with open('/proc/%d/status' % pid) as fd:
             for line in fd:
-                if -1 == line.find(':'):
+                if ':' not in line:
                     continue
                 i = line.index(':')
                 key = line[:i]

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -245,6 +245,8 @@ def status(pid):
     try:
         with open('/proc/%d/status' % pid) as fd:
             for line in fd:
+                if -1 == line.find(':'):
+                    continue
                 i = line.index(':')
                 key = line[:i]
                 val = line[i + 2:-1] # initial :\t and trailing \n


### PR DESCRIPTION
When I use `gdb.attach(p)`, I get an error: `ValueError: substring not found`

I debug it and found that the file **/proc/%d/status** may have blank line. But util/proc.py doesn't solve it very well. If status file has blank line, then it will raise an error.

So I add some code to detect if ":" exists. If find ":" failed, it will continue.

Sorry for my bad english ...