### PR TITLE
ssl custom arguments

### DIFF
--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -55,7 +55,7 @@ class remote(sock):
 
     def __init__(self, host, port,
                  fam = "any", typ = "tcp",
-                 ssl=False, sock=None, ssl_args={},*args, **kwargs):
+                 ssl=False, sock=None, ssl_args=None, *args, **kwargs):
         super(remote, self).__init__(*args, **kwargs)
 
         self.rport  = int(port)
@@ -81,7 +81,7 @@ class remote(sock):
             self.lhost, self.lport = self.sock.getsockname()[:2]
 
             if ssl:
-                self.sock = _ssl.wrap_socket(self.sock,**ssl_args)
+                self.sock = _ssl.wrap_socket(self.sock,**(ssl_args or {}))
 
     def _connect(self, fam, typ):
         sock    = None

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -25,6 +25,7 @@ class remote(sock):
         timeout: A positive number, None or the string "default".
         ssl(bool): Wrap the socket with SSL
         sock(socket.socket): Socket to inherit, rather than connecting
+        ssl_args(dict): Pass ssl.wrap_socket named arguments in a dictionary.
 
     Examples:
 
@@ -54,7 +55,7 @@ class remote(sock):
 
     def __init__(self, host, port,
                  fam = "any", typ = "tcp",
-                 ssl=False, sock=None, *args, **kwargs):
+                 ssl=False, sock=None, ssl_args={},*args, **kwargs):
         super(remote, self).__init__(*args, **kwargs)
 
         self.rport  = int(port)
@@ -80,7 +81,7 @@ class remote(sock):
             self.lhost, self.lport = self.sock.getsockname()[:2]
 
             if ssl:
-                self.sock = _ssl.wrap_socket(self.sock)
+                self.sock = _ssl.wrap_socket(self.sock,**ssl_args)
 
     def _connect(self, fam, typ):
         sock    = None


### PR DESCRIPTION
# SSL custom arguments

This creates a new named argument in the __init__ function of the pwnlib.tubes.remote class named ssl_args which is a dictionary unpacked when calling _ssl.wrap_socket(sock,**ssl_args) so that you can pass your custom arguments for wrap_socket.
