### PR TITLE
 corefile: also expose page_offset

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -858,7 +858,7 @@ class Corefile(ELF):
                               None,
                               s.header.p_vaddr,
                               s.header.p_vaddr + s.header.p_memsz,
-                              s.header.p_flags
+                              s.header.p_flags,
                               None)
             self.mappings.append(mapping)
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -187,7 +187,7 @@ class Mapping(object):
         return '%x-%x %s %x %s' % (self.start,self.stop,self.permstr,self.size,self.name)
 
     def __repr__(self):
-        return '%s(%r, start=%#x, stop=%#x, size=%#x, page_offset=%#x, flags=%#x)' \
+        return '%s(%r, start=%#x, stop=%#x, size=%#x, flags=%#x, page_offset=%#x)' \
             % (self.__class__.__name__,
                self.name,
                self.start,
@@ -299,21 +299,21 @@ class Corefile(ELF):
     ::
 
         >>> Corefile('./core').mappings
-        [Mapping('/home/user/pwntools/crash', start=0x8048000, stop=0x8049000, size=0x1000, page_offset=0x0, flags=0x5),
-         Mapping('/home/user/pwntools/crash', start=0x8049000, stop=0x804a000, size=0x1000, page_offset=0x1, flags=0x4),
-         Mapping('/home/user/pwntools/crash', start=0x804a000, stop=0x804b000, size=0x1000, page_offset=0x2, flags=0x6),
-         Mapping(None, start=0xf7528000, stop=0xf7529000, size=0x1000, page_offset=0x0, flags=0x6),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf7529000, stop=0xf76d1000, size=0x1a8000, page_offset=0x0, flags=0x5),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d1000, stop=0xf76d2000, size=0x1000, page_offset=0x1a8, flags=0x0),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d2000, stop=0xf76d4000, size=0x2000, page_offset=0x1a9, flags=0x4),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d4000, stop=0xf76d5000, size=0x1000, page_offset=0x1aa, flags=0x6),
-         Mapping(None, start=0xf76d5000, stop=0xf76d8000, size=0x3000, page_offset=0x0, flags=0x6),
-         Mapping(None, start=0xf76ef000, stop=0xf76f1000, size=0x2000, page_offset=0x0, flags=0x6),
-         Mapping('[vdso]', start=0xf76f1000, stop=0xf76f2000, size=0x1000, page_offset=0x0, flags=0x5),
-         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf76f2000, stop=0xf7712000, size=0x20000, page_offset=0x0, flags=0x5),
-         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7712000, stop=0xf7713000, size=0x1000, page_offset=0x20, flags=0x4),
-         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7713000, stop=0xf7714000, size=0x1000, page_offset=0x21, flags=0x6),
-         Mapping('[stack]', start=0xfff3e000, stop=0xfff61000, size=0x23000, page_offset=0x0, flags=0x6)]
+        [Mapping('/home/user/pwntools/crash', start=0x8048000, stop=0x8049000, size=0x1000, flags=0x5, page_offset=0x0),
+         Mapping('/home/user/pwntools/crash', start=0x8049000, stop=0x804a000, size=0x1000, flags=0x4, page_offset=0x1),
+         Mapping('/home/user/pwntools/crash', start=0x804a000, stop=0x804b000, size=0x1000, flags=0x6, page_offset=0x2),
+         Mapping(None, start=0xf7528000, stop=0xf7529000, size=0x1000, flags=0x6, page_offset=0x0),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf7529000, stop=0xf76d1000, size=0x1a8000, flags=0x5, page_offset=0x0),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d1000, stop=0xf76d2000, size=0x1000, flags=0x0, page_offset=0x1a8),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d2000, stop=0xf76d4000, size=0x2000, flags=0x4, page_offset=0x1a9),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d4000, stop=0xf76d5000, size=0x1000, flags=0x6, page_offset=0x1aa),
+         Mapping(None, start=0xf76d5000, stop=0xf76d8000, size=0x3000, flags=0x6, page_offset=0x0),
+         Mapping(None, start=0xf76ef000, stop=0xf76f1000, size=0x2000, flags=0x6, page_offset=0x0),
+         Mapping('[vdso]', start=0xf76f1000, stop=0xf76f2000, size=0x1000, flags=0x5, page_offset=0x0),
+         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf76f2000, stop=0xf7712000, size=0x20000, flags=0x5, page_offset=0x0),
+         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7712000, stop=0xf7713000, size=0x1000, flags=0x4, page_offset=0x20),
+         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7713000, stop=0xf7714000, size=0x1000, flags=0x6, page_offset=0x21),
+         Mapping('[stack]', start=0xfff3e000, stop=0xfff61000, size=0x23000, flags=0x6, page_offset=0x0)]
 
     Example:
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -144,7 +144,7 @@ def iter_notes(self):
 class Mapping(object):
     """Encapsulates information about a memory mapping in a :class:`Corefile`.
     """
-    def __init__(self, core, name, start, stop, flags):
+    def __init__(self, core, name, start, stop, page_offset, flags):
         self._core=core
 
         #: :class:`str`: Name of the mapping, e.g. ``'/bin/bash'`` or ``'[vdso]'``.
@@ -158,6 +158,9 @@ class Mapping(object):
 
         #: :class:`int`: Size of the mapping, in bytes
         self.size = stop-start
+
+        #: :class:`int`: Offset in pages in the mapped file
+        self.page_offset = page_offset or 0
 
         #: :class:`int`: Mapping flags, using e.g. ``PROT_READ`` and so on.
         self.flags = flags
@@ -184,12 +187,13 @@ class Mapping(object):
         return '%x-%x %s %x %s' % (self.start,self.stop,self.permstr,self.size,self.name)
 
     def __repr__(self):
-        return '%s(%r, start=%#x, stop=%#x, size=%#x, flags=%#x)' \
+        return '%s(%r, start=%#x, stop=%#x, size=%#x, page_offset=%#x, flags=%#x)' \
             % (self.__class__.__name__,
                self.name,
                self.start,
                self.stop,
                self.size,
+               self.page_offset,
                self.flags)
 
     def __int__(self):
@@ -295,21 +299,21 @@ class Corefile(ELF):
     ::
 
         >>> Corefile('./core').mappings
-        [Mapping('/home/user/pwntools/crash', start=0x8048000, stop=0x8049000, size=0x1000, flags=0x5),
-         Mapping('/home/user/pwntools/crash', start=0x8049000, stop=0x804a000, size=0x1000, flags=0x4),
-         Mapping('/home/user/pwntools/crash', start=0x804a000, stop=0x804b000, size=0x1000, flags=0x6),
-         Mapping(None, start=0xf7528000, stop=0xf7529000, size=0x1000, flags=0x6),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf7529000, stop=0xf76d1000, size=0x1a8000, flags=0x5),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d1000, stop=0xf76d2000, size=0x1000, flags=0x0),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d2000, stop=0xf76d4000, size=0x2000, flags=0x4),
-         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d4000, stop=0xf76d5000, size=0x1000, flags=0x6),
-         Mapping(None, start=0xf76d5000, stop=0xf76d8000, size=0x3000, flags=0x6),
-         Mapping(None, start=0xf76ef000, stop=0xf76f1000, size=0x2000, flags=0x6),
-         Mapping('[vdso]', start=0xf76f1000, stop=0xf76f2000, size=0x1000, flags=0x5),
-         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf76f2000, stop=0xf7712000, size=0x20000, flags=0x5),
-         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7712000, stop=0xf7713000, size=0x1000, flags=0x4),
-         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7713000, stop=0xf7714000, size=0x1000, flags=0x6),
-         Mapping('[stack]', start=0xfff3e000, stop=0xfff61000, size=0x23000, flags=0x6)]
+        [Mapping('/home/user/pwntools/crash', start=0x8048000, stop=0x8049000, size=0x1000, page_offset=0x0, flags=0x5),
+         Mapping('/home/user/pwntools/crash', start=0x8049000, stop=0x804a000, size=0x1000, page_offset=0x1, flags=0x4),
+         Mapping('/home/user/pwntools/crash', start=0x804a000, stop=0x804b000, size=0x1000, page_offset=0x2, flags=0x6),
+         Mapping(None, start=0xf7528000, stop=0xf7529000, size=0x1000, page_offset=0x0, flags=0x6),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf7529000, stop=0xf76d1000, size=0x1a8000, page_offset=0x0, flags=0x5),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d1000, stop=0xf76d2000, size=0x1000, page_offset=0x1a8, flags=0x0),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d2000, stop=0xf76d4000, size=0x2000, page_offset=0x1a9, flags=0x4),
+         Mapping('/lib/i386-linux-gnu/libc-2.19.so', start=0xf76d4000, stop=0xf76d5000, size=0x1000, page_offset=0x1aa, flags=0x6),
+         Mapping(None, start=0xf76d5000, stop=0xf76d8000, size=0x3000, page_offset=0x0, flags=0x6),
+         Mapping(None, start=0xf76ef000, stop=0xf76f1000, size=0x2000, page_offset=0x0, flags=0x6),
+         Mapping('[vdso]', start=0xf76f1000, stop=0xf76f2000, size=0x1000, page_offset=0x0, flags=0x5),
+         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf76f2000, stop=0xf7712000, size=0x20000, page_offset=0x0, flags=0x5),
+         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7712000, stop=0xf7713000, size=0x1000, page_offset=0x20, flags=0x4),
+         Mapping('/lib/i386-linux-gnu/ld-2.19.so', start=0xf7713000, stop=0xf7714000, size=0x1000, page_offset=0x21, flags=0x6),
+         Mapping('[stack]', start=0xfff3e000, stop=0xfff61000, size=0x23000, page_offset=0x0, flags=0x6)]
 
     Example:
 
@@ -621,16 +625,17 @@ class Corefile(ELF):
         for i in range(count):
             start = t.unpack()
             end = t.unpack()
-            ofs = t.unpack()
-            starts.append(start)
+            offset = t.unpack()
+            starts.append((start, offset))
 
         for i in range(count):
             filename = t.recvuntil('\x00', drop=True)
-            start = starts[i]
+            (start, offset) = starts[i]
 
             for mapping in self.mappings:
                 if mapping.start == start:
                     mapping.name = filename
+                    mapping.page_offset = offset
 
         self.mappings = sorted(self.mappings, key=lambda m: m.start)
 
@@ -853,6 +858,7 @@ class Corefile(ELF):
                               None,
                               s.header.p_vaddr,
                               s.header.p_vaddr + s.header.p_memsz,
+                              None,
                               s.header.p_flags)
             self.mappings.append(mapping)
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -858,8 +858,8 @@ class Corefile(ELF):
                               None,
                               s.header.p_vaddr,
                               s.header.p_vaddr + s.header.p_memsz,
-                              None,
-                              s.header.p_flags)
+                              s.header.p_flags
+                              None)
             self.mappings.append(mapping)
 
     def _parse_auxv(self, note):

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -144,7 +144,7 @@ def iter_notes(self):
 class Mapping(object):
     """Encapsulates information about a memory mapping in a :class:`Corefile`.
     """
-    def __init__(self, core, name, start, stop, page_offset, flags):
+    def __init__(self, core, name, start, stop, flags, page_offset):
         self._core=core
 
         #: :class:`str`: Name of the mapping, e.g. ``'/bin/bash'`` or ``'[vdso]'``.


### PR DESCRIPTION
# Pwntools Pull Request

Adds page_offset to corefiles. This is useful to data from the original files.

This pull request depends on: https://github.com/Gallopsled/pwntools/pull/1167

## Testing

tested via testsuite and:

```console
$ gdb ls -batch -ex 'break _start' -ex run -ex 'generate-core-file core'
```

```python
from pwn import Corefile
coredump = Corefile('./core')
print(coredump.mappings)
```