### PR TITLE
Fix typos in process.py

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -435,11 +435,11 @@ class process(tube):
         # appropriate qemu binary to run it.
         qemu_path = qemu.user_path(arch=binary.arch)
 
-        if not qemu:
+        if not qemu_path:
             raise exception
 
         qemu_path = which(qemu_path)
-        if qemu:
+        if qemu_path:
             self._qemu = qemu_path
 
             args = [qemu_path]


### PR DESCRIPTION
These were on the path where `-ENOEXEC` is returned when we're trying to execute a binary, and `qemu-user` packages are not installed (i.e. there is no `qemu-arm` or `qemu-arm-static` installed).

The error handling around this case checked the wrong variable.
