### PR TITLE
Implements "-c" in "phd" (inefficient) - fixes issue 1289

### DIFF
--- a/pwnlib/commandline/phd.py
+++ b/pwnlib/commandline/phd.py
@@ -5,6 +5,7 @@ from __future__ import division
 import argparse
 import os
 import sys
+import io
 
 import pwnlib
 pwnlib.args.free_form = False
@@ -88,6 +89,9 @@ def main(args):
             infile.read(skip)
         else:
             infile.seek(skip, os.SEEK_CUR)
+
+    if count:
+        infile = io.BytesIO(infile.read(count))
 
     hl = []
     if args.highlight:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -441,7 +441,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     if not exe:
         log.error("%s does not exist" % orig_args[0])
     else:
-        gdbscript = 'file %s\n%s' % (exe, gdbscript)
+        gdbscript = 'file "%s"\n%s' % (exe, gdbscript)
 
     # Start gdbserver/qemu
     # (Note: We override ASLR here for the gdbserver process itself.)
@@ -725,7 +725,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
 
     if exe:
         # The 'file' statement should go first
-        pre = 'file %s\n%s' % (exe, pre)
+        pre = 'file "%s"\n%s' % (exe, pre)
 
     cmd = binary()
 


### PR DESCRIPTION
Fixes https://github.com/Gallopsled/pwntools/issues/1289
This not very performant for large values of c as it reads all the bytes into memory before continuing but it was also a dead easy way of implementing it.