### PR TITLE
fixed hex-value lookup for cyclic command-line command

### DIFF
--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -66,6 +66,7 @@ def main(args):
 
         try:
             pat = packing.pack(int(pat, 0), subsize*8)
+            pat = pat.decode('utf-8')
         except ValueError:
             pass
 


### PR DESCRIPTION
pwn cyclic 50

and on program crash, we get _0x61616169_ to do lookup on hex value command is as follow but it fails 
 
pwn cyclic -l 0x61616169                                                                                                                                                              
```
Traceback (most recent call last):
  File "/home/d3xt3r/.pyenv/versions/3.6.9/bin/pwn", line 8, in <module>
    sys.exit(main())
  File "/home/d3xt3r/.pyenv/versions/3.6.9/lib/python3.6/site-packages/pwnlib/commandline/main.py", line 54, in main
    commands[args.command](args)
  File "/home/d3xt3r/.pyenv/versions/3.6.9/lib/python3.6/site-packages/pwnlib/commandline/cyclic.py", line 76, in main
    if not all(c in alphabet for c in pat):
  File "/home/d3xt3r/.pyenv/versions/3.6.9/lib/python3.6/site-packages/pwnlib/commandline/cyclic.py", line 76, in <genexpr>
    if not all(c in alphabet for c in pat):
TypeError: 'in <string>' requires string as left operand, not int
```

This patch will fix that problem
