### PR TITLE
[dev3] Minor changes for python3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ docs/build
 build
 MANIFEST
 dist
+venv
+.vscode
 *.egg-info
 *.core
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 install:
   - pip install --upgrade pip
   - pip install --upgrade appdirs # https://github.com/ActiveState/appdirs/issues/89#issuecomment-282326570
-  - pip install --upgrade --requirement requirements.txt
+  - python setup.py egg_info
   - pip install --upgrade --editable .
   - pip install --upgrade --requirement docs/requirements.txt
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
 install:
   - pip install --upgrade pip
   - pip install --upgrade appdirs # https://github.com/ActiveState/appdirs/issues/89#issuecomment-282326570
+  - pip install --upgrade --requirement requirements.txt
   - pip install --upgrade --editable .
   - pip install --upgrade --requirement docs/requirements.txt
 before_script:

--- a/pwnlib/commandline/errno.py
+++ b/pwnlib/commandline/errno.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import argparse
 import os
+import errno
 
 from pwnlib.commandline import common
 
@@ -24,20 +25,20 @@ def main(args):
     if 0x100000000 - value < 0x200:
       value = 0x100000000 - value
 
-    if value not in os.errno.errorcode:
+    if value not in errno.errorcode:
       print("No errno for %s" % value)
       return
 
-    name = os.errno.errorcode[value]
+    name = errno.errorcode[value]
 
   except ValueError:
     name = args.error.upper()
 
-    if not hasattr(os.errno, name):
+    if not hasattr(errno, name):
       print("No errno for %s" % name)
       return
 
-    value = getattr(os.errno, name)
+    value = getattr(errno, name)
 
 
   print('#define', name, value)

--- a/pwnlib/commandline/main.py
+++ b/pwnlib/commandline/main.py
@@ -46,6 +46,9 @@ commands = {
 }
 
 def main():
+    if len(sys.argv) < 2:
+        parser.print_usage()
+        sys.exit()
     args = parser.parse_args()
     with context.local(log_console = sys.stderr):
         commands[args.command](args)

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -32,7 +32,7 @@ remote_path = remote_path or exe
 password = password or 'secret1234'
 binary_repr = repr(binary)
 %>\
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 %if not quiet:
 # This exploit template was generated via:

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1125,7 +1125,7 @@ class ELF(ELFFile):
         start = address
         stop = address + count
 
-        overlap = self.memory.search(start, stop)
+        overlap = self.memory.overlap(start, stop)
 
         # Create a new view of memory, for just what we need
         memory = intervaltree.IntervalTree(overlap)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'python-dateutil',
                         'packaging',
                         'psutil>=3.3.0',
-                        'intervaltree',
+                        'intervaltree>=3.0',
                         'sortedcontainers',
                         'unicorn']
 

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ install_requires     = ['paramiko>=1.15.2',
                         'python-dateutil',
                         'packaging',
                         'psutil>=3.3.0',
-                        'intervaltree<3.0', # See Gallopsled/pwntools#1238
-                        'sortedcontainers<2.0', # See Gallopsled/pwntools#1154
+                        'intervaltree',
+                        'sortedcontainers',
                         'unicorn']
 
 # Check that the user has installed the Python development headers


### PR DESCRIPTION
Remove downgrade requirement for sortedcontainers and intervaltree.
Change the call to intervaltree's search in elf/elf.py to the new overlap function
Spit out usage text if pwn commandline bin is called without arguments.

With these changes I was able to get it working fine on arch without requiring any downgraded packages or other weird tricks. Not entirely sure if this is python 2 incompatible. From what I can see python2 has errno in its own library, the latest py2 intervaltree has search split into overlap/envelop so I'd imagine its fine.