### PR TITLE
Make DynELF().libc work on current Debian 10 (amd64)

### DIFF
--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -855,7 +855,7 @@ class DynELF(object):
             if self.leak.compare(address + 0xC, "GNU\x00"):
                 return enhex(''.join(self.leak.raw(address + 0x10, 20)))
             else:
-                self.status("Magic did not match")
+                self.status("Build ID not found at offset %#x" % offset)
                 pass
 
     def _make_absolute_ptr(self, ptr_or_offset):

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -196,7 +196,7 @@ def get_build_id_offsets():
     # $ check_arch "x86-64"
     #       6 Displaying notes found at file offset 0x00000174 with length 0x00000024:
     #      82 Displaying notes found at file offset 0x00000270 with length 0x00000024:
-        'amd64': [0x270, 0x174],
+        'amd64': [0x270, 0x174, 0x2e0],
     # $ check_arch "PowerPC or cisco"
     #      88 Displaying notes found at file offset 0x00000174 with length 0x00000024:
         'powerpc': [0x174],


### PR DESCRIPTION
The current version just said "Magic did not match" when trying to leak the build id of Debian's libc. This PR changes the status message and adds the missing offset.