### PR TITLE
Py3 bytes issue

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -467,7 +467,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     garbage = gdbserver.recvline(timeout=1)
     
     # Some versions of gdbserver output an additional message
-    garbage2 = gdbserver.recvline_startswith("Remote debugging from host ", timeout=1)
+    garbage2 = gdbserver.recvline_startswith(b"Remote debugging from host ", timeout=1)
 
     return gdbserver
 


### PR DESCRIPTION
This fixes the following error attempting to use gdb module:

```
~/.virtualenvs/angr/lib/python3.6/site-packages/pwnlib/gdb.py in debug(args, gdbscript, exe, ssh, env, sysroot, **kwargs)
    468
    469     # Some versions of gdbserver output an additional message
--> 470     garbage2 = gdbserver.recvline_startswith("Remote debugging from host ", timeout=1)
    471
    472     return gdbserver

~/.virtualenvs/angr/lib/python3.6/site-packages/pwnlib/tubes/tube.py in recvline_startswith(self, delims, keepends, timeout)
    545         return self.recvline_pred(lambda line: any(map(line.startswith, delims)),
    546                                   keepends=keepends,
--> 547                                   timeout=timeout)
    548
    549     def recvline_endswith(self, delims, keepends = False, timeout = default):

~/.virtualenvs/angr/lib/python3.6/site-packages/pwnlib/tubes/tube.py in recvline_pred(self, pred, keepends, timeout)
    468                     return b''
    469
--> 470                 if pred(line):
    471                     if not keepends:
    472                         line = line[:-len(self.newline)]

~/.virtualenvs/angr/lib/python3.6/site-packages/pwnlib/tubes/tube.py in <lambda>(line)
    543             delims = (delims,)
    544
--> 545         return self.recvline_pred(lambda line: any(map(line.startswith, delims)),
    546                                   keepends=keepends,
    547                                   timeout=timeout)

TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```