### PR TITLE
Tubes encoding, part 1, sending

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -811,15 +811,15 @@ class ContextType(object):
     def bytes(self, value):
         self.bits = value*8
 
-    @property
-    def decode(self):
+    @_validator
+    def decode(self, decode):
         """Return the default encoding for using in tubes receiving"""
-        return self.decode
+        return decode
 
-    @property
-    def encode(self):
+    @_validator
+    def encode(self, encode):
         """Return the default encoding for using in tubes transmission"""
-        return self.encode
+        return encode
 
     @_validator
     def encoding(self, charset):

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -343,8 +343,10 @@ class ContextType(object):
         'buffer_size': 4096,
         'cyclic_alphabet': string.ascii_lowercase.encode(),
         'cyclic_size': 4,
+        'decode': None,
         'delete_corefiles': False,
         'device': os.getenv('ANDROID_SERIAL', None) or None,
+        'encode': 'ascii',
         'encoding': 'auto',
         'endian': 'little',
         'gdbinit': "",
@@ -808,6 +810,16 @@ class ContextType(object):
     @bytes.setter
     def bytes(self, value):
         self.bits = value*8
+
+    @property
+    def decode(self):
+        """Return the default encoding for using in tubes receiving"""
+        return self.decode
+
+    @property
+    def encode(self):
+        """Return the default encoding for using in tubes transmission"""
+        return self.encode
 
     @_validator
     def encoding(self, charset):

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -159,6 +159,8 @@ class tube(Timeout, Logger):
     def _send_encode(self, data, encode):
         if isinstance(data, six.text_type):
             encode = encode or self.encode
+            if encode is None:
+                raise ValueError("Must provide encoding when sending string")
             return data.encode(encode)
         elif isinstance(data, bytes):
             if encode is not None:
@@ -207,7 +209,7 @@ class tube(Timeout, Logger):
         data = b''
 
         with self.countdown(timeout):
-            while not pred(self._recv_decode(data, decode)):
+            while not pred(data):
                 try:
                     res = self.recv(1)
                 except Exception:
@@ -220,7 +222,7 @@ class tube(Timeout, Logger):
                     self.unrecv(data)
                     return b''
 
-        return self._recv_decode(data, decode)
+        return data
 
     def recvn(self, numb, timeout = default, decode=None):
         """recvn(numb, timeout = default) -> str
@@ -268,7 +270,7 @@ class tube(Timeout, Logger):
         else:
             result = self.buffer.get(numb)
 
-        return self._recv_decode(result, decode)
+        return result
 
     def recvuntil(self, delims, drop=False, timeout=default, decode=None):
         """recvuntil(delims, drop=False, timeout=default) -> bytes
@@ -337,7 +339,7 @@ class tube(Timeout, Logger):
 
                 if not res:
                     self.unrecv(b''.join(data) + top)
-                    return self._recv_decode(b'', decode)
+                    return b''
 
                 top += res
                 start = len(top)
@@ -352,13 +354,13 @@ class tube(Timeout, Logger):
                         top = top[:start]
                     else:
                         top = top[:end]
-                    return self._recv_decode(b''.join(data) + top, decode)
+                    return b''.join(data) + top
                 if len(top) > longest:
                     i = -longest - 1
                     data.append(top[:i])
                     top = top[i:]
 
-        return self._recv_decode(b'', decode)
+        return b''
 
     def recvlines(self, numlines=2**20, keepends=False, timeout=default, decode=None):
         r"""recvlines(numlines, keepends=False, timeout=default) -> list of bytes objects


### PR DESCRIPTION
This is an initial attempt to introduce encoding control and default encoding to the tubes module.
At this stage, only the sending part works. With these changes, code like the following work:

```
# Normal case
t = tube()
t.send_raw = lambda d: print(d)
t.send("1")
t.send(b"2")
t.send(str(3))
t.send(b"4", encode='ascii') # Will throw error

# Force no encoding
t = tube(encode=False)
t.send_raw = lambda d: print(d)
t.send(b"5") # Works
t.send("6", encode='ascii') # Works
t.send("7") # Will throw error

# Force no encoding, context level
context.encode = False
t = tube()
t.send_raw = lambda d: print(d)
t.send(b"8") # Works
t.send("9", encode='ascii') # Works
t.send("10") # Will throw error
```

I'm not sure this is completely ready to merge yet but I wanted to post this here to get some feedback and start a discussion. Note that I'm moving away from `context._encode` as I think it is hacky and that it's better that things are set explicitly (or by default value) than trying strange auto-detect things.

My idea moving forward is that the recv*() functions also should do decoding if you set a default encoding, however I thing the sane defaults are ASCII encode any strings sent but return raw bytes for data received.

Thoughts?