### PR TITLE
Reduce cache filename length on rop.py (fix #1180)

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1012,8 +1012,8 @@ class ROP(object):
             files = [files]
         
         sha256 = hashlib.sha256()
-        for elf in self.elfs:
-            sha256.update(elf.get_data())
+        for elf_data in sorted(elf.get_data() for elf in self.elfs):
+            sha256.update(elf_data)
 
         return os.path.join(cachedir, sha256.hexdigest())
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1010,14 +1010,12 @@ class ROP(object):
 
         if isinstance(files, ELF):
             files = [files]
-
-        hashes = []
-
+        
+        sha256 = hashlib.sha256()
         for elf in self.elfs:
-            sha256 = hashlib.sha256(elf.get_data()).hexdigest()
-            hashes.append(sha256)
+            sha256.update(elf.get_data())
 
-        return os.path.join(cachedir, '_'.join(hashes))
+        return os.path.join(cachedir, sha256.hexdigest())
 
     def __cache_load(self, elf):
         filename = self.__get_cachefile_name(elf)


### PR DESCRIPTION
# Pwntools Pull Request

Reduce cache filename length on rop.py.
 Fixes 1180.

## Target Branch (this should target all branches: stable, beta, dev)