### PR TITLE
Do not use intervaltree 3.xx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'pypandoc',
                         'packaging',
                         'psutil>=3.3.0',
-                        'intervaltree',
+                        'intervaltree<3.0', # See Gallopsled/pwntools#1238
                         'sortedcontainers<2.0', # See Gallopsled/pwntools#1154
                         'unicorn']
 


### PR DESCRIPTION
In the future, we may want to update Pwntools to use the newer version.

In the meantime, pin to 2.xx

Fixes #1238 
