### PR TITLE
Allow pwntools to load on Windows

### DIFF
--- a/pwnlib/term/__init__.py
+++ b/pwnlib/term/__init__.py
@@ -27,6 +27,9 @@ def can_init():
     ``pwnlib`` manage the terminal.
     """
 
+    if sys.platform == 'win32':
+        return False
+
     if not sys.stdout.isatty():
         return False
 

--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -2,16 +2,18 @@ from __future__ import absolute_import
 from __future__ import division
 
 import atexit
-import fcntl
 import os
 import re
 import signal
 import six
 import struct
 import sys
-import termios
 import threading
 import traceback
+
+if sys.platform != 'win32':
+    import fcntl
+    import termios
 
 from pwnlib.context import ContextType
 from pwnlib.term import termcap

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -4,19 +4,22 @@ from __future__ import division
 
 import ctypes
 import errno
-import fcntl
 import logging
 import os
 import platform
-import pty
-import resource
 import select
 import signal
 import six
 import stat
 import subprocess
+import sys
 import time
-import tty
+
+if sys.platform != 'win32':
+    import fcntl
+    import pty
+    import resource
+    import tty
 
 from pwnlib import qemu
 from pwnlib.context import context

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -30,7 +30,10 @@ from pwnlib.util.sh_string import sh_string
 # Kill the warning line:
 # No handlers could be found for logger "paramiko.transport"
 paramiko_log = logging.getLogger("paramiko.transport")
-h = logging.StreamHandler(open('/dev/null','w+'))
+if sys.platform != 'win32':
+    h = logging.StreamHandler(open('/dev/null','w+'))
+else:
+    h = logging.StreamHandler(open('nul','w+'))
 h.setFormatter(logging.Formatter())
 paramiko_log.addHandler(h)
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -30,10 +30,7 @@ from pwnlib.util.sh_string import sh_string
 # Kill the warning line:
 # No handlers could be found for logger "paramiko.transport"
 paramiko_log = logging.getLogger("paramiko.transport")
-if sys.platform != 'win32':
-    h = logging.StreamHandler(open('/dev/null','w+'))
-else:
-    h = logging.StreamHandler(open('nul','w+'))
+h = logging.StreamHandler(open(os.devnull,'w+'))
 h.setFormatter(logging.Formatter())
 paramiko_log.addHandler(h)
 

--- a/pwnlib/ui.py
+++ b/pwnlib/ui.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 
-import fcntl
 import os
 import signal
 import six
@@ -9,7 +8,6 @@ import string
 import struct
 import subprocess
 import sys
-import termios
 import time
 import types
 
@@ -21,6 +19,8 @@ from pwnlib.tubes.process import process
 log = getLogger(__name__)
 
 def testpwnproc(cmd):
+    import fcntl
+    import termios
     env = dict(os.environ)
     env.pop("PWNLIB_NOTERM", None)
     def handleusr1(sig, frame):

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,9 @@ install_requires     = ['paramiko>=1.15.2',
                         'unicorn>=1.0.2rc1', # see unicorn-engine/unicorn#1100, unicorn-engine/unicorn#1170
 ]
 
+if sys.platform == 'win32':
+    install_requires.append('windows-curses>=2.1.0')
+
 # Check that the user has installed the Python development headers
 PythonH = os.path.join(get_python_inc(), 'Python.h')
 if not os.path.exists(PythonH):


### PR DESCRIPTION
Fixes loading of pwntools on Windows. `from pwn import *` works. Most of the tweaks were required around the `pwnlib.term` module where most functionality got disabled due to modules only supporting linux.

It allows to use some operating system agnostic features of pwntools out of the box.

This is inspired by #996.

Some features fail or even crash (local processes, gdb, assemble/disassemble) and console colors are still not displayed correctly, but those can be addressed separately.

```
C:\ctfs\pwnable.tw>python start.py
[x[m] Opening connection to chall.pwnable.tw on port 10000
[x[m] Opening connection to chall.pwnable.tw on port 10000: Trying 139.162.123.119
[+[m] Opening connection to chall.pwnable.tw on port 10000: Done
[*[m] 'C:\\ctfs\\pwnable.tw\\start'
    Arch:     i386-32-little
    RELRO:    No RELRO[m
    Stack:    No canary found[m
    NX:       NX disabled[m
    PIE:      No PIE (0x8048000)[m
[*[m] Switching to interactive mode
FLAG{XXXXXXXXXXXX}
```

I guess eventually tests could be run on AppVeyor or similar.