### PR TITLE
Correct self.buffer.add() to self.buffer.unget() in recvline_pred()

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -498,11 +498,11 @@ class tube(Timeout, Logger):
                 try:
                     line = self.recvline(keepends=True)
                 except Exception:
-                    self.buffer.add(tmpbuf)
+                    self.buffer.unget(tmpbuf)
                     raise
 
                 if not line:
-                    self.buffer.add(tmpbuf)
+                    self.buffer.unget(tmpbuf)
                     return b''
 
                 if pred(line):


### PR DESCRIPTION
The use of `self.buffer.add()` in `recvline_pred()` was reordering the buffer if `recvline_pred()` wasn't satisfied or timed out. Corrected this by using `self.buffer.unget()` instead.