### PR TITLE
Workaround for to new pyelftools

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinxcontrib-autoprogram==0.1.4
 isort
 paramiko>=1.15.2
 mako>=1.0.0
-pyelftools>=0.2.3
+pyelftools==0.24
 capstone
 ropgadget>=5.3
 pyserial>=2.7

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ for filename in glob.glob('pwnlib/commandline/*'):
 
 install_requires     = ['paramiko>=1.15.2',
                         'mako>=1.0.0',
-                        'pyelftools>=0.2.4',
+                        'pyelftools==0.24',
                         'capstone>=3.0.5rc2', # See Gallopsled/pwntools#971, Gallopsled/pwntools#1160
                         'ropgadget>=5.3',
                         'pyserial>=2.7',


### PR DESCRIPTION
Since version 0.25 of pyelftools has some changes, installed version must be 0.24.
Will fix : #1189 