### PR TITLE
Testing infrastructure fixes

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -427,7 +427,7 @@ class Corefile(ELF):
 
         Corefiles can also be pulled from remote machines via SSH!
 
-        >>> s = ssh('travis', 'example.pwnme')
+        >>> s = ssh(host='example.pwnme', user='travis', password='demopass')
         >>> _ = s.set_working_directory()
         >>> elf = ELF.from_assembly(shellcraft.trap())
         >>> path = s.upload(elf.path)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'psutil>=3.3.0',
                         'intervaltree',
                         'sortedcontainers<2.0', # See Gallopsled/pwntools#1154
+                        'sphinx==1.6.7',
                         'unicorn']
 
 # Check that the user has installed the Python development headers

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ install_requires     = ['paramiko>=1.15.2',
                         'psutil>=3.3.0',
                         'intervaltree',
                         'sortedcontainers<2.0', # See Gallopsled/pwntools#1154
-                        'sphinx==1.6.7',
                         'unicorn']
 
 # Check that the user has installed the Python development headers

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -89,13 +89,16 @@ setup_linux()
         else
             sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-mips-linux-gnu binutils-powerpc-linux-gnu
         fi
-    fi
-
-    if [ PKG_MAN = "pacman" ]; then
+    elif [ PKG_MAN = "pacman" ]; then
         pacman -S openssh curses jre8-openjdk-headless bintuils arm-none-eabi-binutils yay
         # TODO: binutils-mips-linux-gnu binutils-powerpc-linux-gnu are only in AUR
         yay -S cross-mipsel-linux-gnu-binutils powerpc-linux-gnu-binutils
         systemctl start sshd
+    else
+        echo "Package manager detected : $PKG_MAN"
+        echo "Your package manager isn't apt-get or pacman, try to manually install the following:"
+        echo "openssh curses jre8-openjdk-headless and binutils for x86_86, arm, mips and powerpc"
+        echo "and start openssh server (should allow user travis:demopass)
     fi
 }
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -64,14 +64,38 @@ setup_travis()
 
 setup_linux()
 {
-    sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
-    RELEASE="$(lsb-release -sr)"
-    if [[ "$RELEASE" < "16.04" ]]; then
-        sudo apt-add-repository --yes ppa:pwntools/binutils
-        sudo apt-get update
-        sudo apt-get install -y binutils-arm-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu
-    else
-        sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+    declare -A osInfo;
+    osInfo[/etc/redhat-release]=yum
+    osInfo[/etc/arch-release]=pacman
+    osInfo[/etc/gentoo-release]=emerge
+    osInfo[/etc/SuSE-release]=zypp
+    osInfo[/etc/debian_version]=apt-get
+
+    for f in ${!osInfo[@]}
+    do
+        if [[ -f $f ]];then
+            PKG_MAN=${osInfo[$f]}
+            echo detected package manager $PKG_MAN
+        fi
+    done
+
+    if [ PKG_MAN = "apt-get" ]; then
+        sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
+        RELEASE="$(lsb-release -sr)"
+        if [[ "$RELEASE" < "16.04" ]]; then
+            sudo apt-add-repository --yes ppa:pwntools/binutils
+            sudo apt-get update
+            sudo apt-get install -y binutils-arm-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+        else
+            sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+        fi
+    fi
+
+    if [ PKG_MAN = "pacman" ]; then
+        pacman -S openssh curses jre8-openjdk-headless bintuils arm-none-eabi-binutils yay
+        # TODO: binutils-mips-linux-gnu binutils-powerpc-linux-gnu are only in AUR
+        yay -S cross-mipsel-linux-gnu-binutils powerpc-linux-gnu-binutils
+        systemctl start sshd
     fi
 }
 


### PR DESCRIPTION
As requested by @Arusekk in [his repo](https://github.com/Arusekk/pwntools/pull/4#pullrequestreview-170475469), the following changes are relevant to python2-dev:
* Corefile test has no pw -> failed to log in for me and got the test stuck
* The very recent version of sphinx (1.11 in py3) produces some recursion scanning errors for me -> suggesting a fixed version requirement. However I can't fully verify if the very recent sphinx on py2 also breaks stuff -> ignore it on merging if py3 compatibility isn't an issue and the most recent sphinx on py2 doesn't break anything
* The test-environment only works for apt-get based systems -> fix to get it running on arch/manjaro based systems and detection for other popular package managers