### PR TITLE
Slightly improve dupio with loop opcode

### DIFF
--- a/pwnlib/shellcraft/templates/amd64/linux/dup.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/dup.asm
@@ -14,14 +14,13 @@ Args: [sock (imm/reg) = rbp]
 ${dup}:
     ${amd64.mov('rbp', sock)}
 
-    push 3
+    push 2
+    pop rcx
 ${looplabel}:
-    pop rsi
-    dec rsi
-    js ${after}
-    push rsi
+    push rcx
 
-    ${amd64.linux.syscall('SYS_dup2', 'rbp', 'rsi')}
+    ${amd64.linux.syscall('SYS_dup2', 'ebp', 'ecx')}
 
-    jmp ${looplabel}
+    pop rcx
+    loop ${looplabel}
 ${after}:

--- a/pwnlib/shellcraft/templates/i386/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/dupio.asm
@@ -14,9 +14,8 @@ Args: [sock (imm/reg) = ebp]
     /* dup() file descriptor ${sock} into stdin/stdout/stderr */
 ${dup}:
     ${mov('ebx', sock)}
-    ${mov('ecx', 3)}
+    ${mov('ecx', 2)}
 ${looplabel}:
-    dec ecx
 
     ${dup2('ebx', 'ecx')}
-    jnz ${looplabel}
+    loop ${looplabel}


### PR DESCRIPTION
This is an enhancement that reduces the size of `i386.dupio()` / `amd64.dup()` shellcodes by using `loop` opcode, which is a conditional jump with a counter in `ecx` / `rcx`.

For reference:
http://www.posix.nl/linuxassembly/nasmdochtml/nasmdoca.html#section-A.99