### PR TITLE
Modified shellcraft templates to use '/bin//sh' with '-p' argument

### DIFF
--- a/pwnlib/shellcraft/templates/aarch64/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/sh.asm
@@ -1,4 +1,4 @@
-<% from pwnlib import shellcraft as SC %>
+<% from pwnlib.shellcraft import aarch64 %>
 <%docstring>
 Execute a different process.
 
@@ -8,5 +8,5 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-    ${SC.pushstr('/bin///sh')}
-    ${SC.execve('sp', 0, 0)}
+    ${aarch64.linux.execve('/bin///sh', ['sh','-p'], 0)}
+   

--- a/pwnlib/shellcraft/templates/aarch64/pushstr_array.asm
+++ b/pwnlib/shellcraft/templates/aarch64/pushstr_array.asm
@@ -72,7 +72,7 @@ pairwise_offsets = group(2, sorted_offsets)
     sub  ${register2}, sp, ${register2}
     stp  ${register1}, ${register2}, [sp], ${i * 16}
 %endfor
-%if len(array[-1] != 'sp')
+if len(array[-1] != 'sp')
 
     /* set ${reg} to the current top of the stack */
     ${shellcraft.mov(reg,'sp')}

--- a/pwnlib/shellcraft/templates/aarch64/pushstr_array.asm
+++ b/pwnlib/shellcraft/templates/aarch64/pushstr_array.asm
@@ -72,7 +72,8 @@ pairwise_offsets = group(2, sorted_offsets)
     sub  ${register2}, sp, ${register2}
     stp  ${register1}, ${register2}, [sp], ${i * 16}
 %endfor
-if len(array[-1] != 'sp')
 
+%if len(array[-1]) != 'sp':
     /* set ${reg} to the current top of the stack */
     ${shellcraft.mov(reg,'sp')}
+%endif

--- a/pwnlib/shellcraft/templates/amd64/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-${amd64.linux.execve('/bin///sh', ['sh'], 0)}
+${amd64.linux.execve('/bin///sh', ['sh','-p'], 0)}

--- a/pwnlib/shellcraft/templates/arm/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-    ${arm.linux.execve('/bin///sh', ['sh'], 0)}
+    ${arm.linux.execve('/bin///sh', ['sh','-p'], 0)}

--- a/pwnlib/shellcraft/templates/i386/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-${i386.linux.execve('/bin///sh', ['sh'], 0)}
+${i386.linux.execve('/bin///sh', ['sh','-p'], 0)}

--- a/pwnlib/shellcraft/templates/mips/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sh.asm
@@ -10,4 +10,4 @@ Example:
 
 </%docstring>
 
-${mips.execve('//bin/sh', ['sh'], {})}
+${mips.execve('//bin/sh', ['sh','-p'], {})}

--- a/pwnlib/shellcraft/templates/thumb/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/sh.asm
@@ -8,4 +8,4 @@ Execute a different process.
     'Hello\n'
 
 </%docstring>
-${thumb.linux.execve('/bin///sh', ['sh'], 0)}
+${thumb.linux.execve('/bin///sh', ['sh','-p'], 0)}


### PR DESCRIPTION
# Pwntools Pull Request

This PR is in response to Arusekk's request in the following issue: https://github.com/Gallopsled/pwntools/issues/1324

In brief, the sh.asm files for the various processor architectures have been modified to execute '/bin/sh -p' instead of '/bin/sh'. This is in order to take advantage of shells that do not drop privileges when give the -p argument, and allows users to exploit vulnerable programs with SUID privs without having those privs dropped.

## Testing

As in the testing.md file, testing for shellcraft is more difficult. In this case, I confirmed that commands such as aarch64.sh() and mips.sh() actually produced assembly commands including the -p argument. However, I was only able to conduct practical testing on the amd64 and i386 architectures. (The tests worked as expected, privileges were not dropped by the new shell.)

## Target Branch


| `stable` | Bug fixes that affect the current `stable` branch

Not really a bug, but not really a new feature either...

