### PR TITLE
Launch QEMU with sysroot if specified

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -427,10 +427,10 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
         sysroot = sysroot or qemu.ld_prefix(env=env)
         if not qemu_user:
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
-        qemu_args = ['-g', str(qemu_port)]
+        qemu_args = [qemu_user, '-g', str(qemu_port)]
         if sysroot:
-            qemu_args = ['-L', sysroot] + qemu_args
-        args = [qemu_user] + qemu_args + args
+            qemu_args = ['-L', sysroot]
+        args = qemu_args + args
 
     # Use a sane default sysroot for Android
     if not sysroot and context.os == 'android':

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -427,7 +427,10 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
         sysroot = sysroot or qemu.ld_prefix(env=env)
         if not qemu_user:
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
-        args = [qemu_user, '-g', str(qemu_port)] + args
+        qemu_args = ['-g', str(qemu_port)]
+        if sysroot:
+            qemu_args = ['-L', sysroot] + qemu_args
+        args = [qemu_user] + qemu_args + args
 
     # Use a sane default sysroot for Android
     if not sysroot and context.os == 'android':

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -429,7 +429,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
         qemu_args = [qemu_user, '-g', str(qemu_port)]
         if sysroot:
-            qemu_args = ['-L', sysroot]
+            qemu_args += ['-L', sysroot]
         args = qemu_args + args
 
     # Use a sane default sysroot for Android


### PR DESCRIPTION
When launching an ARM binary with QEMU using `gdb.debug`, we need to specify the `-L` flag to tell QEMU where the sysroot is. Otherwise it will use the default system root instead of the one we specified.

I tested this with the following code before and after this change:
```
#!/usr/bin/env python2

from pwn import *

context(arch='arm')
p = gdb.debug('./nightmare', sysroot='./')
p.interactive()
```

Afterwards, I could see that the loaded libraries in `vmmap` were from the correct sysroot.