### PR TITLE
Fix #1262 - Static format string for ELF description

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -439,9 +439,12 @@ class ELF(ELFFile):
 
     def _describe(self, *a, **kw):
         log.info_once(
-            '%s\n%s\n%s',
+            '%s\n%-10s%s-%s-%s\n%s',
             repr(self.path),
-            '%-10s%s-%s-%s' % ('Arch:', self.arch, self.bits, self.endian),
+            'Arch:',
+            self.arch,
+            self.bits,
+            self.endian,
             self.checksec(*a, **kw)
         )
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -438,9 +438,12 @@ class ELF(ELFFile):
         return pwnlib.gdb.debug([self.path] + argv, *a, **kw)
 
     def _describe(self, *a, **kw):
-        log.info_once('\n'.join((repr(self.path),
-                                '%-10s%s-%s-%s' % ('Arch:', self.arch, self.bits, self.endian),
-                                self.checksec(*a, **kw))))
+        log.info_once(
+            '%s\n%s\n%s',
+            repr(self.path),
+            '%-10s%s-%s-%s' % ('Arch:', self.arch, self.bits, self.endian),
+            self.checksec(*a, **kw)
+        )
 
     def __repr__(self):
         return "ELF(%r)" % self.path


### PR DESCRIPTION
Fixes https://github.com/Gallopsled/pwntools/issues/1262 
No longer crash on binaries with format string expressions in the name.