### PR TITLE
fix rop gadgets caching

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1012,7 +1012,7 @@ class ROP(object):
             files = [files]
 
         sha256 = hashlib.sha256()
-        for elf_data in sorted(elf.get_data() for elf in self.elfs):
+        for elf_data in sorted(elf.get_data() for elf in files):
             sha256.update(elf_data)
 
         return os.path.join(cachedir, sha256.hexdigest())


### PR DESCRIPTION
For multiple elfs in a ROP, the available gadgets returned isn't correct due to caching. There is only one cache file created is for all elfs in a ROP leading to the return of only the gadgets of the first elf. Changed code to use the arguments passed to the __get_cachefile_name function. Closes #1329 