### PR TITLE
Provide correct arch name to gdb for sparc64

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -475,7 +475,8 @@ def get_gdb_arch():
         'powerpc': 'powerpc:common',
         'powerpc64': 'powerpc:common64',
         'mips64': 'mips:isa64',
-        'thumb': 'arm'
+        'thumb': 'arm',
+        'sparc64': 'sparc:v9'
     }.get(context.arch, context.arch)
 
 def binary():


### PR DESCRIPTION
"sparc64" is not correct gdb arch name, set it to "sparc:v9" instead.