### PR TITLE
ROP.find_stack_adjustment() uses the wrong variable

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -880,7 +880,7 @@ class ROP(object):
 
 
     def find_stack_adjustment(self, slots):
-        self.search(move=slots * context.arch)
+        self.search(move=slots * context.bytes)
 
     def chain(self):
         """Build the ROP chain


### PR DESCRIPTION
From the issue #1257:

> Perhaps context.bytes was supposed to be used here, context.arch is a string.

The bytes() method returns a bytes object which is an immmutable (cannot be modified) sequence of integers in the range 0 <=x < 256