### PR TITLE
check qemu_path correctly and give out a reasonable error msg

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -438,7 +438,7 @@ class process(tube):
             raise exception
 
         qemu_path = which(qemu_path)
-        if qemu:
+        if qemu_path:
             self._qemu = qemu_path
 
             args = [qemu_path]

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -435,7 +435,7 @@ class process(tube):
         qemu_path = qemu.user_path(arch=binary.arch)
 
         if not qemu_path:
-            raise RuntimeError("No QEMU runner available, please install QEMU first")
+            raise exception
 
         qemu_path = which(qemu_path)
         if qemu:

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -434,8 +434,8 @@ class process(tube):
         # appropriate qemu binary to run it.
         qemu_path = qemu.user_path(arch=binary.arch)
 
-        if not qemu:
-            raise exception
+        if not qemu_path:
+            raise RuntimeError("No QEMU runner available, please install QEMU first")
 
         qemu_path = which(qemu_path)
         if qemu:


### PR DESCRIPTION
Should check `qemu_path` instead of `qemu` itself.

`qemu` will never be `None` so the exception will never be triggered.
But if `QEMU` is not installed, `qemu_path` will be `None` and later fails `which(qemu_path)`