### PR TITLE
transform `armv7l` arch to `arm`

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -685,6 +685,7 @@ class ContextType(object):
                      ('x86_64', 'amd64'),
                      ('x86', 'i386'),
                      ('i686', 'i386'),
+                     ('armv7l', 'arm'),
                      ('armeabi', 'arm'),
                      ('arm64', 'aarch64')]
         for k, v in transform:


### PR DESCRIPTION
When debugging exploits locally the local context's arch will be set to ``platform.machine()``, 
when said arch property does not exist in ``context.architectures`` an AttributeError will be raised.

This is usually handled in the arch property getter;
https://github.com/Gallopsled/pwntools/blob/41702e89e6700267e955159d37c9031df33df556/pwnlib/context/__init__.py#L681-L693

The transform list doesn't alias armv7l to arm, causing exploits to crash on said architecture.

[traceback.txt](https://github.com/Gallopsled/pwntools/files/3945916/traceback.txt)