### PR TITLE
Fixed bug when rop.call() used sigreturn with string args

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -966,7 +966,10 @@ class ROP(object):
                 SYS_sigreturn  = constants.SYS_rt_sigreturn
 
             for register, value in zip(frame.arguments, arguments):
-                frame[register] = value
+                if not isinstance(value, six.integer_types + (Unresolved,)):
+                    frame[register] = AppendedArgument(value)
+                else:
+                    frame[register] = value
 
         # Set up a call frame which will set EAX and invoke the syscall
         call = Call('SYS_sigreturn',


### PR DESCRIPTION
Previously, the rop._srop_call function would append the args without checking whether their value would fit directly in a register.
It now uses AppendedArgument to determine whether the value is pushed to the end of the ROP chain.