### PR TITLE
fix for tube wrapperS

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1376,8 +1376,8 @@ class tube(Timeout, Logger):
             return context._decode(func(self, *a, **kw))
         wrapperb.__doc__ = 'Same as :meth:`{func.__name__}`, but returns a bytearray'.format(func=func)
         wrapperb.__name__ = func.__name__ + 'b'
-        wrapperS.__doc__ = 'Same as :meth:`{func.__name__}`, but returns a str,' \
-                           'decoding the result using `context.encoding`.' \
+        wrapperS.__doc__ = 'Same as :meth:`{func.__name__}`, but returns a str, ' \
+                           'decoding the result using `context.encoding`. ' \
                            '(note that the binary versions are way faster)'.format(func=func)
         wrapperS.__name__ = func.__name__ + 'S'
         return wrapperb, wrapperS

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1373,7 +1373,7 @@ class tube(Timeout, Logger):
         def wrapperb(self, *a, **kw):
             return bytearray(func(self, *a, **kw))
         def wrapperS(self, *a, **kw):
-            return context._encode(func(self, *a, **kw))
+            return context._decode(func(self, *a, **kw))
         wrapperb.__doc__ = 'Same as :meth:`{func.__name__}`, but returns a bytearray'.format(func=func)
         wrapperb.__name__ = func.__name__ + 'b'
         wrapperS.__doc__ = 'Same as :meth:`{func.__name__}`, but returns a str,' \


### PR DESCRIPTION
Before change, the functions from wrapperS returns bytes rather than str. For example
```python
>>> from pwnlib.tubes.tube import tube
>>> t = tube()
>>> t.recv_raw = lambda n: b"Hello\nWorld\n"
>>> t.recvS()
b'Hello\nWorld\n'
```

changing `context._encode` to `context._decode`, things work correctly. 
```python
>>> t.recvS()
'Hello\nWorld\n'
```

The original docstring is correct, though spaces are missing after punctuations.