### PR TITLE
DynELF: Fixed compare for python 3

### DIFF
--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -292,7 +292,7 @@ class DynELF(object):
         w = None
 
         while True:
-            if self.leak.compare(ptr, '\x7fELF'):
+            if self.leak.compare(ptr, b'\x7fELF'):
                 break
 
             # See if we can short circuit the search
@@ -854,7 +854,7 @@ class DynELF(object):
 
         for offset in libcdb.get_build_id_offsets():
             address = libbase + offset
-            if self.leak.compare(address + 0xC, "GNU\x00"):
+            if self.leak.compare(address + 0xC, b"GNU\x00"):
                 return enhex(b''.join(self.leak.raw(address + 0x10, 20)))
             else:
                 self.status("Build ID not found at offset %#x" % offset)


### PR DESCRIPTION
Minor bug fix.

Changed from string to byte strings for two compares, otherwise Python 3 raises an error while using DynELF.