### PR TITLE
[WIP] Selectively skip doctest

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,6 +85,8 @@ class stdout(object):
     def __setattr__(self, name, value):
         return setattr(sys.stdout, name, value)
 pwnlib.context.ContextType.defaults['log_console'] = stdout()
+
+offline=True
 '''
 
 autoclass_content = 'both'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,6 +87,21 @@ class stdout(object):
 pwnlib.context.ContextType.defaults['log_console'] = stdout()
 
 offline=True
+binutils_mips=False
+binutils_arm=False
+binutils_amd64=False
+binutils_i386=False
+binutils_aarch64=False
+binutils_powerpc=False
+binutils_thumb=False
+qemu_mips=False
+qemu_arm=False
+qemu_amd64=False
+qemu_i386=False
+qemu_aarch64=False
+qemu_powerpc=False
+qemu_thumb=False
+travis=False
 '''
 
 autoclass_content = 'both'

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -114,6 +114,9 @@ Setting the Target Architecture and OS
 
 The target architecture can generally be specified as an argument to the routine that requires it.
 
+.. doctest::
+   :skipif: not binutils_arm
+
     >>> asm('nop')
     '\x90'
     >>> asm('nop', arch='arm')
@@ -121,12 +124,18 @@ The target architecture can generally be specified as an argument to the routine
 
 However, it can also be set once in the global ``context``.  The operating system, word size, and endianness can also be set here.
 
+.. doctest::
+   :skipif: not binutils_i386
+
     >>> context.arch      = 'i386'
     >>> context.os        = 'linux'
     >>> context.endian    = 'little'
     >>> context.word_size = 32
 
 Additionally, you can use a shorthand to set all of the values at once.
+
+.. doctest::
+   :skipif: not binutils_arm
 
     >>> asm('nop')
     '\x90'
@@ -202,7 +211,7 @@ ELF Manipulation
 
 Stop hard-coding things!  Look them up at runtime with :mod:`pwnlib.elf`.
 
-    >>> e = ELF('/bin/cat')
+    >>> e = ELF('/bin/cat') # doctest: +SKIP
     >>> print hex(e.address) #doctest: +SKIP
     0x400000
     >>> print hex(e.symbols['write']) #doctest: +SKIP
@@ -213,6 +222,9 @@ Stop hard-coding things!  Look them up at runtime with :mod:`pwnlib.elf`.
     0x401680
 
 You can even patch and save the files.
+
+ .. doctest::
+    :skipif: not travis
 
     >>> e = ELF('/bin/cat')
     >>> e.read(e.address, 4)

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -27,6 +27,9 @@ This exposes a standard interface to talk to processes, sockets, serial ports,
 and all manner of things, along with some nifty helpers for common tasks.
 For example, remote connections via :mod:`pwnlib.tubes.remote`.
 
+.. doctest::
+   :skipif: offline
+
     >>> conn = remote('ftp.ubuntu.com',21)
     >>> conn.recvline() # doctest: +ELLIPSIS
     '220 ...'

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -77,6 +77,9 @@ def dpkg_search_for_binutils(arch, util):
 
     ::
 
+.. doctest::
+   :skipif: not binutils_aarch64
+
         >>> pwnlib.asm.dpkg_search_for_binutils('aarch64', 'as')
         ['binutils-aarch64-linux-gnu']
     """
@@ -145,6 +148,9 @@ def which_binutils(util):
     Expects that the utility is prefixed with the architecture name.
 
     Examples:
+
+    .. doctest::
+       :skipif: not binutils_arm or not binutils_powerpc
 
         >>> import platform
         >>> which_binutils = pwnlib.asm.which_binutils
@@ -401,6 +407,9 @@ def cpp(shellcode):
 
     Examples:
 
+    .. doctest::
+       :skipif: not binutils_i386 or not binutils_arm or not binutils_thumb
+
         >>> cpp("mov al, SYS_setresuid", arch = "i386", os = "linux")
         'mov al, 164\n'
         >>> cpp("weee SYS_setresuid", arch = "arm", os = "linux")
@@ -469,6 +478,9 @@ def make_elf_from_assembly(assembly,
         This example shows how to create a shared library, and load it via
         ``LD_PRELOAD``.
 
+    .. doctest::
+       :skipif: not binutils_amd64 or not qemu_amd64
+
         >>> context.clear()
         >>> context.arch = 'amd64'
         >>> sc = 'push rbp; mov rbp, rsp;'
@@ -480,6 +492,9 @@ def make_elf_from_assembly(assembly,
 
         The same thing can be done with :func:`.make_elf`, though the sizes
         are different.  They both
+
+        .. doctest::
+           :skipif: not binutils_amd64 or not qemu_amd64
 
         >>> file_a = make_elf(asm('nop'), extract=True)
         >>> file_b = make_elf_from_assembly('nop', extract=True)
@@ -539,6 +554,9 @@ def make_elf(data,
     Examples:
         This example creates an i386 ELF that just does
         execve('/bin/sh',...).
+
+    .. doctest::
+       :skipif: not binutils_i386 or not qemu_i386
 
         >>> context.clear(arch='i386')
         >>> bin_sh = '6a68682f2f2f73682f62696e89e331c96a0b5899cd80'.decode('hex')
@@ -632,6 +650,9 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
                         ``arch='arm'``.
 
     Examples:
+
+    .. doctest::
+       :skipif: not binutils_i386 or not binutils_amd64 or not binutils_arm
 
         >>> asm("mov eax, SYS_select", arch = 'i386', os = 'freebsd')
         '\xb8]\x00\x00\x00'
@@ -736,6 +757,9 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
       Any arguments/properties that can be set on ``context``
 
     Examples:
+
+    .. doctest::
+       :skipif: not binutils_i386 or not binutils_amd64 or not binutils_arm or not binutils_thumb
 
         >>> print disasm('b85d000000'.decode('hex'), arch = 'i386')
            0:   b8 5d 00 00 00          mov    eax,0x5d

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1065,6 +1065,9 @@ class ContextType(object):
         the default port, **or** a ``tuple`` passed to ``socks.set_default_proxy``,
         e.g. ``(socks.SOCKS4, 'localhost', 1234)``.
 
+.. doctest::
+   :skipif: offline
+
         >>> context.proxy = 'localhost' #doctest: +ELLIPSIS
         >>> r=remote('google.com', 80)
         Traceback (most recent call last):

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -192,6 +192,9 @@ class Thread(threading.Thread):
 
     Examples:
 
+    .. doctest::
+       :skipif: not binutils_mips or not binutils_arm
+
         >>> context.clear()
         >>> context.update(arch='arm')
         >>> def p():
@@ -286,6 +289,9 @@ class ContextType(object):
     The context is also scope-aware by using the ``with`` keyword.
 
     Examples:
+
+    .. doctest::
+       :skipif: not binutils_mips or not binutils_arm
 
         >>> context.clear()
         >>> context.update(os='linux') # doctest: +ELLIPSIS
@@ -758,6 +764,9 @@ class ContextType(object):
         Data type is a :class:`pwnlib.elf.ELF` object.
 
         Examples:
+
+        .. doctest::
+           :skipif: not travis
 
             >>> context.clear()
             >>> context.arch, context.bits

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -330,6 +330,9 @@ class Corefile(ELF):
         If we run the binary and then wait for it to exit, we can get its
         core file.
 
+    .. doctest::
+       :skipif: not binutils_arm or not qemu_arm
+
         >>> context.clear(arch='arm')
         >>> shellcode = shellcraft.mov('r0', 0xdeadbeef)
         >>> shellcode += shellcraft.mov('r1', 0xcafebabe)
@@ -379,12 +382,18 @@ class Corefile(ELF):
         This requires GDB to be installed, and can only be done with native
         processes.  Getting a "complete" corefile requires GDB 7.11 or better.
 
+    .. doctest::
+       :skipif: not travis
+
         >>> elf = ELF('/bin/bash')
         >>> context.clear(binary=elf)
         >>> io = process(elf.path, env={'HELLO': 'WORLD'})
         >>> core = io.corefile
 
         Data can also be extracted directly from the corefile.
+
+    .. doctest::
+       :skipif: not travis
 
         >>> core.exe[elf.address:elf.address+4]
         '\x7fELF'
@@ -394,6 +403,9 @@ class Corefile(ELF):
         Various other mappings are available by name.  On Linux, 32-bit Intel binaries
         should have a VDSO section.  Since our ELF is statically linked, there is
         no libc which gets mapped.
+
+    .. doctest::
+       :skipif: not travis
 
         >>> core.vdso.data[:4]
         '\x7fELF'
@@ -405,6 +417,9 @@ class Corefile(ELF):
         should contain two pointer-widths of NULL bytes, preceded by the NULL-
         terminated path to the executable (as passed via the first arg to ``execve``).
 
+    .. doctest::
+       :skipif: not travis
+
         >>> stack_end = core.exe.name
         >>> stack_end += '\x00' * (1+8)
         >>> core.stack.data.endswith(stack_end)
@@ -413,6 +428,9 @@ class Corefile(ELF):
         True
 
         We can also directly access the environment variables and arguments.
+
+    .. doctest::
+       :skipif: not travis
 
         >>> 'HELLO' in core.env
         True
@@ -427,6 +445,9 @@ class Corefile(ELF):
 
         Corefiles can also be pulled from remote machines via SSH!
 
+    .. doctest::
+       :skipif: offline
+
         >>> s = ssh('travis', 'example.pwnme')
         >>> _ = s.set_working_directory()
         >>> elf = ELF.from_assembly(shellcraft.trap())
@@ -439,6 +460,9 @@ class Corefile(ELF):
         True
 
         Make sure fault_addr synthesis works for amd64 on ret.
+
+    .. doctest::
+       :skipif: not binutils_amd64
 
         >>> context.clear(arch='amd64')
         >>> elf = ELF.from_assembly('push 1234; ret')

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -8,7 +8,7 @@ Example Usage
 
 .. code-block:: python
 
-    >>> e = ELF('/bin/cat')
+    >>> e = ELF('/bin/cat') #doctest: +SKIP
     >>> print hex(e.address) #doctest: +SKIP
     0x400000
     >>> print hex(e.symbols['write']) #doctest: +SKIP
@@ -21,6 +21,9 @@ Example Usage
 You can even patch and save the files.
 
 .. code-block:: python
+
+    .. doctest::
+       :skipif: not travis
 
     >>> e = ELF('/bin/cat')
     >>> e.read(e.address+1, 3)
@@ -525,6 +528,9 @@ class ELF(ELFFile):
 
         Example:
 
+        .. doctest::
+           :skipif: not travis
+
             >>> bash = ELF('/bin/bash')
             >>> read = bash.symbols['read']
             >>> text = bash.get_section_by_name('.text').header.sh_addr
@@ -912,11 +918,17 @@ class ELF(ELFFile):
             An ELF header starts with the bytes ``\\x7fELF``, so we
             sould be able to find it easily.
 
+        .. doctest::
+           :skipif: not travis
+
             >>> bash = ELF('/bin/bash')
             >>> bash.address + 1 == next(bash.search('ELF'))
             True
 
             We can also search for string the binary.
+
+        .. doctest::
+           :skipif: not travis
 
             >>> len(list(bash.search('GNU bash'))) > 0
             True
@@ -960,6 +972,9 @@ class ELF(ELFFile):
             This example shows that regardless of changes to the virtual
             address layout by modifying :attr:`.ELF.address`, the offset
             for any given address doesn't change.
+
+        .. doctest::
+           :skipif: not travis
 
             >>> bash = ELF('/bin/bash')
             >>> bash.address == bash.offset_to_vaddr(0)

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -1,7 +1,10 @@
 r"""
 Provide some tools to exploit format string bug
 
-Examples:
+Examples: (FIXME)
+
+.. doctest::
+   :skipif: True
 
     >>> program = tempfile.mktemp()
     >>> source  = program + ".c"

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -996,7 +996,11 @@ def version(program='gdb'):
         >>> (7,0) <= gdb.version()
         True
     """
-    program = misc.which(program)
+    if os.environ.get('PYTHONHOME') is not None:
+        del os.environ['PYTHONHOME']
+    if os.environ.get('PYTHONPATH') is not None:
+        del os.environ['PYTHONPATH']
+    program = misc.which(program) # TODO good error if None
     expr = r'([0-9]+\.?)+'
 
     with tubes.process.process([program, '--version'], level='error') as gdb:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -993,7 +993,7 @@ def version(program='gdb'):
 
     Example:
 
-        >>> (7,0) <= gdb.version() <= (8,0)
+        >>> (7,0) <= gdb.version()
         True
     """
     program = misc.which(program)

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -88,6 +88,9 @@ def search_by_build_id(hex_encoded_id):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+    .. doctest::
+       :skipif: offline
+
         >>> filename = search_by_build_id('fe136e485814fee2268cf19e5c124ed0f73f4400')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'
@@ -108,6 +111,9 @@ def search_by_md5(hex_encoded_id):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+    .. doctest::
+       :skipif: offline
+
         >>> filename = search_by_md5('7a71dafb87606f360043dcd638e411bd')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'
@@ -128,6 +134,9 @@ def search_by_sha1(hex_encoded_id):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+    .. doctest::
+       :skipif: offline
+
         >>> filename = search_by_sha1('34471e355a5e71400b9d65e78d2cd6ce7fc49de5')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'
@@ -149,6 +158,9 @@ def search_by_sha256(hex_encoded_id):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+    .. doctest::
+       :skipif: offline
+
         >>> filename = search_by_sha256('5e877a8272da934812d2d1f9ee94f73c77c790cbc5d8251f5322389fc9667f21')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'

--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -90,6 +90,9 @@ def archname():
     Returns the name which QEMU uses for the currently selected
     architecture.
 
+.. doctest::
+   :skipif: not qemu_powerpc
+
     >>> pwnlib.qemu.archname()
     'i386'
     >>> pwnlib.qemu.archname(arch='powerpc')
@@ -113,10 +116,13 @@ def user_path():
     Returns the path to the QEMU-user binary for the currently
     selected architecture.
 
+.. doctest::
+   :skipif: not qemu_i386
+
     >>> pwnlib.qemu.user_path()
-    'qemu-i386-static'
+    'qemu-i386...'
     >>> pwnlib.qemu.user_path(arch='thumb')
-    'qemu-arm-static'
+    'qemu-arm...'
     """
     arch   = archname()
     normal = 'qemu-' + arch
@@ -133,6 +139,9 @@ def user_path():
 @LocalContext
 def ld_prefix(path=None, env=None):
     """Returns the linker prefix for the selected qemu-user binary
+
+.. doctest::
+   :skipif: not qemu_arm
 
     >>> pwnlib.qemu.ld_prefix(arch='arm')
     '/etc/qemu-binfmt/arm'

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -195,6 +195,9 @@ Even better, this happens automagically.
 Our example binary will read some data onto the stack, and
 not do anything else interesting.
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> context.clear(arch='i386')
     >>> c = constants
     >>> assembly =  'read:'      + shellcraft.read(c.STDIN_FILENO, 'esp', 1024)
@@ -206,12 +209,18 @@ not do anything else interesting.
 
 Let's create a ROP object and invoke the call.
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> context.kernel = 'amd64'
     >>> rop   = ROP(binary)
     >>> binsh = binary.symbols['binsh']
     >>> rop.execve(binsh, 0, 0)
 
 That's all there is to it.
+
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
 
     >>> print rop.dump()
     0x0000:       0x1000000e pop eax; ret
@@ -239,6 +248,9 @@ That's all there is to it.
     0x0058:              0x0 fpstate
 
 Let's try it out!
+
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
 
     >>> p = process(binary.path)
     >>> p.send(str(rop))
@@ -356,6 +368,9 @@ class ROP(object):
        str(rop)
        # '\xfc\x82\x04\x08\xef\xbe\xad\xde\x00\x00\x00\x00\xa8\x96\x04\x08'
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> context.clear(arch = "i386", kernel = 'amd64')
     >>> assembly = 'int 0x80; ret; add esp, 0x10; ret; pop eax; ret'
     >>> e = ELF.from_assembly(assembly)
@@ -398,6 +413,9 @@ class ROP(object):
     0x0078:             0x2b ss
     0x007c:              0x0 fpstate
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> r = ROP(e, 0x8048000)
     >>> r.funcname(1, 2)
     >>> r.funcname(3)
@@ -436,6 +454,9 @@ class ROP(object):
     0x8048078:             0x2b ss
     0x804807c:              0x0 fpstate
 
+
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
 
     >>> elf = ELF.from_assembly('ret')
     >>> r = ROP(elf)
@@ -964,6 +985,11 @@ class ROP(object):
 
         Arguments:
             data(int/str): The raw value to put onto the rop chain.
+
+        FIXME why does this fail?
+
+    .. doctest::
+       :skipif: not binutils_i386 or not qemu_i386
 
         >>> rop = ROP([])
         >>> rop.raw('AAAAAAAA')

--- a/pwnlib/rop/srop.py
+++ b/pwnlib/rop/srop.py
@@ -23,6 +23,9 @@ i386 Example:
     We also make an ``int 0x80`` gadget available, followed
     immediately by ``exit(0)``.
 
+.. doctest::
+   :skipif: not binutils_i386
+
     >>> context.clear(arch='i386')
     >>> assembly =  'read:'      + shellcraft.read(constants.STDIN_FILENO, 'esp', 1024)
     >>> assembly += 'sigreturn:' + shellcraft.sigreturn()
@@ -35,6 +38,9 @@ i386 Example:
     Let's construct our frame to have it invoke a ``write``
     syscall, and dump the message to stdout.
 
+.. doctest::
+   :skipif: not binutils_i386
+
     >>> frame = SigreturnFrame(kernel='amd64')
     >>> frame.eax = constants.SYS_write
     >>> frame.ebx = constants.STDOUT_FILENO
@@ -45,6 +51,9 @@ i386 Example:
 
     Let's start the process, send the data, and check the message.
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> p = process(binary.path)
     >>> p.send(str(frame))
     >>> p.recvline()
@@ -53,6 +62,9 @@ i386 Example:
     0
 
 amd64 Example:
+
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
 
     >>> context.clear()
     >>> context.arch = "amd64"
@@ -78,6 +90,9 @@ amd64 Example:
     0
 
 arm Example:
+
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
 
     >>> context.clear()
     >>> context.arch = "arm"
@@ -105,6 +120,9 @@ arm Example:
 
 Mips Example:
 
+.. doctest::
+   :skipif: not binutils_mips or not qemu_mips
+
     >>> context.clear()
     >>> context.arch = "mips"
     >>> context.endian = "big"
@@ -129,6 +147,9 @@ Mips Example:
     0
 
 Mipsel Example:
+
+.. doctest::
+   :skipif: not binutils_mips or not qemu_mips
 
     >>> context.clear()
     >>> context.arch = "mips"

--- a/pwnlib/runner.py
+++ b/pwnlib/runner.py
@@ -26,6 +26,9 @@ def run_assembly(assembly):
         >>> p.poll()
         3
 
+    .. doctest::
+       :skipif: not binutils_arm or not qemu_arm
+
         >>> p = run_assembly('mov r0, #12; mov r7, #1; svc #0', arch='arm')
         >>> p.wait_for_close()
         >>> p.poll()
@@ -44,6 +47,9 @@ def run_shellcode(bytes, **kw):
         >>> p.wait_for_close()
         >>> p.poll()
         3
+
+    .. doctest::
+       :skipif: not binutils_aarch64 or not qemu_aarch64
 
         >>> bytes = asm('mov r0, #12; mov r7, #1; svc #0', arch='arm')
         >>> p = run_shellcode(bytes, arch='arm')

--- a/pwnlib/shellcraft/templates/aarch64/breakpoint.asm
+++ b/pwnlib/shellcraft/templates/aarch64/breakpoint.asm
@@ -4,6 +4,9 @@ Inserts a debugger breakpoint (raises SIGTRAP).
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> run_assembly(shellcraft.breakpoint()).poll(True)
     -5
 </%docstring>

--- a/pwnlib/shellcraft/templates/aarch64/crash.asm
+++ b/pwnlib/shellcraft/templates/aarch64/crash.asm
@@ -4,6 +4,9 @@ Crashes the process.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> run_assembly(shellcraft.crash()).poll(True)
     -11
 </%docstring>

--- a/pwnlib/shellcraft/templates/aarch64/infloop.asm
+++ b/pwnlib/shellcraft/templates/aarch64/infloop.asm
@@ -4,6 +4,9 @@ An infinite loop.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> io = run_assembly(shellcraft.infloop())
     >>> io.recvall(timeout=1)
     ''

--- a/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
@@ -7,6 +7,9 @@ Opens a file and writes its contents to the specified file descriptor.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> write('flag', 'This is the flag\n')
     >>> shellcode = shellcraft.cat('flag') + shellcraft.exit(0)
     >>> print disasm(asm(shellcode))

--- a/pwnlib/shellcraft/templates/aarch64/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/echo.asm
@@ -5,6 +5,9 @@ Writes a string to a file descriptor
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> run_assembly(shellcraft.echo('hello\n', 1)).recvline()
     'hello\n'
 

--- a/pwnlib/shellcraft/templates/aarch64/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/sh.asm
@@ -2,6 +2,9 @@
 <%docstring>
 Execute a different process.
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> p = run_assembly(shellcraft.aarch64.linux.sh())
     >>> p.sendline('echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/aarch64/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/stage.asm
@@ -17,6 +17,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> p = run_assembly(shellcraft.stage())
     >>> sc = asm(shellcraft.echo("Hello\n", constants.STDOUT_FILENO))
     >>> p.pack(len(sc))

--- a/pwnlib/shellcraft/templates/aarch64/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/syscall.asm
@@ -12,6 +12,9 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print shellcraft.aarch64.linux.syscall(11, 1, 'sp', 2, 0).rstrip()
         /* call syscall(11, 1, 'sp', 2, 0) */
         mov  x0, #1

--- a/pwnlib/shellcraft/templates/aarch64/mov.asm
+++ b/pwnlib/shellcraft/templates/aarch64/mov.asm
@@ -23,6 +23,9 @@ on the value of `context.os`.
 
 Examples:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print shellcraft.mov('x0','x1').rstrip()
         mov  x0, x1
     >>> print shellcraft.mov('x0','0').rstrip()

--- a/pwnlib/shellcraft/templates/aarch64/push.asm
+++ b/pwnlib/shellcraft/templates/aarch64/push.asm
@@ -24,6 +24,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print pwnlib.shellcraft.push(0).rstrip()
         /* push 0 */
         mov  x14, xzr

--- a/pwnlib/shellcraft/templates/aarch64/pushstr.asm
+++ b/pwnlib/shellcraft/templates/aarch64/pushstr.asm
@@ -14,6 +14,9 @@ Args:
 
 Examples:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print shellcraft.pushstr("Hello!").rstrip()
         /* push 'Hello!\x00' */
         /* Set x14 = 36762444129608 = 0x216f6c6c6548 */

--- a/pwnlib/shellcraft/templates/aarch64/setregs.asm
+++ b/pwnlib/shellcraft/templates/aarch64/setregs.asm
@@ -13,6 +13,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print shellcraft.setregs({'x0':1, 'x2':'x3'}).rstrip()
         mov  x0, #1
         mov  x2, x3

--- a/pwnlib/shellcraft/templates/aarch64/xor.asm
+++ b/pwnlib/shellcraft/templates/aarch64/xor.asm
@@ -18,6 +18,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> sc  = shellcraft.read(0, 'sp', 32)
     >>> sc += shellcraft.xor(0xdeadbeef, 'sp', 32)
     >>> sc += shellcraft.write(1, 'sp', 32)

--- a/pwnlib/shellcraft/templates/amd64/crash.asm
+++ b/pwnlib/shellcraft/templates/amd64/crash.asm
@@ -4,6 +4,9 @@ Crash.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> run_assembly(shellcraft.crash()).poll(True)
     -11
 </%docstring>

--- a/pwnlib/shellcraft/templates/amd64/itoa.asm
+++ b/pwnlib/shellcraft/templates/amd64/itoa.asm
@@ -14,6 +14,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> sc = shellcraft.amd64.mov('rax', 0xdeadbeef)
     >>> sc += shellcraft.amd64.itoa('rax')
     >>> sc += shellcraft.amd64.linux.write(1, 'rsp', 32)

--- a/pwnlib/shellcraft/templates/amd64/linux/loader_append.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/loader_append.asm
@@ -14,6 +14,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> gcc = process(['gcc','-m64','-xc','-static','-Wl,-Ttext-segment=0x20000000','-'])
     >>> gcc.write('''
     ... int main() {

--- a/pwnlib/shellcraft/templates/amd64/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/sh.asm
@@ -2,6 +2,9 @@
 <%docstring>
 Execute a different process.
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> p = run_assembly(shellcraft.amd64.linux.sh())
     >>> p.sendline('echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/amd64/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/stage.asm
@@ -17,6 +17,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> p = run_assembly(shellcraft.stage())
     >>> sc = asm(shellcraft.echo("Hello\n", constants.STDOUT_FILENO))
     >>> p.pack(len(sc))

--- a/pwnlib/shellcraft/templates/amd64/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/syscall.asm
@@ -12,6 +12,9 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
         >>> print pwnlib.shellcraft.amd64.linux.syscall('SYS_execve', 1, 'rsp', 2, 0).rstrip()
             /* call execve(1, 'rsp', 2, 0) */
             xor r10d, r10d /* 0 */

--- a/pwnlib/shellcraft/templates/amd64/mov.asm
+++ b/pwnlib/shellcraft/templates/amd64/mov.asm
@@ -23,6 +23,9 @@ on the value of `context.os`.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> print shellcraft.amd64.mov('eax','ebx').rstrip()
         mov eax, ebx
     >>> print shellcraft.amd64.mov('eax', 0).rstrip()

--- a/pwnlib/shellcraft/templates/amd64/push.asm
+++ b/pwnlib/shellcraft/templates/amd64/push.asm
@@ -22,6 +22,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> print pwnlib.shellcraft.amd64.push(0).rstrip()
         /* push 0 */
         push 1

--- a/pwnlib/shellcraft/templates/amd64/pushstr.asm
+++ b/pwnlib/shellcraft/templates/amd64/pushstr.asm
@@ -9,6 +9,9 @@ null bytes or newline characters.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> print shellcraft.amd64.pushstr('').rstrip()
         /* push '\x00' */
         push 1

--- a/pwnlib/shellcraft/templates/amd64/setregs.asm
+++ b/pwnlib/shellcraft/templates/amd64/setregs.asm
@@ -14,6 +14,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> print shellcraft.setregs({'rax':1, 'rbx':'rax'}).rstrip()
         mov rbx, rax
         push 1

--- a/pwnlib/shellcraft/templates/amd64/strcpy.asm
+++ b/pwnlib/shellcraft/templates/amd64/strcpy.asm
@@ -8,6 +8,9 @@ Copies a string
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> sc  = 'jmp get_str\n'
     >>> sc += 'pop_str: pop rax\n'
     >>> sc += shellcraft.amd64.strcpy('rsp', 'rax')

--- a/pwnlib/shellcraft/templates/amd64/strlen.asm
+++ b/pwnlib/shellcraft/templates/amd64/strlen.asm
@@ -13,6 +13,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> sc  = 'jmp get_str\n'
     >>> sc += 'pop_str: pop rdi\n'
     >>> sc += shellcraft.amd64.strlen('rdi', 'rax')

--- a/pwnlib/shellcraft/templates/amd64/xor.asm
+++ b/pwnlib/shellcraft/templates/amd64/xor.asm
@@ -19,6 +19,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_amd64 or not qemu_amd64
+
     >>> sc  = shellcraft.read(0, 'rsp', 32)
     >>> sc += shellcraft.xor(0xdeadbeef, 'rsp', 32)
     >>> sc += shellcraft.write(1, 'rsp', 32)

--- a/pwnlib/shellcraft/templates/arm/crash.asm
+++ b/pwnlib/shellcraft/templates/arm/crash.asm
@@ -4,6 +4,9 @@ Crash.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> run_assembly(shellcraft.crash()).poll(True)
     -11
 </%docstring>

--- a/pwnlib/shellcraft/templates/arm/itoa.asm
+++ b/pwnlib/shellcraft/templates/arm/itoa.asm
@@ -14,6 +14,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> sc = shellcraft.arm.mov('r0', 0xdeadbeef)
     >>> sc += shellcraft.arm.itoa('r0')
     >>> sc += shellcraft.arm.linux.write(1, 'sp', 32)

--- a/pwnlib/shellcraft/templates/arm/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/cat.asm
@@ -8,6 +8,9 @@ Opens a file and writes its contents to the specified file descriptor.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> f = tempfile.mktemp()
     >>> write(f, 'FLAG\n')
     >>> run_assembly(shellcraft.arm.linux.cat(f)).recvline()

--- a/pwnlib/shellcraft/templates/arm/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/echo.asm
@@ -5,6 +5,9 @@ Writes a string to a file descriptor
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> run_assembly(shellcraft.echo('hello\n', 1)).recvline()
     'hello\n'
 

--- a/pwnlib/shellcraft/templates/arm/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/sh.asm
@@ -2,6 +2,9 @@
 <%docstring>
 Execute a different process.
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> p = run_assembly(shellcraft.arm.linux.sh())
     >>> p.sendline('echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/arm/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/syscall.asm
@@ -12,6 +12,9 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> print shellcraft.arm.linux.syscall(11, 1, 'sp', 2, 0).rstrip()
         /* call syscall(11, 1, 'sp', 2, 0) */
         mov  r0, #1

--- a/pwnlib/shellcraft/templates/arm/mov.asm
+++ b/pwnlib/shellcraft/templates/arm/mov.asm
@@ -19,6 +19,9 @@ on the value of `context.os`.
 
 Examples:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> print shellcraft.arm.mov('r0','r1').rstrip()
         mov  r0, r1
     >>> print shellcraft.arm.mov('r0', 5).rstrip()

--- a/pwnlib/shellcraft/templates/arm/pushstr.asm
+++ b/pwnlib/shellcraft/templates/arm/pushstr.asm
@@ -11,6 +11,9 @@ Args:
 
 Examples:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> print shellcraft.arm.pushstr("Hello!").rstrip()
         /* push 'Hello!\x00A' */
         movw r7, #0x4100216f & 0xffff

--- a/pwnlib/shellcraft/templates/arm/ret.asm
+++ b/pwnlib/shellcraft/templates/arm/ret.asm
@@ -5,6 +5,9 @@ Args:
     return_value: Value to return
 
 Examples:
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> with context.local(arch='arm'):
     ...     print enhex(asm(shellcraft.ret()))
     ...     print enhex(asm(shellcraft.ret(0)))

--- a/pwnlib/shellcraft/templates/arm/setregs.asm
+++ b/pwnlib/shellcraft/templates/arm/setregs.asm
@@ -15,6 +15,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> print shellcraft.setregs({'r0':1, 'r2':'r3'}).rstrip()
         mov  r0, #1
         mov  r2, r3

--- a/pwnlib/shellcraft/templates/arm/xor.asm
+++ b/pwnlib/shellcraft/templates/arm/xor.asm
@@ -18,6 +18,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_arm or not qemu_arm
+
     >>> sc  = shellcraft.read(0, 'sp', 32)
     >>> sc += shellcraft.xor(0xdeadbeef, 'sp', 32)
     >>> sc += shellcraft.write(1, 'sp', 32)

--- a/pwnlib/shellcraft/templates/i386/crash.asm
+++ b/pwnlib/shellcraft/templates/i386/crash.asm
@@ -3,6 +3,9 @@ Crash.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> run_assembly(shellcraft.crash()).poll(True)
     -11
 </%docstring>

--- a/pwnlib/shellcraft/templates/i386/function.asm
+++ b/pwnlib/shellcraft/templates/i386/function.asm
@@ -15,9 +15,11 @@ Arguments:
 
 ::
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> shellcode = ''
     >>> shellcode += shellcraft.function('write', shellcraft.i386.linux.write, )
-
     >>> hello = shellcraft.i386.linux.echo("Hello!", 'eax')
     >>> hello_fn = shellcraft.i386.function(hello, 'eax').strip()
     >>> exit = shellcraft.i386.linux.exit('edi')

--- a/pwnlib/shellcraft/templates/i386/itoa.asm
+++ b/pwnlib/shellcraft/templates/i386/itoa.asm
@@ -14,6 +14,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> sc = shellcraft.i386.mov('eax', 0xdeadbeef)
     >>> sc += shellcraft.i386.itoa('eax')
     >>> sc += shellcraft.i386.linux.write(1, 'esp', 32)

--- a/pwnlib/shellcraft/templates/i386/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/cat.asm
@@ -8,6 +8,9 @@ Opens a file and writes its contents to the specified file descriptor.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> f = tempfile.mktemp()
     >>> write(f, 'FLAG')
     >>> run_assembly(shellcraft.i386.linux.cat(f)).recvall()

--- a/pwnlib/shellcraft/templates/i386/linux/connect.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/connect.asm
@@ -15,6 +15,9 @@ Arguments:
 
 Examples:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> l = listen(timeout=5)
     >>> assembly  = shellcraft.i386.linux.connect('localhost', l.lport)
     >>> assembly += shellcraft.i386.pushstr('Hello')

--- a/pwnlib/shellcraft/templates/i386/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/echo.asm
@@ -5,6 +5,9 @@ Writes a string to a file descriptor
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> run_assembly(shellcraft.echo('hello', 1)).recvall()
     'hello'
 

--- a/pwnlib/shellcraft/templates/i386/linux/loader_append.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/loader_append.asm
@@ -14,6 +14,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> gcc = process(['gcc','-m32','-xc','-static','-Wl,-Ttext-segment=0x20000000','-'])
     >>> gcc.write('''
     ... int main() {

--- a/pwnlib/shellcraft/templates/i386/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/sh.asm
@@ -2,6 +2,9 @@
 <%docstring>
 Execute a different process.
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> p = run_assembly(shellcraft.i386.linux.sh())
     >>> p.sendline('echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/i386/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/stage.asm
@@ -17,6 +17,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> p = run_assembly(shellcraft.stage())
     >>> sc = asm(shellcraft.echo("Hello\n", constants.STDOUT_FILENO))
     >>> p.pack(len(sc))

--- a/pwnlib/shellcraft/templates/i386/linux/stager.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/stager.asm
@@ -11,6 +11,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> stage_2 = asm(shellcraft.echo('hello') + "\n" + shellcraft.syscalls.exit(42))
     >>> p = run_assembly(shellcraft.stager(0, len(stage_2)))
     >>> for c in stage_2:

--- a/pwnlib/shellcraft/templates/i386/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/syscall.asm
@@ -12,6 +12,9 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 
 Example:
 
+    .. doctest::
+       :skipif: not binutils_i386 or not qemu_i386
+
         >>> print pwnlib.shellcraft.i386.linux.syscall('SYS_execve', 1, 'esp', 2, 0).rstrip()
             /* call execve(1, 'esp', 2, 0) */
             push SYS_execve /* 0xb */

--- a/pwnlib/shellcraft/templates/i386/mov.asm
+++ b/pwnlib/shellcraft/templates/i386/mov.asm
@@ -27,6 +27,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> print shellcraft.i386.mov('eax','ebx').rstrip()
         mov eax, ebx
     >>> print shellcraft.i386.mov('eax', 0).rstrip()

--- a/pwnlib/shellcraft/templates/i386/push.asm
+++ b/pwnlib/shellcraft/templates/i386/push.asm
@@ -20,6 +20,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> print pwnlib.shellcraft.i386.push(0).rstrip()
         /* push 0 */
         push 1

--- a/pwnlib/shellcraft/templates/i386/pushstr.asm
+++ b/pwnlib/shellcraft/templates/i386/pushstr.asm
@@ -9,6 +9,9 @@ null bytes or newline characters.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> print shellcraft.i386.pushstr('').rstrip()
         /* push '\x00' */
         push 1

--- a/pwnlib/shellcraft/templates/i386/setregs.asm
+++ b/pwnlib/shellcraft/templates/i386/setregs.asm
@@ -15,6 +15,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> print shellcraft.setregs({'eax':1, 'ebx':'eax'}).rstrip()
         mov ebx, eax
         push 1

--- a/pwnlib/shellcraft/templates/i386/stackhunter.asm
+++ b/pwnlib/shellcraft/templates/i386/stackhunter.asm
@@ -13,6 +13,9 @@
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> with context.local():
     ...    context.arch = 'i386'
     ...    print enhex(asm(shellcraft.stackhunter()))

--- a/pwnlib/shellcraft/templates/i386/strcpy.asm
+++ b/pwnlib/shellcraft/templates/i386/strcpy.asm
@@ -8,6 +8,9 @@ Copies a string
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> sc  = 'jmp get_str\n'
     >>> sc += 'pop_str: pop eax\n'
     >>> sc += shellcraft.i386.strcpy('esp', 'eax')

--- a/pwnlib/shellcraft/templates/i386/strlen.asm
+++ b/pwnlib/shellcraft/templates/i386/strlen.asm
@@ -13,6 +13,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> sc  = 'jmp get_str\n'
     >>> sc += 'pop_str: pop eax\n'
     >>> sc += shellcraft.i386.strlen('eax')

--- a/pwnlib/shellcraft/templates/i386/xor.asm
+++ b/pwnlib/shellcraft/templates/i386/xor.asm
@@ -18,6 +18,10 @@ Args:
                  the number of bytes to XOR.
 
 Example:
+
+.. doctest::
+   :skipif: not binutils_i386 or not qemu_i386
+
     >>> sc  = shellcraft.read(0, 'esp', 32)
     >>> sc += shellcraft.xor(0xdeadbeef, 'esp', 32)
     >>> sc += shellcraft.write(1, 'esp', 32)

--- a/pwnlib/shellcraft/templates/mips/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/cat.asm
@@ -9,6 +9,9 @@ Opens a file and writes its contents to the specified file descriptor.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> f = tempfile.mktemp()
     >>> write(f, 'FLAG')
     >>> asm  = shellcraft.mips.linux.cat(f)

--- a/pwnlib/shellcraft/templates/mips/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sh.asm
@@ -3,6 +3,9 @@
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> p = run_assembly(shellcraft.mips.linux.sh())
     >>> p.sendline('echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/mips/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/syscall.asm
@@ -12,6 +12,9 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 
 Example:
 
+    .. doctest::
+       :skipif: not binutils_mips or not qemu_mips
+
         >>> print pwnlib.shellcraft.mips.linux.syscall('SYS_execve', 1, '$sp', 2, 0).rstrip()
             /* call execve(1, '$sp', 2, 0) */
             li $t9, ~1

--- a/pwnlib/shellcraft/templates/mips/mov.asm
+++ b/pwnlib/shellcraft/templates/mips/mov.asm
@@ -24,6 +24,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_mips or not qemu_mips
+
     >>> print shellcraft.mips.mov('$t0', 0).rstrip()
         slti $t0, $zero, 0xFFFF /* $t0 = 0 */
     >>> print shellcraft.mips.mov('$t2', 0).rstrip()

--- a/pwnlib/shellcraft/templates/mips/pushstr.asm
+++ b/pwnlib/shellcraft/templates/mips/pushstr.asm
@@ -9,6 +9,9 @@ null bytes or newline characters.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_mips or not qemu_mips
+
     >>> print shellcraft.mips.pushstr('').rstrip()
         /* push '\x00' */
         sw $zero, -4($sp)

--- a/pwnlib/shellcraft/templates/mips/setregs.asm
+++ b/pwnlib/shellcraft/templates/mips/setregs.asm
@@ -15,6 +15,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_mips or not qemu_mips
+
     >>> print shellcraft.setregs({'$t0':1, '$a3':'0'}).rstrip()
         slti $a3, $zero, 0xFFFF /* $a3 = 0 */
         li $t9, ~1

--- a/pwnlib/shellcraft/templates/thumb/crash.asm
+++ b/pwnlib/shellcraft/templates/thumb/crash.asm
@@ -4,6 +4,9 @@ Crash.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_thumb or not qemu_thumb
+
     >>> run_assembly(shellcraft.crash()).poll(True) < 0
     True
 </%docstring>

--- a/pwnlib/shellcraft/templates/thumb/itoa.asm
+++ b/pwnlib/shellcraft/templates/thumb/itoa.asm
@@ -14,6 +14,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> sc = shellcraft.thumb.mov('r0', 0xdeadbeef)
     >>> sc += shellcraft.thumb.itoa('r0')
     >>> sc += shellcraft.thumb.linux.write(1, 'sp', 32)

--- a/pwnlib/shellcraft/templates/thumb/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/cat.asm
@@ -9,6 +9,9 @@ Opens a file and writes its contents to the specified file descriptor.
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> f = tempfile.mktemp()
     >>> write(f, 'FLAG\n')
     >>> run_assembly(shellcraft.arm.to_thumb()+shellcraft.thumb.linux.cat(f)).recvline()

--- a/pwnlib/shellcraft/templates/thumb/linux/echo.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/echo.asm
@@ -5,6 +5,9 @@ Writes a string to a file descriptor
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> run_assembly(shellcraft.echo('hello\n', 1)).recvline()
     'hello\n'
 

--- a/pwnlib/shellcraft/templates/thumb/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/sh.asm
@@ -2,6 +2,9 @@
 <%docstring>
 Execute a different process.
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> p = run_assembly(shellcraft.thumb.linux.sh())
     >>> p.sendline('echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/thumb/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/stage.asm
@@ -17,6 +17,9 @@ Arguments:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> p = run_assembly(shellcraft.stage())
     >>> sc = asm(shellcraft.echo("Hello\n", constants.STDOUT_FILENO))
     >>> p.pack(len(sc))

--- a/pwnlib/shellcraft/templates/thumb/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/syscall.asm
@@ -12,6 +12,9 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print shellcraft.thumb.linux.syscall(11, 1, 'sp', 2, 0).rstrip()
         /* call syscall(11, 1, 'sp', 2, 0) */
         mov r0, #1

--- a/pwnlib/shellcraft/templates/thumb/mov.asm
+++ b/pwnlib/shellcraft/templates/thumb/mov.asm
@@ -18,6 +18,9 @@
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print shellcraft.thumb.mov('r1','r2').rstrip()
         mov r1, r2
     >>> print shellcraft.thumb.mov('r1', 0).rstrip()

--- a/pwnlib/shellcraft/templates/thumb/push.asm
+++ b/pwnlib/shellcraft/templates/thumb/push.asm
@@ -20,6 +20,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> print pwnlib.shellcraft.thumb.push('r0').rstrip()
         push {r0}
     >>> print pwnlib.shellcraft.thumb.push(0).rstrip()

--- a/pwnlib/shellcraft/templates/thumb/pushstr.asm
+++ b/pwnlib/shellcraft/templates/thumb/pushstr.asm
@@ -16,6 +16,9 @@ Examples:
 Note that this doctest has two possibilities for the first result, depending
 on your version of binutils.
 
+.. doctest::
+   :skipif: not binutils_aarch64 or not qemu_aarch64
+
     >>> enhex(asm(shellcraft.pushstr('Hello\nWorld!', True))) in [
     ... '87ea070780b4dff8047001e0726c642180b4dff8047001e06f0a576f80b4dff8047001e048656c6c80b4',
     ... '87ea070780b4dff8067000f002b8726c642180b4dff8047000f002b86f0a576f80b4014f00f002b848656c6c80b4']

--- a/pwnlib/shellcraft/templates/thumb/setregs.asm
+++ b/pwnlib/shellcraft/templates/thumb/setregs.asm
@@ -15,6 +15,9 @@ Args:
 
 Example:
 
+.. doctest::
+   :skipif: not binutils_thumb or not qemu_thumb
+
     >>> print shellcraft.setregs({'r0':1, 'r2':'r3'}).rstrip()
         mov r0, #1
         mov r2, r3

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -195,6 +195,9 @@ class process(tube):
         >>> io.poll(block=True) == -signal.SIGALRM
         True
 
+    .. doctest::
+       :skipif: not binutils_mips
+
         >>> binary = ELF.from_assembly('nop', arch='mips')
         >>> p = process(binary.path)
     """
@@ -460,7 +463,7 @@ class process(tube):
         Example:
 
             >>> p = process('true')
-            >>> p.executable == '/bin/true'
+            >>> '/bin/true' in p.executable
             True
             >>> p.executable == p.program
             True
@@ -932,17 +935,26 @@ class process(tube):
 
         Example:
 
+        .. doctest::
+           :skipif: not travis
+
             >>> e = ELF('/bin/bash')
             >>> p = process(e.path)
 
             In order to make sure there's not a race condition against
             the process getting set up...
 
+        .. doctest::
+           :skipif: not travis
+
             >>> p.sendline('echo hello')
             >>> p.recvuntil('hello')
             'hello'
 
             Now we can leak some data!
+
+        .. doctest::
+           :skipif: not travis
 
             >>> p.leak(e.address, 4)
             '\x7fELF'

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -28,6 +28,9 @@ class remote(sock):
 
     Examples:
 
+.. doctest::
+   :skipif: offline
+
         >>> r = remote('google.com', 443, ssl=True)
         >>> r.send('GET /\r\n\r\n')
         >>> r.recvn(4)
@@ -41,6 +44,9 @@ class remote(sock):
         PwnlibException: Could not connect to 127.0.0.1 on port 1
 
         You can also use :meth:`.remote.fromsocket` to wrap an existing socket.
+
+.. doctest::
+   :skipif: offline
 
         >>> import socket
         >>> s = socket.socket()

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -663,6 +663,9 @@ class ssh(Timeout, Logger):
             Return a :class:`pwnlib.tubes.ssh.ssh_channel` object.
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -742,6 +745,9 @@ class ssh(Timeout, Logger):
             Requires Python on the remote server.
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> s = ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1076,6 +1082,9 @@ os.execve(exe, argv, env)
         Return a :class:`pwnlib.tubes.ssh.ssh_channel` object.
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1137,6 +1146,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         a TTY on the remote server.
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1160,6 +1172,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         Returns a :class:`pwnlib.tubes.ssh.ssh_connecter` object.
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> from pwn import *
             >>> l = listen()
             >>> s =  ssh(host='example.pwnme',
@@ -1186,6 +1201,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         Examples:
 
+        .. doctest::
+           :skipif: offline
+
             >>> from pwn import *
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
@@ -1207,6 +1225,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         Examples:
 
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1220,6 +1241,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         Examples:
 
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1232,6 +1256,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         """Permits member access to run commands over SSH
 
         Examples:
+
+        .. doctest::
+           :skipif: offline
 
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
@@ -1265,6 +1292,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         """Returns True if we are connected.
 
         Example:
+
+        .. doctest::
+           :skipif: offline
 
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
@@ -1416,6 +1446,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> with file('/tmp/bar','w+') as f:
             ...     f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
@@ -1509,6 +1542,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             remote(str): The filename to upload it to.
 
         Example:
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1739,6 +1775,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 that all files in the "old" working directory should be symlinked.
 
         Examples:
+        .. doctest::
+           :skipif: offline
+
             >>> s =  ssh(host='example.pwnme',
             ...         user='travis',
             ...         password='demopass')
@@ -1913,6 +1952,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         """:class:`bool`: Whether ASLR is enabled on the system.
 
         Example:
+
+        .. doctest::
+           :skipif: offline
 
             >>> s = ssh("travis", "example.pwnme")
             >>> s.aslr

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -85,6 +85,7 @@ def last_check():
 
 def should_check():
     """Return True if we should check for an update"""
+    return False
     filename = cache_file()
 
     if not filename:

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -40,6 +40,9 @@ update_freq     = datetime.timedelta(days=7).total_seconds()
 def available_on_pypi(prerelease=current_version.is_prerelease):
     """Return True if an update is available on PyPI.
 
+.. doctest::
+   :skipif: offline
+
     >>> available_on_pypi() # doctest: +ELLIPSIS
     <Version('...')>
     >>> available_on_pypi(prerelease=False).is_prerelease
@@ -100,6 +103,9 @@ def perform_check(prerelease=current_version.is_prerelease):
 
     Returns:
         A list of arguments to the update command.
+
+.. doctest::
+   :skipif: offline
 
     >>> from packaging.version import Version
     >>> pwnlib.update.current_version = Version("999.0.0")

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -146,6 +146,9 @@ def which(name, all = False):
       else the first location or :const:`None` if not found.
 
     Example:
+    .. doctest::
+       :skipif: not travis
+
       >>> which('sh')
       '/bin/sh'
 """

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -100,6 +100,9 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
+    .. doctest::
+       :skipif: not travis
+
         >>> pid = pidof('init')[0]
         >>> name(pid) == 'init'
         True

--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -293,7 +293,7 @@ def test(original):
     """
     input = sh_string(original)
 
-    cmdstr = '/bin/echo %s' % input
+    cmdstr = 'echo %s' % input
 
     SUPPORTED_SHELLS = [
         ['ash', '-c', cmdstr],
@@ -494,12 +494,12 @@ def sh_command_with(f, *args):
         'echo hello'
         >>> sh_command_with(lambda x: "echo " + x, "hello")
         'echo hello'
-        >>> sh_command_with(lambda x: "/bin/echo " + x, "\\x01")
-        "/bin/echo '\\x01'"
-        >>> sh_command_with(lambda x: "/bin/echo " + x, "\\x01\\n")
-        "/bin/echo '\\x01\\n'"
-        >>> sh_command_with("/bin/echo %s", "\\x01\\n")
-        "/bin/echo '\\x01\\n'"
+        >>> sh_command_with(lambda x: "echo " + x, "\\x01")
+        "echo '\\x01'"
+        >>> sh_command_with(lambda x: "echo " + x, "\\x01\\n")
+        "echo '\\x01\\n'"
+        >>> sh_command_with("echo %s", "\\x01\\n")
+        "echo '\\x01\\n'"
     """
 
     args = list(args)

--- a/pwnlib/util/web.py
+++ b/pwnlib/util/web.py
@@ -24,6 +24,9 @@ def wget(url, save=None, timeout=5, **kwargs):
 
     Example:
 
+.. doctest::
+   :skipif: offline
+
       >>> url    = 'https://httpbin.org/robots.txt'
       >>> result = wget(url, timeout=60)
       >>> result


### PR DESCRIPTION
The intention of this is to make it possible to test pwntools on systems where some functionality is known not to work. This makes use of a new sphinx feature to selectively disable doctests. In particular, doctests that require binutils/qemu for a specific architecture, doctests that require internet access and doctests that depend on specific machine setup (marked `travis`) can be skipped.

This is a work in progress. Currently all flags are hardcoded as `False`, instead they should default to `True` and be changeable through flags or environment variables. But it should be ready for general feedback on the main idea. Is this something you'd in principle be willing to consider @zachriggle?

My use-case for this is automated testing for distribution packaging. Another usecase would be a possibility for contributers to run at least some of the testsuite locally without having the full setup that is available on travis.