### PR TITLE
use bytes instead of str

### DIFF
--- a/pwnlib/rop/call.py
+++ b/pwnlib/rop/call.py
@@ -232,7 +232,7 @@ class Call(object):
                                     fmt % self.target,
                                     self.args)
 
-    def __str__(self):
+    def __bytes__(self):
         fmt = "%#x" if isinstance(self.target, six.integer_types) else "%r"
         args = []
         for arg in self.args:


### PR DESCRIPTION
This is a fix attempt to fix some bytes-str issue in rop/call. Before the patch, it always says something like __str__ return bytes.

I know this might not be the optimal solution, but it works for me.