### PR TITLE
Enable text colors in Windows console

### DIFF
--- a/pwnlib/term/termcap.py
+++ b/pwnlib/term/termcap.py
@@ -1,56 +1,7 @@
-from __future__ import division
-from __future__ import print_function
-
 __all__ = ['get']
-import curses
-import os
 import sys
+if sys.platform == 'win32':
+    from pwnlib.term.windows_termcap import get
+else:
+    from pwnlib.term.unix_termcap import get
 
-cache = None
-
-def get(cap, *args, **kwargs):
-    default = kwargs.pop('default', '')
-
-    if 'PWNLIB_NOTERM' in os.environ:
-        return ''
-
-    # Hack for readthedocs.org
-    if 'READTHEDOCS' in os.environ:
-        return ''
-
-    if kwargs != {}:
-        raise TypeError("get(): No such argument %r" % kwargs.popitem()[0])
-
-    if cache == None:
-        init()
-    s = cache.get(cap)
-    if not s:
-        s = curses.tigetstr(cap)
-        if s == None:
-            s = curses.tigetnum(cap)
-            if s == -2:
-                s = curses.tigetflag(cap)
-                if s == -1:
-                    # default to empty string so tparm doesn't fail
-                    s = ''
-                else:
-                    s = bool(s)
-        cache[cap] = s
-    # if `s' is not set `curses.tparm' will throw an error if given arguments
-    if args and s:
-        return curses.tparm(s, *args)
-    else:
-        return s
-
-def init():
-    global cache
-
-    if 'PWNLIB_NOTERM' not in os.environ:
-        # Fix for BPython
-        try:
-            curses.setupterm()
-        except curses.error as e:
-            import traceback
-            print('Warning:', ''.join(traceback.format_exception_only(e.__class__, e)), file=sys.stderr)
-
-    cache = {}

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -40,7 +40,7 @@ class Module(types.ModuleType):
             'cyan': 6,
             'white': 7,
             }
-        self._reset = '\x1b[m'
+        self._reset = termcap.get('reset')
         self._attributes = {}
         for x, y in [('italic'   , 'sitm'),
                      ('bold'     , 'bold'),

--- a/pwnlib/term/unix_termcap.py
+++ b/pwnlib/term/unix_termcap.py
@@ -1,0 +1,59 @@
+from __future__ import division
+from __future__ import print_function
+
+__all__ = ['get']
+import curses
+import os
+import sys
+
+cache = None
+
+def get(cap, *args, **kwargs):
+    default = kwargs.pop('default', '')
+
+    if 'PWNLIB_NOTERM' in os.environ:
+        return ''
+
+    # Hack for readthedocs.org
+    if 'READTHEDOCS' in os.environ:
+        return ''
+
+    if kwargs != {}:
+        raise TypeError("get(): No such argument %r" % kwargs.popitem()[0])
+
+    if cache == None:
+        init()
+    s = cache.get(cap)
+    if not s:
+        s = curses.tigetstr(cap)
+        if s == None:
+            s = curses.tigetnum(cap)
+            if s == -2:
+                s = curses.tigetflag(cap)
+                if s == -1:
+                    # default to empty string so tparm doesn't fail
+                    s = ''
+                else:
+                    s = bool(s)
+        cache[cap] = s
+    # if `s' is not set `curses.tparm' will throw an error if given arguments
+    if args and s:
+        return curses.tparm(s, *args)
+    else:
+        return s
+
+def init():
+    global cache
+
+    if 'PWNLIB_NOTERM' not in os.environ:
+        # Fix for BPython
+        try:
+            curses.setupterm()
+        except curses.error as e:
+            import traceback
+            print('Warning:', ''.join(traceback.format_exception_only(e.__class__, e)), file=sys.stderr)
+
+    cache = {}
+    # Manually add reset sequence into the cache.
+    # Can't look it up using tigetstr.
+    cache['reset'] = '\x1b[m'

--- a/pwnlib/term/unix_termcap.py
+++ b/pwnlib/term/unix_termcap.py
@@ -21,12 +21,12 @@ def get(cap, *args, **kwargs):
     if kwargs != {}:
         raise TypeError("get(): No such argument %r" % kwargs.popitem()[0])
 
-    if cache == None:
+    if cache is None:
         init()
     s = cache.get(cap)
     if not s:
         s = curses.tigetstr(cap)
-        if s == None:
+        if s is None:
             s = curses.tigetnum(cap)
             if s == -2:
                 s = curses.tigetflag(cap)

--- a/pwnlib/term/windows_termcap.py
+++ b/pwnlib/term/windows_termcap.py
@@ -17,7 +17,7 @@ def get(cap, *args, **kwargs):
     if kwargs != {}:
         raise TypeError("get(): No such argument %r" % kwargs.popitem()[0])
 
-    if cache == None:
+    if cache is None:
         init()
     
     s = cache.get(cap)

--- a/pwnlib/term/windows_termcap.py
+++ b/pwnlib/term/windows_termcap.py
@@ -1,0 +1,90 @@
+import os
+import msvcrt
+import ctypes
+import sys
+from ctypes import wintypes
+
+__all__ = ['get']
+
+cache = None
+
+def get(cap, *args, **kwargs):
+    default = kwargs.pop('default', '')
+
+    if 'PWNLIB_NOTERM' in os.environ:
+        return default
+
+    if kwargs != {}:
+        raise TypeError("get(): No such argument %r" % kwargs.popitem()[0])
+
+    if cache == None:
+        init()
+    
+    s = cache.get(cap)
+    if s:
+        if args:
+            return s(*args)
+        return s
+    return default
+
+def init():
+    global cache
+    cache = {}
+
+    if 'PWNLIB_NOTERM' not in os.environ:
+        try:
+            enable_vt_mode()
+        except:
+            # If the terminal doesn't support ANSI escape codes, don't use them.
+            return
+
+    # Setup capabilities similar to curses on unix.
+    # https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+    cache['colors'] = 256
+    cache['reset'] = '\x1b[0m'
+    cache['bold'] = '\x1b[1m'
+    cache['smul'] = '\x1b[4m'
+    cache['rev'] = '\x1b[7m'
+    cache['setaf'] = lambda c: '\x1b[3{}m'.format(c) if c < 8 else '\x1b[9{}m'.format(c-8)
+    cache['setab'] = lambda c: '\x1b[4{}m'.format(c) if c < 8 else '\x1b[10{}m'.format(c-8)
+
+# Enable ANSI escape sequences on Windows 10.
+# https://bugs.python.org/issue30075
+kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+ERROR_INVALID_PARAMETER = 0x0057
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+def _check_bool(result, func, args):
+    if not result:
+        raise ctypes.WinError(ctypes.get_last_error())
+    return args
+
+LPDWORD = ctypes.POINTER(wintypes.DWORD)
+kernel32.GetConsoleMode.errcheck = _check_bool
+kernel32.GetConsoleMode.argtypes = (wintypes.HANDLE, LPDWORD)
+kernel32.SetConsoleMode.errcheck = _check_bool
+kernel32.SetConsoleMode.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+
+def set_conout_mode(new_mode, mask=0xffffffff):
+    # don't assume StandardOutput is a console.
+    # open CONOUT$ instead
+    fdout = os.open('CONOUT$', os.O_RDWR)
+    try:
+        hout = msvcrt.get_osfhandle(fdout)
+        old_mode = wintypes.DWORD()
+        kernel32.GetConsoleMode(hout, ctypes.byref(old_mode))
+        mode = (new_mode & mask) | (old_mode.value & ~mask)
+        kernel32.SetConsoleMode(hout, mode)
+        return old_mode.value
+    finally:
+        os.close(fdout)
+
+def enable_vt_mode():
+    mode = mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    try:
+        return set_conout_mode(mode, mask)
+    except WindowsError as e:
+        if e.winerror == ERROR_INVALID_PARAMETER:
+            raise NotImplementedError
+        raise

--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,6 @@ install_requires     = ['paramiko>=1.15.2',
                         'unicorn>=1.0.2rc1', # see unicorn-engine/unicorn#1100, unicorn-engine/unicorn#1170
 ]
 
-if sys.platform == 'win32':
-    install_requires.append('windows-curses>=2.1.0')
-
 # Check that the user has installed the Python development headers
 PythonH = os.path.join(get_python_inc(), 'Python.h')
 if not os.path.exists(PythonH):


### PR DESCRIPTION
Consoles on Windows 10 [support ANSI escape sequences](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) including color codes.
Emulate unix curses/terminalinfo `tigetstr` terminal capabilities by hardcoding the given escape sequences for used curses capabilities.

ANSI escape sequences have to be enabled using `kernel32.SetConsoleMode(hndl, ENABLE_VIRTUAL_TERMINAL_PROCESSING)` for the current console on Windows 10.
This uses the proposed way to enable it from within Python from the rejected feature request over at https://bugs.python.org/issue30075