### PR TITLE
Fix gdb and fmtstr doctests format

### DIFF
--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -31,7 +31,7 @@ from pwnlib.exception import PwnlibException
 from pwnlib.gdb import attach, debug, debug_assembly, debug_shellcode
 from pwnlib.filepointer import *
 from pwnlib.flag import *
-from pwnlib.fmtstr import FmtStr, fmtstr_payload
+from pwnlib.fmtstr import FmtStr, fmtstr_payload, fmtstr_split
 from pwnlib.log import getLogger
 from pwnlib.memleak import MemLeak, RelativeMemLeak
 from pwnlib.regsort import *

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -245,9 +245,9 @@ class AtomWrite(object):
         Combine adjacent writes into a single write.
 
         Example:
-        >>> context.clear(endian = "little")
-        >>> pwnlib.fmtstr.AtomWrite(0x0, 0x1, 0x1, 0xff).union(pwnlib.fmtstr.AtomWrite(0x1, 0x1, 0x2, 0x77))
-        AtomWrite(start=0, size=2, integer=0x201, mask=0xff77)
+            >>> context.clear(endian = "little")
+            >>> pwnlib.fmtstr.AtomWrite(0x0, 0x1, 0x1, 0xff).union(pwnlib.fmtstr.AtomWrite(0x1, 0x1, 0x2, 0x77))
+            AtomWrite(start=0, size=2, integer=0x201, mask=0x77ff)
         """
         assert other.start == self.end, "writes to combine must be continous"
         if context.endian == "little":
@@ -777,22 +777,22 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
 
     Examples:
         >>> context.clear(arch = 'amd64')
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')))
+        >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')
         b'%322419390c%4$llnaaaabaa\x00\x00\x00\x00\x00\x00\x00\x00'
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x1337babe}, write_size='short')))
+        >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='short')
         b'%47806c%5$lln%22649c%6$hnaaaabaa\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00'
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x1337babe}, write_size='byte')))
+        >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='byte')
         b'%190c%7$lln%85c%8$hhn%36c%9$hhn%131c%10$hhnaaaab\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00'
         >>> context.clear(arch = 'i386')
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')))
+        >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')
         b'%322419390c%5$na\x00\x00\x00\x00'
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x1337babe}, write_size='short')))
+        >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='short')
         b'%4919c%7$hn%42887c%8$hna\x02\x00\x00\x00\x00\x00\x00\x00'
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x1337babe}, write_size='byte')))
+        >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='byte')
         b'%19c%12$hhn%36c%13$hhn%131c%14$hhn%4c%15$hhn\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00'
-        >>> print(repr(fmtstr_payload(1, {0x0: 0x00000001}, write_size='byte')))
+        >>> fmtstr_payload(1, {0x0: 0x00000001}, write_size='byte')
         b'%1c%3$na\x00\x00\x00\x00'
-        >>> print(repr(fmtstr_payload(1, {0x0: b"\xff\xff\x04\x11\x00\x00\x00\x00"}, write_size='short')))
+        >>> fmtstr_payload(1, {0x0: b"\xff\xff\x04\x11\x00\x00\x00\x00"}, write_size='short')
         b'%327679c%7$lln%18c%8$hhn\x00\x00\x00\x00\x03\x00\x00\x00'
     """
     sz = WRITE_SIZE[write_size]
@@ -834,15 +834,6 @@ class FmtStr(object):
     """
 
     def __init__(self, execute_fmt, offset = None, padlen = 0, numbwritten = 0):
-        """
-        Instantiates an object which try to automating exploit the vulnerable process
-
-        Arguments:
-            execute_fmt(function): function to call for communicate with the vulnerable process
-            offset(int): the first formatter's offset you control
-            padlen(int): size of the pad you want to add before the payload
-            numbwritten(int): number of already written bytes
-        """
         self.execute_fmt = execute_fmt
         self.offset = offset
         self.padlen = padlen

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -300,8 +300,7 @@ def _get_runner(ssh=None):
 
 @LocalContext
 def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kwargs):
-    r"""debug(args) -> tube
-
+    r"""
     Launch a GDB server with the specified command line,
     and launches GDB to attach to it.
 
@@ -354,9 +353,11 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     ... break main
     ... continue
     ... ''')
+    >>> # Send a command to Bash
     >>> io.sendline("echo hello")
     >>> io.recvline()
     b'hello\n'
+    >>> # Interact with the process
     >>> io.interactive() # doctest: +SKIP
     >>> io.close()
 
@@ -371,9 +372,11 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     ... break free
     ... continue
     ... ''')
+    >>> # Send a command to Bash
     >>> io.sendline("echo hello")
     >>> io.recvline()
     b'hello\n'
+    >>> # Interact with the process
     >>> io.interactive() # doctest: +SKIP
     >>> io.close()
 
@@ -381,19 +384,16 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     by using the ``ssh=`` keyword to pass in your :class:`.ssh` instance.
 
     >>> # Connect to the SSH server
-
-    >>> # Start a process on the server
     >>> shell = ssh('travis', 'example.pwnme', password='demopass')
+    >>> # Start a process on the server
     >>> io = gdb.debug(['bash'],
     ...                 ssh = shell,
     ...                 gdbscript = '''
     ... break main
     ... continue
     ... ''')
-
     >>> # Send a command to Bash
     >>> io.sendline("echo hello")
-
     >>> # Interact with the process
     >>> io.interactive() # doctest: +SKIP
     >>> io.close()
@@ -457,7 +457,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     if not ssh and context.os == 'android':
         host = context.adb_host
 
-    attach((host, port), exe=exe, gdbscript=gdbscript, need_ptrace_scope = False, ssh=ssh, sysroot=sysroot)
+    attach((host, port), exe=exe, gdbscript=gdbscript, ssh=ssh, sysroot=sysroot)
 
     # gdbserver outputs a message when a client connects
     garbage = gdbserver.recvline(timeout=1)
@@ -505,9 +505,8 @@ def binary():
     return gdb
 
 @LocalContext
-def attach(target, gdbscript = '', exe = None, need_ptrace_scope = True, gdb_args = None, ssh = None, sysroot = None):
-    r"""attach(target, gdbscript = None, exe = None, arch = None, ssh = None) -> None
-
+def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysroot = None):
+    r"""
     Start GDB in a new terminal and attach to `target`.
 
     Arguments:
@@ -555,14 +554,12 @@ def attach(target, gdbscript = '', exe = None, need_ptrace_scope = True, gdb_arg
 
     >>> # Start a process
     >>> bash = process('bash')
-
     >>> # Attach the debugger
     >>> pid = gdb.attach(bash, '''
     ... set follow-fork-mode child
     ... break execve
     ... continue
     ... ''')
-
     >>> # Interact with the process
     >>> bash.sendline("whoami")
     >>> bash.recvline()
@@ -572,36 +569,29 @@ def attach(target, gdbscript = '', exe = None, need_ptrace_scope = True, gdb_arg
     >>> # Start a forking server
     >>> server = process(['socat', 'tcp-listen:12345,fork,reuseaddr', 'exec:/bin/bash'])
     >>> sleep(1)
-
     >>> # Connect to the server
     >>> io = remote('127.0.0.1', 12345)
-
     >>> # Connect the debugger to the server-spawned process
     >>> pid = gdb.attach(io, '''
     ... break exit
     ... continue
     ... ''', exe = '/bin/bash')
-
-    >>> # Talk to the spawned 'sh'
+    >>> # Talk to the spawned 'bash'
     >>> io.sendline("echo hello")
     >>> io.recvline()
     b'hello\n'
     >>> io.sendline("exit")
-
     >>> io.close()
 
     >>> # Connect to the SSH server
     >>> shell = ssh('travis', 'example.pwnme', password='demopass')
-
     >>> # Start a process on the server
     >>> cat = shell.process(['cat'])
-
     >>> # Attach a debugger to it
     >>> gdb.attach(cat, '''
     ... break exit
     ... continue
     ... ''')
-
     >>> cat.sendline("hello")
     >>> cat.recvline()
     b'hello\n'


### PR DESCRIPTION
1. Doctests with empty line between them will be split into different code blocks: https://docs.pwntools.com/en/dev/gdb.html
I correct the format according to https://docs.pwntools.com/en/stable/gdb.html
2. The `need_ptrace_scope` argument is useless after #828
3. We don't need to add description for `__init__`