### PR TITLE
Add .set noat directive to fix MIPS shellcode assembly.

### DIFF
--- a/pwnlib/shellcraft/templates/mips/linux/findpeer.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/findpeer.asm
@@ -17,6 +17,7 @@ findpeer:
 
 next_socket:
     /* Next file descriptor */
+    .set noat
     ${mov('$at', 1)}
     add $s0, $s0, $at
 

--- a/pwnlib/shellcraft/templates/mips/linux/forkbomb.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/forkbomb.asm
@@ -11,5 +11,6 @@ Performs a forkbomb attack.
 %>
 ${dosloop}:
     ${fork()}
+    .set noat
     beq $at, $at, ${dosloop}
     ${nop()}


### PR DESCRIPTION
# Pwntools Pull Request

This PR addresses [issue 1187](https://github.com/Gallopsled/pwntools/issues/1187) that I filed shortly ago. Currently in the `dev` branch, a user cannot run for MIPS arch, the following without a fatal error.
```
asm(shellcraft.mips.linux.findpeer())
```
The fix is similar to that of [Chromium's](https://codereview.chromium.org/1275393002). I've simply added `.set noat` to the MIPS shellcode templates where it seems to apply, until I'm able to assemble all of the shellcode examples in the [documentation](http://docs.pwntools.com/en/stable/shellcraft/mips.html).

## Testing
This does not provide any tests for whether or  not any calls to `asm` with `pwnlib` shellcode breaks in future. Willing to attempt if it's felt necessary.

## Target Branch

This targets the `dev` branch.

There were other issues surrounding assembling MIPS shellcode in  `master`, and I had switched to using the `dev` branch for my needs.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.
