### PR TITLE
Use bytes instead of string in serialtube class

### DIFF
--- a/pwnlib/tubes/serialtube.py
+++ b/pwnlib/tubes/serialtube.py
@@ -63,7 +63,7 @@ class serialtube(tube.tube):
             raise EOFError
 
         if self.convert_newlines:
-            data = data.replace('\n', '\r\n')
+            data = data.replace(b'\n', b'\r\n')
 
         while data:
             n = self.conn.write(data)


### PR DESCRIPTION
Solves #1397 by making sure the serialtube class uses bytes when converting newlines.
