### PR TITLE
Switch FTP servers to ftp.ubuntu.com

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -27,7 +27,7 @@ This exposes a standard interface to talk to processes, sockets, serial ports,
 and all manner of things, along with some nifty helpers for common tasks.
 For example, remote connections via :mod:`pwnlib.tubes.remote`.
 
-    >>> conn = remote('ftp.ubuntu.org',21)
+    >>> conn = remote('ftp.ubuntu.com',21)
     >>> conn.recvline() # doctest: +ELLIPSIS
     '220 ...'
     >>> conn.send('USER anonymous\r\n')


### PR DESCRIPTION
Fixes Gallopsled/pwntools#1172
