### PR TITLE
Switch Travis CI to 16.04 (xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 addons:
   apt:
@@ -13,6 +13,13 @@ addons:
     - zsh
     - pandoc
     - gdb
+    - binutils
+    - qemu-user-static
+    - binutils-multiarch
+    - binutils-aarch64-linux-gnu
+    - binutils-arm-linux-gnueabihf
+    - binutils-mips-linux-gnu
+    - binutils-powerpc-linux-gnu
 cache:
     - pip
     - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ cache:
     - pip
     - directories:
         - usr
-        - /home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/
-        - /home/travis/virtualenv/python2.7.13/bin/
+        - /home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/
+        - /home/travis/virtualenv/python2.7.15/bin/
 sudo: required
 python:
-  - "2.7"
+  - "2.7.15"
 before_install:
   - echo $-
   - source travis/install.sh

--- a/docs/source/util/proc.rst
+++ b/docs/source/util/proc.rst
@@ -1,6 +1,7 @@
 .. testsetup:: *
 
    from pwnlib.util.proc import *
+   from pwnlib.tubes.process import process
    import os, sys
 
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -36,7 +36,7 @@ Disassembly
     To disassemble code, simply invoke :func:`disasm` on the bytes to disassemble.
 
     >>> disasm('\xb8\x0b\x00\x00\x00')
-    '   0:   b8 0b 00 00 00          mov    eax,0xb'
+    '   0:   b8 0b 00 00 00          mov    eax, 0xb'
 
 """
 from __future__ import absolute_import
@@ -737,15 +737,15 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
     Examples:
 
         >>> print disasm('b85d000000'.decode('hex'), arch = 'i386')
-           0:   b8 5d 00 00 00          mov    eax,0x5d
+           0:   b8 5d 00 00 00          mov    eax, 0x5d
         >>> print disasm('b85d000000'.decode('hex'), arch = 'i386', byte = 0)
-           0:   mov    eax,0x5d
+           0:   mov    eax, 0x5d
         >>> print disasm('b85d000000'.decode('hex'), arch = 'i386', byte = 0, offset = 0)
-        mov    eax,0x5d
+        mov    eax, 0x5d
         >>> print disasm('b817000000'.decode('hex'), arch = 'amd64')
-           0:   b8 17 00 00 00          mov    eax,0x17
+           0:   b8 17 00 00 00          mov    eax, 0x17
         >>> print disasm('48c7c017000000'.decode('hex'), arch = 'amd64')
-           0:   48 c7 c0 17 00 00 00    mov    rax,0x17
+           0:   48 c7 c0 17 00 00 00    mov    rax, 0x17
         >>> print disasm('04001fe552009000'.decode('hex'), arch = 'arm')
            0:   e51f0004        ldr     r0, [pc, #-4]   ; 0x4
            4:   00900052        addseq  r0, r0, r2, asr r0
@@ -816,4 +816,4 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
             line += i
         lines.append(line)
 
-    return '\n'.join(lines)
+    return re.sub(',([^ ])', r', \1', '\n'.join(lines))

--- a/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
@@ -12,7 +12,7 @@ Example:
     >>> print disasm(asm(shellcode))
        0:   d28d8cce        mov     x14, #0x6c66                    // #27750
        4:   f2acec2e        movk    x14, #0x6761, lsl #16
-       8:   f81f0fee        str     x14, [sp, #-16]!
+       8:   f81f0fee        str     x14, [sp,#-16]!
        c:   d29ff380        mov     x0, #0xff9c                     // #65436
       10:   f2bfffe0        movk    x0, #0xffff, lsl #16
       14:   f2dfffe0        movk    x0, #0xffff, lsl #32

--- a/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/cat.asm
@@ -12,7 +12,7 @@ Example:
     >>> print disasm(asm(shellcode))
        0:   d28d8cce        mov     x14, #0x6c66                    // #27750
        4:   f2acec2e        movk    x14, #0x6761, lsl #16
-       8:   f81f0fee        str     x14, [sp,#-16]!
+       8:   f81f0fee        str     x14, [sp, #-16]!
        c:   d29ff380        mov     x0, #0xff9c                     // #65436
       10:   f2bfffe0        movk    x0, #0xffff, lsl #16
       14:   f2dfffe0        movk    x0, #0xffff, lsl #32

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -99,8 +99,9 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
-        >>> name(os.getpid()) == os.path.basename(sys.argv[0])
-        True
+        >>> p = process('cat')
+        >>> name(p)
+        'cat'
     """
     return psutil.Process(pid).name()
 

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -99,8 +99,11 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
-        >>> pid = pidof('init')[0]
-        >>> name(pid) == 'init'
+        >>> pid = 1
+        >>> n = name(pid)
+        >>> n
+        'systemd'
+        >>> pid in pidof(n)
         True
     """
     return psutil.Process(pid).name()

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -100,7 +100,7 @@ def name(pid):
 
     Example:
         >>> p = process('cat')
-        >>> name(p)
+        >>> name(p.pid)
         'cat'
     """
     return psutil.Process(pid).name()

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -99,11 +99,8 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
-        >>> from pwnlib import context
-        >>> from pwnlib.tubes.process import process
-        >>> with context.quiet, process('sh') as p:
-        ...     name(p.pid)
-        'sh'
+        >>> name(os.getpid()) == os.path.basename(sys.argv[0])
+        True
     """
     return psutil.Process(pid).name()
 

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -99,12 +99,11 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
-        >>> pid = 1
-        >>> n = name(pid)
-        >>> n
-        'systemd'
-        >>> pid in pidof(n)
-        True
+        >>> from pwnlib import context
+        >>> from pwnlib.tubes.process import process
+        >>> with context.quiet, process('sh') as p:
+        ...     name(p.pid)
+        'sh'
     """
     return psutil.Process(pid).name()
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -184,7 +184,7 @@ setup_osx()
 }
 
 if [[ "$USER" == "travis" ]]; then
-    setup_travis
+#   setup_travis
     setup_android_emulator
 elif [[ "$USER" == "shippable" ]]; then
     sudo apt-get update


### PR DESCRIPTION
Ubuntu 16.04 finally includes `binutils-mips-linux-gnu`,
which is required.  So there is no need to download
packages manually anymore.  This can help supporting
python 3.

This is a PR against `stable`.