### PR TITLE
Switch Travis CI to 16.04 (xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     - pandoc
     - gdb
     - binutils
-    - qemu-arm-static
+    - qemu-user-static
     - binutils-multiarch
     - binutils-aarch64-linux-gnu
     - binutils-arm-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 addons:
   apt:
@@ -13,6 +13,13 @@ addons:
     - zsh
     - pandoc
     - gdb
+    - binutils
+    - qemu-arm-static
+    - binutils-multiarch
+    - binutils-aarch64-linux-gnu
+    - binutils-arm-linux-gnueabihf
+    - binutils-mips-linux-gnu
+    - binutils-powerpc-linux-gnu
 cache:
     - pip
     - directories:

--- a/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
@@ -12,7 +12,7 @@ Example:
     >>> print disasm(asm(shellcode))
        0:   d28d8cce        mov     x14, #0x6c66                    // #27750
        4:   f2acec2e        movk    x14, #0x6761, lsl #16
-       8:   f81f0fee        str     x14, [sp, #-16]!
+       8:   f81f0fee        str     x14, [sp,#-16]!
        c:   d29ff380        mov     x0, #0xff9c                     // #65436
       10:   f2bfffe0        movk    x0, #0xffff, lsl #16
       14:   f2dfffe0        movk    x0, #0xffff, lsl #32

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -100,8 +100,11 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
-        >>> pid = pidof('init')[0]
-        >>> name(pid) == 'init'
+        >>> pid = 1
+        >>> n = name(pid)
+        >>> n
+        'systemd'
+        >>> pid in pidof(n)
         True
     """
     return psutil.Process(pid).name()

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -184,7 +184,7 @@ setup_osx()
 }
 
 if [[ "$USER" == "travis" ]]; then
-    setup_travis
+#   setup_travis
     setup_android_emulator
 elif [[ "$USER" == "shippable" ]]; then
     sudo apt-get update


### PR DESCRIPTION
Ubuntu 16.04 finally includes `binutils-mips-linux-gnu`, which is required. So there is no need to download packages manually anymore. This can help supporting python 3.