### PR TITLE
Fix small issues in thumb shellcode

### DIFF
--- a/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
@@ -6,6 +6,10 @@
 
     Finds a connected socket. If port is specified it is checked
     against the peer port. Resulting socket is left in r6.
+
+    Example:
+        >>> enhex(asm(shellcraft.findpeer(1337)))
+        '6ff00006ee4606f101064ff001074fea072707f11f07f54630461fb401a96a4601df0130efdd01994fea11414ff039024fea022202f105029142e4d1'
 </%docstring>
 findpeer:
     /* File descriptor in r6 */

--- a/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
@@ -1,4 +1,4 @@
-<% from pwnlib.shellcraft.thumb.linux import mov %>
+<% from pwnlib.shellcraft.thumb import mov %>
 <% from socket import htons %>
 <%page args="port = None"/>
 <%docstring>

--- a/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
@@ -52,7 +52,7 @@ compare_port:
     ldr r1, [sp, #4]
     lsr r1, #16
 
-    /* Put the port (${port}) to search for into r1 */
+    /* Put the port (${port}) to search for into r2 */
     ${mov('r2', htons(int(port)))}
 
     /* Is it the one we have been searching for? */

--- a/pwnlib/shellcraft/templates/thumb/linux/listen.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/listen.asm
@@ -6,6 +6,10 @@
 
     Listens on a TCP port, accept a client and leave his socket in r6.
     Port is the TCP port to listen on, network is either 'ipv4' or 'ipv6'.
+
+    Example:
+        >>> enhex(asm(shellcraft.listen(1337, 'ipv4')))
+        '4ff001074fea072707f119074ff002004ff0010182ea020201df0646004901e00200053906b469464ff0100207f1010701df30464ff0010107f1020701df304681ea010182ea020207f1010701df0646'
 </%docstring>
     /* First create listening socket */
     ${mov('r7', 'SYS_socket')}

--- a/pwnlib/shellcraft/templates/thumb/linux/listen.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/listen.asm
@@ -1,4 +1,4 @@
-<% from pwnlib.shellcraft.thumb.linux import mov %>
+<% from pwnlib.shellcraft.thumb import mov %>
 <% from socket import htons %>
 <%page args="port, network='ipv4'"/>
 <%docstring>


### PR DESCRIPTION
When running pwntools in `thumb` context, the shellcode for `findpeer.asm` and `listen.asm` won't compile due to wrong import of the `mov` instruction. The first commit fixes this.
Furthermore, a comment that was wrong is fixed in the next commit.