### PR TITLE
Increase fetch depth to 100 to increase cache hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 10 # used only for optimizing jre away
+        fetch-depth: 100 # used only for optimizing jre away
 
     - name: Cache for pip
       uses: actions/cache@v1


### PR DESCRIPTION
AVD installation is one of the longest parts of the CI process

This deserves as much optimization as it can get, as it greatly increases testing iteration speed