### PR TITLE
Fix 'break' syscall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
 install:
   - pip install --upgrade pip
   - pip install --upgrade appdirs # https://github.com/ActiveState/appdirs/issues/89#issuecomment-282326570
+  - python setup.py egg_info      # pypa/pip#6275
   - pip install --upgrade --editable .
   - pip install --upgrade --requirement docs/requirements.txt
 before_script:

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/break_.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/break_.asm
@@ -4,7 +4,7 @@ import pwnlib.abi
 import pwnlib.constants
 import pwnlib.shellcraft
 %>
-<%docstring>break(vararg_0, vararg_1, vararg_2, vararg_3, vararg_4) -> str
+<%docstring>break_(vararg_0, vararg_1, vararg_2, vararg_3, vararg_4) -> str
 
 Invokes the syscall break.
 
@@ -83,7 +83,7 @@ Returns:
     else:
         raise Exception("Could not locate any syscalls: %r" % syscalls)
 %>
-    /* break(${', '.join(syscall_repr)}) */
+    /* break_(${', '.join(syscall_repr)}) */
 %for name, arg in string_arguments.items():
     ${pwnlib.shellcraft.pushstr(arg, append_null=('\x00' not in arg))}
     ${pwnlib.shellcraft.mov(regs[argument_names.index(name)], abi.stack)}


### PR DESCRIPTION
Fixed the 'break' syscall by renaming the method to break_ so as not to collide with the keyword. Closes #1312.