### PR TITLE
Don't try to set non-existing fd to non-blocking - fixes #1278

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -344,9 +344,10 @@ class process(tube):
 
         # Set in non-blocking mode so that a call to call recv(1000) will
         # return as soon as a the first byte is available
-        fd = self.proc.stdout.fileno()
-        fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-        fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+        if self.proc.stdout:
+            fd = self.proc.stdout.fileno()
+            fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
         # Save off information about whether the binary is setuid / setgid
         self.uid = os.getuid()


### PR DESCRIPTION
Now as discussed in the issue https://github.com/Gallopsled/pwntools/issues/1278 I'm not sure what the value of this would be but with this change, setting `stdout` to a fd works and doesn't crash.

The only change is that we skip setting it to non blocking mode. I don't think this should have any negative effect as setting stdout to a fd renders many pipe features useless.

Should there be some more sophisticated handling of this instead.
The reason it used to crash can be found in the PYthon docs:

> If the stdout argument was PIPE, this attribute is a file object that provides output from the child process. Otherwise, it is None.