### PR TITLE
Do not use format operator in logging statements

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -180,7 +180,7 @@ def which_binutils(util):
             if context.arch in arches:
                 arches.append(None)
     except AttributeError:
-        log.warn_once("Your local binutils won't be used because architecture %r is not supported." % machine)
+        log.warn_once("Your local binutils won't be used because architecture %r is not supported.", machine)
 
     utils = [util]
 
@@ -650,7 +650,7 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
     code      += _arch_header()
     code      += cpp(shellcode)
 
-    log.debug('Assembling\n%s' % code)
+    log.debug('Assembling\n%s', code)
 
     tmpdir    = tempfile.mkdtemp(prefix = 'pwn-asm-')
     step1     = path.join(tmpdir, 'step1')
@@ -693,7 +693,7 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
                 [which_binutils('readelf'), '-r', step2]
             ).strip()
             if extract and len(relocs.split('\n')) > 1:
-                log.error('Shellcode contains relocations:\n%s' % relocs)
+                log.error('Shellcode contains relocations:\n%s', relocs)
         else:
             shutil.copy(step2, step3)
 
@@ -788,7 +788,7 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
         output1 = output0.split('<.text>:\n')
 
         if len(output1) != 2:
-            log.error('Could not find .text in objdump output:\n%s' % output0)
+            log.error('Could not find .text in objdump output:\n%s', output0)
 
         result = output1[1].strip('\n').rstrip().expandtabs()
     except Exception:

--- a/pwnlib/commandline/constgrep.py
+++ b/pwnlib/commandline/constgrep.py
@@ -84,7 +84,7 @@ def main(args):
             try:
                 constant = safeeval.expr(args.constant)
             except:
-                log.error("Could not evaluate constant %r" % args.constant)
+                log.error("Could not evaluate constant %r", args.constant)
         else:
             constant = None
 

--- a/pwnlib/commandline/pwnstrip.py
+++ b/pwnlib/commandline/pwnstrip.py
@@ -36,7 +36,7 @@ def main(args):
 
     for function in args.patch:
         if function not in elf.symbols:
-            log.error("Could not find function %r" % function)
+            log.error("Could not find function %r", function)
 
         trap = asm(shellcraft.trap())
         offset = elf.symbols[function]

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -197,7 +197,7 @@ def main(args):
         exit()
 
     if args.shellcode not in shellcraft.templates:
-        log.error("Unknown shellcraft template %r. Use --list to see available shellcodes." % args.shellcode)
+        log.error("Unknown shellcraft template %r. Use --list to see available shellcodes.", args.shellcode)
 
     func = get_template(args.shellcode)
 

--- a/pwnlib/config.py
+++ b/pwnlib/config.py
@@ -54,7 +54,7 @@ def initialize():
 
     for section in c.sections():
         if section not in registered_configs:
-            log.warn("Unknown configuration section %r" % section)
+            log.warn("Unknown configuration section %r", section)
             continue
         settings = dict(c.items(section))
         registered_configs[section](settings)

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -530,10 +530,10 @@ class Corefile(ELF):
         self._address  = 0
 
         if not self.elftype == 'CORE':
-            log.error("%s is not a valid corefile" % self.file.name)
+            log.error("%s is not a valid corefile", self.file.name)
 
         if not self.arch in prstatus_types.keys():
-            log.warn_once("%s does not use a supported corefile architecture, registers are unavailable" % self.file.name)
+            log.warn_once("%s does not use a supported corefile architecture, registers are unavailable", self.file.name)
 
         prstatus_type = prstatus_types.get(self.arch, None)
         prpsinfo_type = prpsinfo_types.get(self.bits, None)
@@ -1039,7 +1039,7 @@ class Corefile(ELF):
             'Hello!'
         """
         if name not in self.env:
-            log.error("Environment variable %r not set" % name)
+            log.error("Environment variable %r not set", name)
 
         return self.string(self.env[name])
 
@@ -1074,7 +1074,7 @@ class Corefile(ELF):
     def debug(self, *a, **kw):
         """Open the corefile under a debugger."""
         if a or kw:
-            log.error("Arguments are not supported for %s.debug()" % self.__class__.__name__)
+            log.error("Arguments are not supported for %s.debug()", self.__class__.__name__)
 
         import pwnlib.gdb
         pwnlib.gdb.attach(self, exe=self.exe.path)
@@ -1125,12 +1125,12 @@ class CorefileFinder(object):
         self.kernel_core_pattern = self.read('/proc/sys/kernel/core_pattern').strip()
         self.kernel_core_uses_pid = bool(int(self.read('/proc/sys/kernel/core_uses_pid')))
 
-        log.debug("core_pattern: %r" % self.kernel_core_pattern)
-        log.debug("core_uses_pid: %r" % self.kernel_core_uses_pid)
+        log.debug("core_pattern: %r", self.kernel_core_pattern)
+        log.debug("core_uses_pid: %r", self.kernel_core_uses_pid)
 
         self.interpreter = self.binfmt_lookup()
 
-        log.debug("interpreter: %r" % self.interpreter)
+        log.debug("interpreter: %r", self.interpreter)
 
         # If we have already located the corefile, we will
         # have renamed it to 'core.<pid>'
@@ -1138,7 +1138,7 @@ class CorefileFinder(object):
         self.core_path = None
 
         if os.path.isfile(core_path):
-            log.debug("Found core immediately: %r" % core_path)
+            log.debug("Found core immediately: %r", core_path)
             self.core_path = core_path
 
         # Try QEMU first, since it's unlikely to be a false-positive unless
@@ -1167,7 +1167,7 @@ class CorefileFinder(object):
 
         # Check the PID
         if core_pid != self.pid:
-            log.warn("Corefile PID does not match! (got %i)" % core_pid)
+            log.warn("Corefile PID does not match! (got %i)", core_pid)
 
         # Register the corefile for removal only if it's an exact match
         elif context.delete_corefiles:
@@ -1209,7 +1209,7 @@ class CorefileFinder(object):
         """
         crash_data = self.apport_read_crash_data()
 
-        log.debug("Apport Crash Data:\n%s" % crash_data)
+        log.debug("Apport Crash Data:\n%s", crash_data)
 
         if crash_data:
             return self.apport_crash_extract_corefile(crash_data)
@@ -1271,7 +1271,7 @@ class CorefileFinder(object):
         crash_path = '/var/crash/%s.%i.crash' % (crash_name, uid)
 
         try:
-            log.debug("Looking for Apport crash at %r" % crash_path)
+            log.debug("Looking for Apport crash at %r", crash_path)
             data = self.read(crash_path)
         except Exception:
             return None
@@ -1303,7 +1303,7 @@ class CorefileFinder(object):
         """
         # We only support apport
         if '/apport' not in self.kernel_core_pattern:
-            log.warn_once("Unsupported core_pattern: %r" % self.kernel_core_pattern)
+            log.warn_once("Unsupported core_pattern: %r", self.kernel_core_pattern)
             return None
 
         apport_core = self.apport_corefile()
@@ -1360,13 +1360,13 @@ class CorefileFinder(object):
         if os.pathsep not in corefile_path:
             corefile_path = os.path.join(self.cwd, corefile_path)
 
-        log.debug("Trying corefile_path: %r" % corefile_path)
+        log.debug("Trying corefile_path: %r", corefile_path)
 
         try:
             self.read(corefile_path)
             return corefile_path
         except Exception as e:
-            log.debug("No dice: %s" % e)
+            log.debug("No dice: %s", e)
 
     def qemu_corefile(self):
         """qemu_corefile() -> str
@@ -1390,7 +1390,7 @@ class CorefileFinder(object):
         # Get the full path
         corefile_path = os.path.join(self.cwd, corefile_name)
 
-        log.debug("Trying corefile_path: %r" % corefile_path)
+        log.debug("Trying corefile_path: %r", corefile_path)
 
         # Glob all of them, return the *most recent* based on numeric sort order.
         for corefile in sorted(glob.glob(corefile_path), reverse=True):

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1102,7 +1102,7 @@ class Coredump(Corefile):
 class CorefileFinder(object):
     def __init__(self, proc):
         if proc.poll() is None:
-            log.error("Process %i has not exited" % (process.pid))
+            log.error("Process %r has not exited", process.pid)
 
         self.process = proc
         self.pid = proc.pid
@@ -1134,7 +1134,7 @@ class CorefileFinder(object):
 
         # If we have already located the corefile, we will
         # have renamed it to 'core.<pid>'
-        core_path = 'core.%i' % (proc.pid)
+        core_path = 'core.%r' % (proc.pid)
         self.core_path = None
 
         if os.path.isfile(core_path):
@@ -1159,7 +1159,7 @@ class CorefileFinder(object):
 
         # Move the corefile if we're configured that way
         if context.rename_corefiles:
-            new_path = 'core.%i' % core_pid
+            new_path = 'core.%r' % core_pid
             if core_pid > 0 and new_path != self.core_path:
                 write(new_path, self.read(self.core_path))
                 self.unlink(self.core_path)
@@ -1167,7 +1167,7 @@ class CorefileFinder(object):
 
         # Check the PID
         if core_pid != self.pid:
-            log.warn("Corefile PID does not match! (got %i)", core_pid)
+            log.warn("Corefile PID does not match! (got %r)", core_pid)
 
         # Register the corefile for removal only if it's an exact match
         elif context.delete_corefiles:
@@ -1355,7 +1355,7 @@ class CorefileFinder(object):
         corefile_path = pattern.sub(lambda m: replace[re.escape(m.group(0))], core_pattern)
 
         if self.kernel_core_uses_pid:
-            corefile_path += '.%i' % self.pid
+            corefile_path += '.%r' % self.pid
 
         if os.pathsep not in corefile_path:
             corefile_path = os.path.join(self.cwd, corefile_path)

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -51,11 +51,17 @@ from elftools.elf.constants import P_FLAGS
 from elftools.elf.constants import SHN_INDICES
 from elftools.elf.descriptions import describe_e_type
 from elftools.elf.elffile import ELFFile
-from elftools.elf.enums import ENUM_P_TYPE
 from elftools.elf.gnuversions import GNUVerDefSection
 from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import SymbolTableSection
 from elftools.elf.segments import InterpSegment
+
+# ENUM_P_TYPE was renamed to ENUM_P_TYPE_BASE in elftools 0.25:
+# https://github.com/eliben/pyelftools/commit/73716604dcd617f77ea39f20b32189ca6dc395e5
+try:
+    from elftools.elf.enums import ENUM_P_TYPE_BASE
+except ImportError:
+    from elftools.elf.enums import ENUM_P_TYPE as ENUM_P_TYPE_BASE
 
 import intervaltree
 
@@ -1746,7 +1752,7 @@ class ELF(ELFFile):
 
         Zeroes out the ``PT_GNU_STACK`` program header ``p_type`` field.
         """
-        PT_GNU_STACK = packing.p32(ENUM_P_TYPE['PT_GNU_STACK'])
+        PT_GNU_STACK = packing.p32(ENUM_P_TYPE_BASE['PT_GNU_STACK'])
 
         if not self.executable:
             log.error("Can only make stack executable with executables")
@@ -1767,4 +1773,3 @@ class ELF(ELFFile):
                 return
 
         log.error("Could not find PT_GNU_STACK, stack should already be executable")
-

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -56,12 +56,11 @@ from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import SymbolTableSection
 from elftools.elf.segments import InterpSegment
 
-# ENUM_P_TYPE was renamed to ENUM_P_TYPE_BASE in elftools 0.25:
-# https://github.com/eliben/pyelftools/commit/73716604dcd617f77ea39f20b32189ca6dc395e5
+# See https://github.com/Gallopsled/pwntools/issues/1189
 try:
-    from elftools.elf.enums import ENUM_P_TYPE_BASE
+    from elftools.elf.enums import ENUM_P_TYPE
 except ImportError:
-    from elftools.elf.enums import ENUM_P_TYPE as ENUM_P_TYPE_BASE
+    from elftools.elf.enums import ENUM_P_TYPE_BASE as ENUM_P_TYPE
 
 import intervaltree
 
@@ -1752,7 +1751,7 @@ class ELF(ELFFile):
 
         Zeroes out the ``PT_GNU_STACK`` program header ``p_type`` field.
         """
-        PT_GNU_STACK = packing.p32(ENUM_P_TYPE_BASE['PT_GNU_STACK'])
+        PT_GNU_STACK = packing.p32(ENUM_P_TYPE['PT_GNU_STACK'])
 
         if not self.executable:
             log.error("Can only make stack executable with executables")

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -814,11 +814,11 @@ class ELF(ELFFile):
         ...         assert '__stack_chk_fail' in test.plt, test
         """
         if self.statically_linked:
-            log.debug("%r is statically linked, skipping GOT/PLT symbols" % self.path)
+            log.debug("%r is statically linked, skipping GOT/PLT symbols", self.path)
             return
 
         if not self.got:
-            log.debug("%r doesn't have any GOT symbols, skipping PLT" % self.path)
+            log.debug("%r doesn't have any GOT symbols, skipping PLT", self.path)
             return
 
         # This element holds an address associated with the procedure linkage table

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -66,7 +66,7 @@ def emulate_plt_instructions_inner(elf, got, pc, data, targets):
     }.get(elf.arch, None)
 
     if arch is None:
-        log.warn("Could not emulate PLT instructions for %r" % elf)
+        log.warn("Could not emulate PLT instructions for %r", elf)
         return {}
 
     emulation_bits = elf.bits

--- a/pwnlib/encoders/encoder.py
+++ b/pwnlib/encoders/encoder.py
@@ -84,7 +84,7 @@ def encode(raw_bytes, avoid=None, expr=None, force=0, pcreg=''):
             continue
 
         if avoid & set(v):
-            log.warning_once("Encoder %s did not succeed" % encoder)
+            log.warning_once("Encoder %s did not succeed", encoder)
             continue
 
         return v

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -425,7 +425,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
         qemu_user = qemu.user_path()
         sysroot = sysroot or qemu.ld_prefix(env=env)
         if not qemu_user:
-            log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
+            log.error("Cannot debug %s binaries without appropriate QEMU binaries", context.arch)
         args = [qemu_user, '-g', str(qemu_port)] + args
 
     # Use a sane default sysroot for Android
@@ -434,11 +434,11 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
 
     # Make sure gdbserver/qemu is installed
     if not which(args[0]):
-        log.error("%s is not installed" % args[0])
+        log.error("%s is not installed", args[0])
 
     exe = exe or which(orig_args[0])
     if not exe:
-        log.error("%s does not exist" % orig_args[0])
+        log.error("%s does not exist", orig_args[0])
     else:
         gdbscript = 'file %s\n%s' % (exe, gdbscript)
 
@@ -648,7 +648,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
 
         pids = pidof(target)
         if not pids:
-            log.error('No such process: %s' % target)
+            log.error('No such process: %s', target)
         pid = pids[0]
         log.info('Attaching to youngest process "%s" (PID = %d)' %
                  (target, pid))
@@ -710,7 +710,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
     elif isinstance(target, elf.corefile.Corefile):
         pre += 'target core %s\n' % target.path
     else:
-        log.error("don't know how to attach to target: %r" % target)
+        log.error("don't know how to attach to target: %r", target)
 
     # if we have a pid but no exe, just look it up in /proc/
     if pid and not exe:
@@ -743,7 +743,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
             ssh.download_file(exe)
             exe = os.path.basename(exe)
         if not os.path.isfile(exe):
-            log.error('No such file: %s' % exe)
+            log.error('No such file: %s', exe)
         cmd += ' "%s"' % exe
 
     if pid and not context.os == 'android':

--- a/pwnlib/regsort.py
+++ b/pwnlib/regsort.py
@@ -346,7 +346,7 @@ def regsort(in_out, all_regs, tmp = None, xchg = True, randomize = None):
                 break
         else:
             nope = sorted((k,v) for k,v in in_out.items())
-            log.error("Cannot break dependency cycles in %r" % nope)
+            log.error("Cannot break dependency cycles in %r", nope)
 
 
     # Don't set the temporary register now

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -326,7 +326,7 @@ class DescriptiveStack(list):
                 if self.address != 0 and self.address < data < self.next:
                     off = data - addr
             else:
-                log.error("Don't know how to dump %r" % data)
+                log.error("Don't know how to dump %r", data)
             desc = self.descriptions.get(addr, '')
             if desc:
                 line += ' %s' % desc
@@ -771,7 +771,7 @@ class ROP(object):
                             adjust   = self.search(move = fix_bytes)
 
                             if not adjust:
-                                log.error("Could not find gadget to adjust stack by %#x bytes" % fix_bytes)
+                                log.error("Could not find gadget to adjust stack by %#x bytes", fix_bytes)
 
                             nextGadgetAddr += adjust.move
 
@@ -889,7 +889,7 @@ class ROP(object):
 
         # Otherwise, if it is a syscall we might be able to call it
         elif not self._srop_call(resolvable, arguments):
-            log.error('Could not resolve %r.' % resolvable)
+            log.error('Could not resolve %r.', resolvable)
 
 
 
@@ -911,7 +911,7 @@ class ROP(object):
             if syscall_gadget:
                 break
         else:
-            log.error("Could not find any instructions in %r" % syscall_instructions)
+            log.error("Could not find any instructions in %r", syscall_instructions)
 
         # Generate the SROP frame which would invoke the syscall
         with context.local(arch=self.elfs[0].arch):

--- a/pwnlib/shellcraft/templates/amd64/mov.asm
+++ b/pwnlib/shellcraft/templates/amd64/mov.asm
@@ -92,7 +92,7 @@ Args:
 </%docstring>
 <%
 if not get_register(dest):
-    log.error('%r is not a register' % dest)
+    log.error('%r is not a register', dest)
 
 dest = get_register(dest)
 
@@ -222,5 +222,5 @@ else:
         % endif
     % endif
 % else:
-    <% log.error('%s is neither a register nor an immediate' % src) %>\
+    <% log.error('%s is neither a register nor an immediate', src) %>\
 % endif

--- a/pwnlib/shellcraft/templates/i386/mov.asm
+++ b/pwnlib/shellcraft/templates/i386/mov.asm
@@ -95,18 +95,18 @@ if not isinstance(src, (str, tuple)):
     src_name = pretty(src)
 
 if not get_register(dest):
-    log.error('%r is not a register' % dest)
+    log.error('%r is not a register', dest)
 
 dest = get_register(dest)
 
 if dest.size > 32 or dest.is64bit:
-    log.error("cannot use %s on i386" % dest)
+    log.error("cannot use %s on i386", dest)
 
 if get_register(src):
     src = get_register(src)
 
     if src.is64bit:
-        log.error("cannot use %s on i386" % src)
+        log.error("cannot use %s on i386", src)
 
     if dest.size < src.size and src.name not in dest.bigger:
         log.error("cannot mov %s, %s: dddest is smaller than src" % (dest, src))

--- a/pwnlib/shellcraft/templates/mips/mov.asm
+++ b/pwnlib/shellcraft/templates/mips/mov.asm
@@ -61,7 +61,7 @@ Example:
 </%docstring>
 <%
 if isinstance(src, str) and src.startswith('$') and src not in registers.mips:
-    log.error("Unknown register %r" % src)
+    log.error("Unknown register %r", src)
     return
 
 if not dst.startswith('$'):
@@ -69,7 +69,7 @@ if not dst.startswith('$'):
     return
 
 if isinstance(src, str) and dst.startswith('$') and dst not in registers.mips:
-    log.error("Unknown register %r" % dst)
+    log.error("Unknown register %r", dst)
     return
 
 if isinstance(src, str) and src not in registers.mips:

--- a/pwnlib/shellcraft/templates/thumb/mov.asm
+++ b/pwnlib/shellcraft/templates/thumb/mov.asm
@@ -68,7 +68,7 @@ if isinstance(src, (str, unicode)):
             try:
                 src = eval(src)
             except (AttributeError, ValueError):
-                log.error("Could not figure out the value of %r" % src)
+                log.error("Could not figure out the value of %r", src)
                 return
 
 # ARM has a mov-const-with-shift

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -228,7 +228,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
     if not terminal:
         log.error('Could not find a terminal binary to use. Set context.terminal to your terminal.')
     elif not which(terminal):
-        log.error('Could not find terminal binary %r. Set context.terminal to your terminal.' % terminal)
+        log.error('Could not find terminal binary %r. Set context.terminal to your terminal.', terminal)
 
     if isinstance(args, tuple):
         args = list(args)
@@ -244,7 +244,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
             log.error("Cannot use commands with semicolon.  Create a script and invoke that directly.")
         argv += list(command)
 
-    log.debug("Launching a new terminal: %r" % argv)
+    log.debug("Launching a new terminal: %r", argv)
 
     pid = os.fork()
 

--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -313,7 +313,7 @@ def test(original):
         binary = shell[0]
 
         if not which(binary):
-            log.warn_once('Shell %r is not available' % binary)
+            log.warn_once('Shell %r is not available', binary)
             continue
 
         progress = log.progress('%s: %r' % (binary, original))


### PR DESCRIPTION
This leads to issues when the resulting string has format operators.

Fails with exception:

    >>> log.warn_once('asdf %r' % '|hello world %d')

Does not fail:

    >> log.warn_once('asdf %r', '|hello world %d')

Notice the change from '%' to ', '.

This change can be somewhat automated via:

    $ sed -i -E "s/( log\.(debug|error|warn)(_once)?.*) % ([^(]+$)/\1, \4/" **/*.py

However, this only works for messages which contain only one format parameter.

Closes #1177 