### PR TITLE
Docker: Kill 14 layers in pwntools base images

### DIFF
--- a/extra/docker/kali/Dockerfile
+++ b/extra/docker/kali/Dockerfile
@@ -6,21 +6,19 @@
 FROM kalilinux/kali-linux-docker
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN apt-get install -y git
-RUN apt-get install -y libssl-dev
-RUN apt-get install -y libffi-dev
-RUN apt-get install -y python2.7
-RUN apt-get install -y python-pip
-RUN apt-get install -y python-dev
-RUN pip install --upgrade pip
-RUN python -m pip install --upgrade pwntools
-RUN PWNLIB_NOTERM=1 pwn update
-
-RUN apt-get install -y sudo
-RUN useradd -m pwntools
-RUN passwd --delete --unlock pwntools
-RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
+RUN apt-get update && apt-get install -y build-essential \
+        git \
+        libssl-dev \
+        libffi-dev \
+        python2.7 \
+        python-pip \
+        python-dev \
+    && pip install --upgrade pip \
+    && python -m pip install --upgrade pwntools \
+    && PWNLIB_NOTERM=1 pwn update \
+    && apt-get install -y sudo \
+    && useradd -m pwntools \
+    && passwd --delete --unlock pwntools \
+    && echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
 USER pwntools
 WORKDIR /home/pwntools

--- a/extra/docker/kali/Dockerfile
+++ b/extra/docker/kali/Dockerfile
@@ -6,7 +6,9 @@
 FROM kalilinux/kali-linux-docker
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update && apt-get install -y build-essential \
+RUN apt-get update \
+    && apt-get install -y \
+        build-essential \
         git \
         libssl-dev \
         libffi-dev \

--- a/extra/docker/precise/Dockerfile
+++ b/extra/docker/precise/Dockerfile
@@ -6,7 +6,9 @@
 FROM ubuntu:precise
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update && apt-get install -y build-essential \
+RUN apt-get update \
+    && apt-get install -y \
+        build-essential \
         git \
         libssl-dev \
         libffi-dev \

--- a/extra/docker/precise/Dockerfile
+++ b/extra/docker/precise/Dockerfile
@@ -6,21 +6,19 @@
 FROM ubuntu:precise
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN apt-get install -y git
-RUN apt-get install -y libssl-dev
-RUN apt-get install -y libffi-dev
-RUN apt-get install -y python2.7
-RUN apt-get install -y python-pip
-RUN apt-get install -y python-dev
-RUN pip install --upgrade pip
-RUN python -m pip install --upgrade pwntools
-RUN PWNLIB_NOTERM=1 pwn update
-
-RUN apt-get install -y sudo
-RUN useradd -m pwntools
-RUN passwd --delete --unlock pwntools
-RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
+RUN apt-get update && apt-get install -y build-essential \
+        git \
+        libssl-dev \
+        libffi-dev \
+        python2.7 \
+        python-pip \
+        python-dev \
+    && pip install --upgrade pip \
+    && python -m pip install --upgrade pwntools \
+    && PWNLIB_NOTERM=1 pwn update \
+    && apt-get install -y sudo \
+    && useradd -m pwntools \
+    && passwd --delete --unlock pwntools \
+    && echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
 USER pwntools
 WORKDIR /home/pwntools

--- a/extra/docker/trusty/Dockerfile
+++ b/extra/docker/trusty/Dockerfile
@@ -6,21 +6,19 @@
 FROM ubuntu:trusty
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN apt-get install -y git
-RUN apt-get install -y libssl-dev
-RUN apt-get install -y libffi-dev
-RUN apt-get install -y python2.7
-RUN apt-get install -y python-pip
-RUN apt-get install -y python-dev
-RUN pip install --upgrade pip
-RUN python -m pip install --upgrade pwntools
-RUN PWNLIB_NOTERM=1 pwn update
-
-RUN apt-get install -y sudo
-RUN useradd -m pwntools
-RUN passwd --delete --unlock pwntools
-RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
+RUN apt-get update && apt-get install -y build-essential \
+        git \
+        libssl-dev \
+        libffi-dev \
+        python2.7 \
+        python-pip \
+        python-dev \
+    && pip install --upgrade pip \
+    && python -m pip install --upgrade pwntools \
+    && PWNLIB_NOTERM=1 pwn update \
+    && apt-get install -y sudo \
+    && useradd -m pwntools \
+    && passwd --delete --unlock pwntools \
+    && echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
 USER pwntools
 WORKDIR /home/pwntools

--- a/extra/docker/trusty/Dockerfile
+++ b/extra/docker/trusty/Dockerfile
@@ -6,7 +6,9 @@
 FROM ubuntu:trusty
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update && apt-get install -y build-essential \
+RUN apt-get update \
+    && apt-get install -y \
+        build-essential \
         git \
         libssl-dev \
         libffi-dev \

--- a/extra/docker/xenial/Dockerfile
+++ b/extra/docker/xenial/Dockerfile
@@ -6,7 +6,9 @@
 FROM ubuntu:xenial
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update && apt-get install -y build-essential \
+RUN apt-get update \
+    && apt-get install -y \
+        build-essential \
         git \
         libssl-dev \
         libffi-dev \

--- a/extra/docker/xenial/Dockerfile
+++ b/extra/docker/xenial/Dockerfile
@@ -6,21 +6,19 @@
 FROM ubuntu:xenial
 MAINTAINER Maintainer Gallopsled et al.
 
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN apt-get install -y git
-RUN apt-get install -y libssl-dev
-RUN apt-get install -y libffi-dev
-RUN apt-get install -y python2.7
-RUN apt-get install -y python-pip
-RUN apt-get install -y python-dev
-RUN pip install --upgrade pip
-RUN python -m pip install --upgrade pwntools
-RUN PWNLIB_NOTERM=1 pwn update
-
-RUN apt-get install -y sudo
-RUN useradd -m pwntools
-RUN passwd --delete --unlock pwntools
-RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
+RUN apt-get update && apt-get install -y build-essential \
+        git \
+        libssl-dev \
+        libffi-dev \
+        python2.7 \
+        python-pip \
+        python-dev \
+    && pip install --upgrade pip \
+    && python -m pip install --upgrade pwntools \
+    && PWNLIB_NOTERM=1 pwn update \
+    && apt-get install -y sudo \
+    && useradd -m pwntools \
+    && passwd --delete --unlock pwntools \
+    && echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools
 USER pwntools
 WORKDIR /home/pwntools


### PR DESCRIPTION
We noticed that pwntools/pwntools has an excessive amount of layers, this change squashes 14 of them into a single layer.