### PR TITLE
The SSH tube now keeps the environment variable's order.

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -891,6 +891,7 @@ class ssh(Timeout, Logger):
             self.error("env must be a dict: %r" % env)
 
         # Allow passing in sys.stdin/stdout/stderr objects
+        env = list(env.items())
         handles = {sys.stdin: 0, sys.stdout:1, sys.stderr:2}
         stdin  = handles.get(stdin, stdin)
         stdout = handles.get(stdout, stdout)
@@ -917,7 +918,7 @@ import os, sys, ctypes, resource, platform, stat
 from collections import OrderedDict
 exe   = %(executable)r
 argv  = %(argv)r
-env   = %(env)r
+env   = OrderedDict(%(env)r)
 
 os.chdir(%(cwd)r)
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -891,7 +891,6 @@ class ssh(Timeout, Logger):
             self.error("env must be a dict: %r" % env)
 
         # Allow passing in sys.stdin/stdout/stderr objects
-        env = list(env.items())
         handles = {sys.stdin: 0, sys.stdout:1, sys.stderr:2}
         stdin  = handles.get(stdin, stdin)
         stdout = handles.get(stdout, stdout)
@@ -911,6 +910,9 @@ class ssh(Timeout, Logger):
 
         func_src  = inspect.getsource(func).strip()
         setuid = True if setuid is None else bool(setuid)
+        
+        # Converts the environment variables to a list of tuples to remain order.
+        env = list(env.items())
 
         script = r"""
 #!/usr/bin/env python2


### PR DESCRIPTION
## Explanation
The SSH tube now keeps the environment variables of processes it creates using `ssh.process` in order.
The way of achieving that is through passing the env to the script as a list of tuples,
since Python3's dictionaries are ordered by default, or you can use `OrderedDict`,
the result would be that the spawned process on the remote machine will keep the environment variables in order.
    
## Why
This is very important to exploits that are based on the stack's order and especially the environment variables.
For instance, a common challenge is comparing `argc == 0`, and afterwards accessing the `argv` array, with an out-of-bounds read/write.
The shellcode needs to be at a certain index consistently and cannot rely on the stack moving around and getting scrambled.


## Example
```py
from pwn import *
shellcode = asm('nop') * 500 + asm(shellcraft.sh())
envp = {str(k): '' for k in range(1, 10)}
envp['9'] = shellcode
envp['10'] = b'A' * 0xd + b'\xb4\xde\xff\xff'

# *shellcode [0xffffdeb4]
# *buf [ebp-0xC]

s = ssh('utumno5', 'utumno.labs.overthewire.org', 2227, '...')
# Won't work without the following patch.
p = s.process(executable='/utumno/utumno5', argv=[], env=envp)
# Works, since env keeps its order.
p = process(executable='./utumno5', argv=[], env=envp)
```
The following code block won't work as long as this PR isn't merged.
The reason is that the `envp` variable runs differently locally and remote.
This PR will make it consistent so that the order of the dict will remain and avoid the miss-matching between the local and remote execution.