### PR TITLE
Implement property getter/setter for context.newline, and make tubes honor it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.4.0 (`dev`)
 
+- [#1541][1541] Use `context.newline` for tubes by default
+
+[1541]: https://github.com/Gallopsled/pwntools/pull/1541
+
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -359,7 +359,7 @@ class ContextType(object):
         'log_console': sys.stdout,
         'randomize': False,
         'rename_corefiles': True,
-        'newline': '\n',
+        'newline': b'\n',
         'noptrace': False,
         'os': 'linux',
         'proxy': None,
@@ -1278,6 +1278,15 @@ class ContextType(object):
         Default value is ``True``.
         """
         return bool(v)
+
+    @_validator
+    def newline(self, v):
+        """Line ending used for Tubes by default.
+
+        This configures the newline emitted by e.g. ``sendline`` or that is used
+        as a delimiter for e.g. ``recvline``.
+        """
+        return six.ensure_binary(v)
 
 
     @_validator

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -32,10 +32,6 @@ class tube(Timeout, Logger):
     default = Timeout.default
     forever = Timeout.forever
 
-    #: Delimiter to use for :meth:`sendline`, :meth:`recvline`,
-    #: and related functions.
-    newline = b'\n'
-
     def __init__(self, timeout = default, level = None, *a, **kw):
         super(tube, self).__init__(timeout)
 
@@ -44,7 +40,34 @@ class tube(Timeout, Logger):
             self.setLevel(level)
 
         self.buffer = Buffer(*a, **kw)
+        self._newline = None
         atexit.register(self.close)
+
+    @property
+    def newline(self):
+        '''Character sent with methods like sendline() or used for recvline().
+
+            >>> t = tube()
+            >>> t.newline = 'X'
+            >>> t.unrecv('A\nB\nCX')
+            >>> t.recvline()
+            b'A\nB\nCX'
+
+            >>> t = tube()
+            >>> context.newline = '\r\n'
+            >>> t.newline
+            b'\r\n'
+
+            # Clean up
+            >>> context.clear()
+        '''
+        if self._newline is not None:
+            return self._newline
+        return context.newline
+
+    @newline.setter
+    def newline(self, newline):
+        self._newline = six.ensure_binary(newline)
 
     # Functions based on functions from subclasses
     def recv(self, numb = None, timeout = default):

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -45,7 +45,7 @@ class tube(Timeout, Logger):
 
     @property
     def newline(self):
-        '''Character sent with methods like sendline() or used for recvline().
+        r'''Character sent with methods like sendline() or used for recvline().
 
             >>> t = tube()
             >>> t.newline = 'X'


### PR DESCRIPTION

The default newline can now be set context-wide, or per-tube.

```py
>>> t = tube()
>>> t.newline = 'X'
>>> t.unrecv('A\nB\nCX')
>>> t.recvline()
b'A\nB\nCX'

>>> t = tube()
>>> context.newline = '\r\n'
>>> t.newline
b'\r\n'
```