### PR TITLE
Fix typo in the help message of pwn disasm

### DIFF
--- a/pwnlib/commandline/disasm.py
+++ b/pwnlib/commandline/disasm.py
@@ -21,7 +21,7 @@ parser.add_argument(
     'hex',
     metavar = 'hex',
     nargs = '*',
-    help = 'Hex-string to disasemble. If none are supplied, then it uses stdin in non-hex mode.'
+    help = 'Hex-string to disassemble. If none are supplied, then it uses stdin in non-hex mode.'
 )
 
 parser.add_argument(


### PR DESCRIPTION
Fixes a very minor typo in the help message of `pwn disasm`.