### PR TITLE
Don't include "__name__" in "__all__" - Fixes #1279

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ cache:
         - usr
         - /home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/
         - /home/travis/virtualenv/python2.7.15/bin/
-sudo: required
 python:
   - "2.7.15"
 before_install:

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -78,4 +78,4 @@ info    = log.info
 debug   = log.debug
 success = log.success
 
-__all__ += list(globals().keys())
+__all__ += [x for x in globals().keys() if x != '__name__']

--- a/pwnlib/commandline/phd.py
+++ b/pwnlib/commandline/phd.py
@@ -5,6 +5,7 @@ from __future__ import division
 import argparse
 import os
 import sys
+import io
 
 import pwnlib
 pwnlib.args.free_form = False
@@ -88,6 +89,9 @@ def main(args):
             infile.read(skip)
         else:
             infile.seek(skip, os.SEEK_CUR)
+
+    if count:
+        infile = io.BytesIO(infile.read(count))
 
     hl = []
     if args.highlight:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -441,7 +441,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     if not exe:
         log.error("%s does not exist" % orig_args[0])
     else:
-        gdbscript = 'file %s\n%s' % (exe, gdbscript)
+        gdbscript = 'file "%s"\n%s' % (exe, gdbscript)
 
     # Start gdbserver/qemu
     # (Note: We override ASLR here for the gdbserver process itself.)
@@ -725,7 +725,7 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
 
     if exe:
         # The 'file' statement should go first
-        pre = 'file %s\n%s' % (exe, pre)
+        pre = 'file "%s"\n%s' % (exe, pre)
 
     cmd = binary()
 

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -344,9 +344,10 @@ class process(tube):
 
         # Set in non-blocking mode so that a call to call recv(1000) will
         # return as soon as a the first byte is available
-        fd = self.proc.stdout.fileno()
-        fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-        fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+        if self.proc.stdout:
+            fd = self.proc.stdout.fileno()
+            fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
         # Save off information about whether the binary is setuid / setgid
         self.uid = os.getuid()

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -65,7 +65,7 @@ setup_travis()
 setup_linux()
 {
     sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
-    RELEASE="$(lsb-release -sr)"
+    RELEASE="$(lsb_release -sr)"
     if [[ "$RELEASE" < "16.04" ]]; then
         sudo apt-add-repository --yes ppa:pwntools/binutils
         sudo apt-get update


### PR DESCRIPTION
This fixes https://github.com/Gallopsled/pwntools/issues/1279

However I'm wondering why this is changed at all compared to the python2 version:

Python2 version:
```
try:
    import cPickle as pickle
except ImportError:
    import pickle

try:
    from cStringIO import StringIO
except ImportError:
    from StringIO import StringIO
```

Python3 version:
```
__all__ = ["pickle", "StringIO", "BytesIO"]
from six.moves import cPickle as pickle, cStringIO as StringIO
from six import BytesIO
...
__all__ += [x for x in globals().keys() if x != '__name__']
```

Why is the last line, "\_\_all\_\_ += ..." needed at all?