### PR TITLE
Support opening of new terminal windows in WSL

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -194,6 +194,9 @@ def run_in_new_terminal(command, terminal = None, args = None):
           variable), a new pane will be opened.
         - If GNU Screen is detected (by the presence of the ``$STY`` environment
           variable), a new screen will be opened.
+        - If WSL (Windows Subsystem for Linux) is detected (by the presence of
+          a ``wsl.exe`` binary in the ``$PATH`` and ``/proc/sys/kernel/osrelease``
+          containing ``Microsoft``), a new ``cmd.exe`` window will be opened.
 
     Arguments:
         command (str): The command to run.
@@ -226,6 +229,14 @@ def run_in_new_terminal(command, terminal = None, args = None):
         elif 'STY' in os.environ and which('screen'):
             terminal = 'screen'
             args     = ['-t','pwntools-gdb','bash','-c']
+        else:
+            is_wsl = False
+            if os.path.exists('/proc/sys/kernel/osrelease'):
+                with open('/proc/sys/kernel/osrelease', 'rb') as f:
+                    is_wsl = b'Microsoft' in f.read()
+            if is_wsl and which('cmd.exe') and which('wsl.exe') and which('bash.exe'):
+                terminal = 'cmd.exe'
+                args     = ['/c', 'start', 'bash.exe', '-c']
 
     if not terminal:
         log.error('Could not find a terminal binary to use. Set context.terminal to your terminal.')


### PR DESCRIPTION
Detect if pwntools is running in a Windows Subsystem for Linux "VM" and set the terminal to open a new `cmd.exe` window on the host.

This replaces the need to add `context.terminal = ['cmd.exe', '/c', 'start', 'ubuntu', 'run']` to every script. Instead of hardcoding a distribution like `ubuntu` use the selected default distribution in WSL. Running `wsl.exe` instead of `bash.exe` caused the new window to close immediately, so I've settled with `bash.exe`. If someone has a different `bash.exe` in their path before the WSL binaries - well they'll need to fix their environment.

https://devblogs.microsoft.com/commandline/a-guide-to-invoking-wsl/

Debugging using `gdb.attach` under WSL with gdb in a new window out of the box! Since this is added as the last option in the list of possible terminals, running screen or tmux in wsl will still use those.