### PR TITLE
gdb.debug() environment variables fix

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -236,7 +236,7 @@ def _gdbserver_args(pid=None, path=None, args=None, which=None, env=None):
     if pid:
         gdbserver_args += ['--once', '--attach']
 
-    if env != None:
+    if env is not None:
         env_args = []
         for key in tuple(env):
             if key.startswith('LD_'): # LD_PRELOAD / LD_LIBRARY_PATH etc.

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -236,13 +236,14 @@ def _gdbserver_args(pid=None, path=None, args=None, which=None, env=None):
     if pid:
         gdbserver_args += ['--once', '--attach']
 
-    if env:
+    if env != None:
         env_args = []
         for key in tuple(env):
             if key.startswith('LD_'): # LD_PRELOAD / LD_LIBRARY_PATH etc.
                 env_args.append('{}={}'.format(key, env.pop(key)))
-        if env_args:
-            gdbserver_args += ['--wrapper', 'env'] + env_args + ['--']
+            else:
+                env_args.append('{}={}'.format(key, env[key]))
+        gdbserver_args += ['--wrapper', 'env', '-i'] + env_args + ['--']
 
     gdbserver_args += ['localhost:0']
     gdbserver_args += args


### PR DESCRIPTION
If passed an empty dictionary defining the environment variables, the process invoked by gdb.debug() has environment variable 'PWD' set to the directory containing the executable.  This behaviour is not observered when NOPTRACE is enabled:  the program runs without any environment variables set.  Similarly, if an empty environment variable dictionary is passed to process(), it appears to also run under a truly empty environment.  Additionally, attempts to overwrite the "PWD" environment variable with a dictionary entry are not successful under gdb.debug().

This fix brings the gdb.debug() treatment of environment variables in line with process() and gdb.debug() with NOPTRACE enabled. 
 It allows both empty environments, and overwriting of the 'PWD' environment variable.

# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request
