### PR TITLE
Py3: raw_input => six.moves.input

### DIFF
--- a/pwnlib/ui.py
+++ b/pwnlib/ui.py
@@ -53,7 +53,7 @@ def yesno(prompt, default = None):
                                        'No' if default == False else 'no',
                                        )
         while True:
-            opt = raw_input(prompt).lower()
+            opt = six.moves.input(prompt).lower()
             if opt == '' and default != None:
                 return default
             elif opt in ('y','yes'):
@@ -142,7 +142,7 @@ def options(prompt, opts, default = None):
             if default:
                 s += '[%s] ' % str(default)
             try:
-                x = int(raw_input(s) or default)
+                x = int(six.moves.input(s) or default)
             except (ValueError, TypeError):
                 continue
             if x >= 1 and x <= len(opts):
@@ -157,7 +157,7 @@ def pause(n = None):
             term.getkey()
         else:
             log.info('Paused (press enter to continue)')
-            raw_input('')
+            six.moves.input('')
     elif isinstance(n, six.integer_types):
         with log.waitfor("Waiting") as l:
             for i in range(n, 0, -1):


### PR DESCRIPTION
This fixes `pause()` and other pwnlib/ui.py methods.