### PR TITLE
gdb path uses binary() function

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -670,9 +670,10 @@ def attach(target, gdbscript = None, exe = None, need_ptrace_scope = True, gdb_a
             cmd = ['sshpass', '-p', shell.password] + cmd
         if shell.keyfile:
             cmd += ['-i', shell.keyfile]
-        cmd += ['gdb -q %r %s -x "%s"' % (target.executable,
-                                       target.pid,
-                                       tmpfile)]
+        cmd += ['%s -q %r %s -x "%s"' % (binary(),
+                                         target.executable,
+                                         target.pid,
+                                         tmpfile)]
 
         misc.run_in_new_terminal(' '.join(cmd))
         return
@@ -882,7 +883,7 @@ def find_module_addresses(binary, ssh=None, ulimit=False):
     # Get the addresses from GDB
     #
     libs = {}
-    cmd  = "gdb -q --args %s" % (binary)
+    cmd  = "%s -q --args %s" % (binary(), binary)
     expr = re.compile(r'(0x\S+)[^/]+(.*)')
 
     if ulimit:


### PR DESCRIPTION
At the moment the gdb command is hardcoded in attach and find_modules functions. This can be problematic when a user has multiple gdb environments and want to specifically use gef for instance.

For more information on multiple gdb environments check here: https://medium.com/bugbountywriteup/pwndbg-gef-peda-one-for-all-and-all-for-one-714d71bf36b8?source=---------4------------------

A solution to that would be to use the binary() function instead that checks if "gdb-pwntools" exists and returns that before using vanilla "gdb". As a result, a user can explicitly set how gdb will be initialized when used with pwntools by creating a gdb-pwntools file in a /usr/bin/ folder. 

