### PR TITLE
Fix TypeError: find_module() takes exactly 3 arguments (2 given)

### DIFF
--- a/pwnlib/shellcraft/__init__.py
+++ b/pwnlib/shellcraft/__init__.py
@@ -165,7 +165,7 @@ tether = sys.modules[__name__]
 shellcraft = module(__name__, '')
 
 class LazyImporter:
-    def find_module(self, fullname, path):
+    def find_module(self, fullname, path=None):
         if not fullname.startswith('pwnlib.shellcraft.'):
             return None
 


### PR DESCRIPTION
pwnlib.shellcraft installs its custom import finder (LazyImporter) into
sys.meta_path.

According to PEP 302, finder is expected to have prototype

    finder.find_module(fullname, path=None)

Note that the second argument is optional. pwnlib's LazyImporter has second
argument required, which leads to compatibility problems, surfacing
when trying to use pwnlib with other third-party modules:

    >>> import pwnlib
    >>> import faker
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/tmp/.venv/lib/python2.7/site-packages/faker/__init__.py", line 2, in <module>
        from faker.factory import Factory  # noqa F401
      File "/tmp/.venv/lib/python2.7/site-packages/faker/factory.py", line 12, in <module>
        from faker.config import AVAILABLE_LOCALES, DEFAULT_LOCALE, PROVIDERS
      File "/tmp/.venv/lib/python2.7/site-packages/faker/config.py", line 15, in <module>
        AVAILABLE_LOCALES = find_available_locales(PROVIDERS)
      File "/tmp/.venv/lib/python2.7/site-packages/faker/utils/loading.py", line 45, in find_available_locales
        provider_module = import_module(provider_path)
      File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
        __import__(name)
      File "/tmp/.venv/lib/python2.7/site-packages/faker/providers/internet/__init__.py", line 4, in <module>
        from text_unidecode import unidecode
      File "/tmp/.venv/lib/python2.7/site-packages/text_unidecode/__init__.py", line 6, in <module>
        _replaces = pkgutil.get_data(__name__, 'data.bin').decode('utf8').split('\x00')
      File "/usr/lib64/python2.7/pkgutil.py", line 576, in get_data
        loader = get_loader(package)
      File "/usr/lib64/python2.7/pkgutil.py", line 462, in get_loader
        return find_loader(fullname)
      File "/usr/lib64/python2.7/pkgutil.py", line 473, in find_loader
        loader = importer.find_module(fullname)
    TypeError: find_module() takes exactly 3 arguments (2 given)
