### PR TITLE
fix unicode-str stuff in ssh.py

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -821,7 +821,7 @@ class ssh(Timeout, Logger):
         for i, arg in enumerate(argv):
             if '\x00' in arg[:-1]:
                 self.error('Inappropriate nulls in argv[%i]: %r' % (i, arg))
-            argv[i] = arg.rstrip('\x00')
+            argv[i] = str(arg.rstrip('\x00'))
 
         # Python also doesn't like when envp contains '\x00'
         if env and hasattr(env, 'items'):
@@ -836,7 +836,7 @@ class ssh(Timeout, Logger):
         cwd        = cwd or self.cwd
 
         # Validate, since failures on the remote side will suck.
-        if not isinstance(executable, str):
+        if not isinstance(executable, str) and not isinstance(executable, unicode):
             self.error("executable / argv[0] must be a string: %r" % executable)
         if not isinstance(argv, (list, tuple)):
             self.error("argv must be a list or tuple: %r" % argv)


### PR DESCRIPTION
# Pwntools Pull Request

This request fixes some weird unicode-str stuff in ssh.py. Previously, it rejects unicode argument in `argv` but allows it in `executable`. In this request, all unicode arguments in `argv` will be accepted and transformed into `str` internally.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request
