### PR TITLE
Fix infinite loop in term.py

### DIFF
--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -246,9 +246,7 @@ def parse(s):
     out = []
     buf = map(ord, s)
     i = 0
-    while True:
-        if i >= len(buf):
-            break
+    while i < len(buf):
         x = None
         c = buf[i]
         if c >= 0x20 and c <= 0x7e:
@@ -315,6 +313,9 @@ def parse(s):
         elif c == 0x0d:
             x = (CR, None)
             i += 1
+        else:
+            i += 1
+
         if _graphics_mode:
             continue
         if x is None:


### PR DESCRIPTION
If the last character is an escape sequence, and we have entered graphics_mode,
the loop will never exit.

Fixes #1244