### PR TITLE
Detect AVR binutils

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -191,6 +191,8 @@ def which_binutils(util):
             # e.g. objdump
             if arch is None:
                 pattern = gutil
+            elif arch == 'avr':
+                pattern ='avr-%s' % gutil
 
             # e.g. aarch64-linux-gnu-objdump
             else:

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -190,18 +190,18 @@ def which_binutils(util):
         for gutil in utils:
             # e.g. objdump
             if arch is None:
-                pattern = gutil
-            elif arch == 'avr':
-                pattern ='avr-%s' % gutil
+                patterns = [gutil]
 
-            # e.g. aarch64-linux-gnu-objdump
+            # e.g. aarch64-linux-gnu-objdump, avr-objdump
             else:
-                pattern = '%s*linux*-%s' % (arch,gutil)
+                patterns = ['%s*linux*-%s' % (arch, gutil),
+                            '%s-%s' % (arch, gutil)]
 
-            for dir in environ['PATH'].split(':'):
-                res = sorted(glob(path.join(dir, pattern)))
-                if res:
-                    return res[0]
+            for pattern in patterns:
+                for dir in environ['PATH'].split(':'):
+                    res = sorted(glob(path.join(dir, pattern)))
+                    if res:
+                        return res[0]
 
     # No dice!
     print_binutils_instructions(util, context)

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -324,6 +324,7 @@ def _bfdname():
         'amd64'   : 'elf64-x86-64',
         'arm'     : 'elf32-%sarm' % E,
         'thumb'   : 'elf32-%sarm' % E,
+        'avr'     : 'elf32-avr',
         'mips'    : 'elf32-trad%smips' % E,
         'mips64'  : 'elf64-trad%smips' % E,
         'alpha'   : 'elf64-alpha',


### PR DESCRIPTION
Both Debian and Ubuntu provide a `binutils-avr` package, which contains
an assembler for AVR as `avr-as`. However, pwntools was looking for
something with `linux` in the name, such as `avr-linux-gnu-as`. Of course,
such a target triplet is nonsense, Linux does not run on AVRs
(apart from that one hack that actually emulated some other CPU which
therefore doesn't count).