### PR TITLE
fix(py3/config): six.string_types instead of (str, unicode)

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1417,7 +1417,7 @@ def update_context_defaults(section):
 
         default = ContextType.defaults[key]
 
-        if isinstance(default, (str, unicode, tuple, int, long, list, dict)):
+        if isinstance(default, six.string_types + six.integer_types + (tuple, list, dict)):
             value = safeeval.expr(value)
         else:
             log.warn("Unsupported configuration option %r in section %r" % (key, 'context'))


### PR DESCRIPTION
encountered this while testing the `dev3` branch:
```python
>>> from pwn import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pwntools/pwn/__init__.py", line 8, in <module>
    pwnlib.config.initialize()
  File "pwntools/pwnlib/config.py", line 61, in initialize
    registered_configs[section](settings)
  File "pwntools/pwnlib/context/__init__.py", line 1420, in update_context_defaults
    if isinstance(default, (str, unicode, tuple, int, long, list, dict)):
NameError: name 'unicode' is not defined
```