### PR TITLE
Improve and optimize fmtstr_payload

### DIFF
--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -195,9 +195,11 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte'):
         payload_fmt += '@'*nbpad
         return payload_fmt + payload_adr, nbpad
 
+    cut = 0
     payload, nbpad = generate_payload()
     while int(nbpad/align) > 0:
-        payload, nbpad = generate_payload(int(nbpad/align)*align)
+        cut += int(nbpad/align)*align
+        payload, nbpad = generate_payload(cut)
 
     return payload
 


### PR DESCRIPTION
This PR improves fmtstr_payload.
· It does not make any changes to the function calling method
· By placing the address behind, it works even if it contains NULL bytes
· Since attack vectors are sorted by the number of bytes to write, the attack ends faster