### PR TITLE
fix vmlinux memory read bug

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1006,17 +1006,7 @@ class ELF(ELFFile):
             # Check for holes which we can fill
             if self._fill_gaps and i+1 < len(load_segments):
                 next_start = load_segments[i+1].header.p_vaddr
-                # This method of filling holes is not rigorous enough. Take
-                # vmlinux for example, [start,stop_mem] like that
-                # [0xffffffff81000000, 0xffffffff81dcc000]
-                # [0xffffffff81e00000, 0xffffffff81f7d000]
-                # [0x0000000000000000, 0x0000000000017e98]
-                # [0xffffffff81f95000, 0xffffffff823bb000]
-                # 
-                # So don't fill 0x0000000000017e98 - 0xffffffff81f95000, 
-                # or 0xffffffff81000000 - 0xffffffff81f95000 will remapped with None, 
-                # which triger bug in memory read.
-                # So we should check if they are user-user or kernel-kernel.
+                
                 if stop_mem < next_start and stop_mem>>(self.bits-1) == next_start>>(self.bits-1):
                     self.memory.addi(stop_mem, next_start, None)
             else:

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -208,10 +208,6 @@ class ELF(ELFFile):
 
         super(ELF,self).__init__(self.mmap)
 
-        #: IntervalTree which maps all of the loaded memory segments
-        self.memory = intervaltree.IntervalTree()
-        self._populate_memory()
-
         #: :class:`str`: Path to the file
         self.path = os.path.abspath(path)
 
@@ -267,6 +263,10 @@ class ELF(ELFFile):
             or mask(flags, E_FLAGS.EF_MIPS_ARCH_64R2):
                 self.arch = 'mips64'
                 self.bits = 64
+
+        #: IntervalTree which maps all of the loaded memory segments
+        self.memory = intervaltree.IntervalTree()
+        self._populate_memory()
 
         # Is this a native binary? Should we be checking QEMU?
         try:
@@ -1006,7 +1006,18 @@ class ELF(ELFFile):
             # Check for holes which we can fill
             if self._fill_gaps and i+1 < len(load_segments):
                 next_start = load_segments[i+1].header.p_vaddr
-                if stop_mem < next_start:
+                # This method of filling holes is not rigorous enough. Take
+                # vmlinux for example, [start,stop_mem] like that
+                # [0xffffffff81000000, 0xffffffff81dcc000]
+                # [0xffffffff81e00000, 0xffffffff81f7d000]
+                # [0x0000000000000000, 0x0000000000017e98]
+                # [0xffffffff81f95000, 0xffffffff823bb000]
+                # 
+                # So don't fill 0x0000000000017e98 - 0xffffffff81f95000, 
+                # or 0xffffffff81000000 - 0xffffffff81f95000 will remapped with None, 
+                # which triger bug in memory read.
+                # So we should check if they are user-user or kernel-kernel.
+                if stop_mem < next_start and stop_mem>>(self.bits-1) == next_start>>(self.bits-1):
                     self.memory.addi(stop_mem, next_start, None)
             else:
                 page_end = (stop_mem + 0xfff) & ~(0xfff)


### PR DESCRIPTION
old version:
```
In [1]: from pwn import *

In [2]: b = ELF('vmlinux_s',checksec=False)

In [3]: b.read(0xffffffff81000000,8)
Out[3]: '\x00\x00\x00\x00\x00\x00\x00\x00\xe8\xa4\x01\x00\x00H\x8d-'
```
fix:
```
In [1]: from pwn import *

In [2]: b = ELF('vmlinux_s',checksec=False)

In [3]: b.read(0xffffffff81000000,8)
Out[3]: '\xe8\xa4\x01\x00\x00H\x8d-'
```