### PR TITLE
Replaced S.en|decode('hex') with en|unhex(S)

### DIFF
--- a/docs/source/asm.rst
+++ b/docs/source/asm.rst
@@ -6,6 +6,7 @@
    from pwnlib.asm import *
    from pwnlib import shellcraft
    from pwnlib.tubes.process import process
+   from pwnlib.util.fiddling import unhex
 
 
 :mod:`pwnlib.asm` --- Assembler functions

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -97,7 +97,7 @@ unpacking codes, and littering your code with helper routines.
     >>> import struct
     >>> p32(0xdeadbeef) == struct.pack('I', 0xdeadbeef)
     True
-    >>> leet = '37130000'.decode('hex')
+    >>> leet = unhex('37130000')
     >>> u32('abcd') == struct.unpack('I', 'abcd')[0]
     True
 
@@ -158,12 +158,12 @@ Assembly and Disassembly
 Never again will you need to run some already-assembled pile of shellcode
 from the internet!  The :mod:`pwnlib.asm` module is full of awesome.
 
-    >>> asm('mov eax, 0').encode('hex')
+    >>> enhex(asm('mov eax, 0'))
     'b800000000'
 
 But if you do, it's easy to suss out!
 
-    >>> print disasm('6a0258cd80ebf9'.decode('hex'))
+    >>> print disasm(unhex('6a0258cd80ebf9'))
        0:   6a 02                   push   0x2
        2:   58                      pop    eax
        3:   cd 80                   int    0x80
@@ -176,7 +176,7 @@ loaded with useful time-saving shellcodes.
 Let's say that we want to `setreuid(getuid(), getuid())` followed by `dup`ing
 file descriptor 4 to `stdin`, `stdout`, and `stderr`, and then pop a shell!
 
-    >>> asm(shellcraft.setreuid() + shellcraft.dupsh(4)).encode('hex') # doctest: +ELLIPSIS
+    >>> enhex(asm(shellcraft.setreuid() + shellcraft.dupsh(4))) # doctest: +ELLIPSIS
     '6a3158cd80...'
 
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -541,7 +541,7 @@ def make_elf(data,
         execve('/bin/sh',...).
 
         >>> context.clear(arch='i386')
-        >>> bin_sh = '6a68682f2f2f73682f62696e89e331c96a0b5899cd80'.decode('hex')
+        >>> bin_sh = unhex('6a68682f2f2f73682f62696e89e331c96a0b5899cd80')
         >>> filename = make_elf(bin_sh, extract=False)
         >>> p = process(filename)
         >>> p.sendline('echo Hello; exit')
@@ -737,20 +737,20 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
 
     Examples:
 
-        >>> print disasm('b85d000000'.decode('hex'), arch = 'i386')
+        >>> print disasm(unhex('b85d000000'), arch = 'i386')
            0:   b8 5d 00 00 00          mov    eax,0x5d
-        >>> print disasm('b85d000000'.decode('hex'), arch = 'i386', byte = 0)
+        >>> print disasm(unhex('b85d000000'), arch = 'i386', byte = 0)
            0:   mov    eax,0x5d
-        >>> print disasm('b85d000000'.decode('hex'), arch = 'i386', byte = 0, offset = 0)
+        >>> print disasm(unhex('b85d000000'), arch = 'i386', byte = 0, offset = 0)
         mov    eax,0x5d
-        >>> print disasm('b817000000'.decode('hex'), arch = 'amd64')
+        >>> print disasm(unhex('b817000000'), arch = 'amd64')
            0:   b8 17 00 00 00          mov    eax,0x17
-        >>> print disasm('48c7c017000000'.decode('hex'), arch = 'amd64')
+        >>> print disasm(unhex('48c7c017000000'), arch = 'amd64')
            0:   48 c7 c0 17 00 00 00    mov    rax,0x17
-        >>> print disasm('04001fe552009000'.decode('hex'), arch = 'arm')
+        >>> print disasm(unhex('04001fe552009000'), arch = 'arm')
            0:   e51f0004        ldr     r0, [pc, #-4]   ; 0x4
            4:   00900052        addseq  r0, r0, r2, asr r0
-        >>> print disasm('4ff00500'.decode('hex'), arch = 'thumb', bits=32)
+        >>> print disasm(unhex('4ff00500'), arch = 'thumb', bits=32)
            0:   f04f 0005       mov.w   r0, #5
     """
     result = ''

--- a/pwnlib/commandline/disasm.py
+++ b/pwnlib/commandline/disasm.py
@@ -65,7 +65,7 @@ def main(args):
         if not set(string.hexdigits) >= set(dat):
             print "This is not a hex string"
             exit(-1)
-        dat = dat.decode('hex')
+        dat = unhex(dat)
     else:
         dat = sys.stdin.read()
 

--- a/pwnlib/commandline/hex.py
+++ b/pwnlib/commandline/hex.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 
 from pwnlib.commandline import common
+from pwnlib.util.fiddling import enhex
 
 parser = common.parser_commands.add_parser(
     'hex',
@@ -17,9 +18,9 @@ parser.add_argument('data', nargs='*',
 
 def main(args):
     if not args.data:
-        print sys.stdin.read().encode('hex')
+        print enhex(sys.stdin.read())
     else:
-        print ' '.join(args.data).encode('hex')
+        print enhex(' '.join(args.data))
 
 if __name__ == '__main__':
     pwnlib.commandline.common.main(__file__)

--- a/pwnlib/commandline/unhex.py
+++ b/pwnlib/commandline/unhex.py
@@ -7,6 +7,7 @@ import sys
 from string import whitespace
 
 from pwnlib.commandline import common
+from pwnlib.util.fiddling import unhex
 
 parser = common.parser_commands.add_parser(
     'unhex',
@@ -21,9 +22,9 @@ def main(args):
     try:
         if not args.hex:
             s = sys.stdin.read().translate(None, whitespace)
-            sys.stdout.write(s.decode('hex'))
+            sys.stdout.write(unhex(s))
         else:
-            sys.stdout.write(''.join(args.hex).decode('hex'))
+            sys.stdout.write(unhex(''.join(args.hex)))
     except TypeError as e:
         sys.stderr.write(str(e) + '\n')
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -299,7 +299,7 @@ class ContextType(object):
         >>> context.bits
         32
         >>> def nop():
-        ...   print pwnlib.asm.asm('nop').encode('hex')
+        ...   print enhex(pwnlib.asm.asm('nop'))
         >>> nop()
         00f020e3
         >>> with context.local(arch = 'i386'):

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -15,7 +15,7 @@ Example
     # leaks at least one byte at that address.
     def leak(address):
         data = p.read(address, 4)
-        log.debug("%#x => %s" % (address, (data or '').encode('hex')))
+        log.debug("%#x => %s" % (address, enhex(data or '')))
         return data
 
     # For the sake of this example, let's say that we

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import base64
+import binascii
 import random
 import re
 import os
@@ -35,7 +36,7 @@ def unhex(s):
     s = s.strip()
     if len(s) % 2 != 0:
         s = '0' + s
-    return s.decode('hex')
+    return binascii.unhexlify(s)
 
 def enhex(x):
     """enhex(x) -> str
@@ -47,7 +48,7 @@ def enhex(x):
         >>> enhex("test")
         '74657374'
     """
-    return x.encode('hex')
+    return binascii.hexlify(x)
 
 def urlencode(s):
     """urlencode(s) -> str

--- a/pwnlib/util/getdents.py
+++ b/pwnlib/util/getdents.py
@@ -45,7 +45,7 @@ def dirents(buf):
     Example:
 
         >>> data = '5ade6d010100000010002e0000000004010000000200000010002e2e006e3d04092b6d010300000010007461736b00045bde6d010400000010006664003b3504'
-        >>> data = data.decode('hex')
+        >>> data = unhex(data)
         >>> print dirents(data)
         ['.', '..', 'fd', 'task']
     """


### PR DESCRIPTION
If we want to get pwntools python3-compatible, we need to keep in mind its different codec handling.

The `'hex'` encoding is still present in python 3.4+, but as `str.encode()` should return `bytes` and `bytes.decode()` should return `str`, using it this way is no longer possible.

See https://python.readthedocs.io/en/stable/whatsnew/3.4.html#improvements-to-codec-handling