### PR TITLE
Implements "-c" in "phd" (inefficient) - fixes issue 1289

### DIFF
--- a/pwnlib/commandline/phd.py
+++ b/pwnlib/commandline/phd.py
@@ -5,6 +5,7 @@ from __future__ import division
 import argparse
 import os
 import sys
+import io
 
 import pwnlib
 pwnlib.args.free_form = False
@@ -88,6 +89,9 @@ def main(args):
             infile.read(skip)
         else:
             infile.seek(skip, os.SEEK_CUR)
+
+    if count:
+        infile = io.BytesIO(infile.read(count))
 
     hl = []
     if args.highlight:


### PR DESCRIPTION
Fixes #1289
This not very performant for large values of c as it reads all the bytes into memory before continuing but it was also a dead easy way of implementing it.