### PR TITLE
DynELF: Python 3 fixes for string/bytes comparisons

### DIFF
--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -292,7 +292,7 @@ class DynELF(object):
         w = None
 
         while True:
-            if self.leak.compare(ptr, '\x7fELF'):
+            if self.leak.compare(ptr, b'\x7fELF'):
                 break
 
             # See if we can short circuit the search
@@ -641,7 +641,7 @@ class DynELF(object):
             p_name = leak.field(cur, LinkMap.l_name)
             name   = leak.s(p_name)
 
-            if libname in name:
+            if libname.encode('utf-8') in name:
                 break
 
             if name:
@@ -740,6 +740,7 @@ class DynELF(object):
 
                 # Leak the name of the function from the symbol table
                 name = leak.s(strtab + leak.field(sym, Sym.st_name))
+                name = name.decode('utf-8')
 
                 # Make sure it matches the name of the symbol we were looking for.
                 if name == symb:
@@ -823,6 +824,7 @@ class DynELF(object):
                 # Check for collision on hash values
                 sym  = symtab + sizeof(Sym) * (ndx + i)
                 name = leak.s(strtab + leak.field(sym, Sym.st_name))
+                name = name.decode('utf-8')
 
                 if name == symb:
                     # No collision, get offset and calculate address
@@ -854,7 +856,7 @@ class DynELF(object):
 
         for offset in libcdb.get_build_id_offsets():
             address = libbase + offset
-            if self.leak.compare(address + 0xC, "GNU\x00"):
+            if self.leak.compare(address + 0xC, b"GNU\x00"):
                 return enhex(b''.join(self.leak.raw(address + 0x10, 20)))
             else:
                 self.status("Build ID not found at offset %#x" % offset)


### PR DESCRIPTION
Couple minor fixes for using DynELF with Python3 due to string/byte comparisons failing. Importantly this fixes an issue where DynELF's `lookup` function to find a symbol remotely.

There are possibly other issues along the same vein, as I did not use all features of the module.

Regarding test coverage, the module DynELF does not have any coverage (and I could not see a simple way of adding any as it would need a non-trivial leak function mocked) so I think its ok to leave testing is out of scope of this PR.