### PR TITLE
Re-enable Corefile tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
+    - name: Enable verbose logging
+      run: set -x
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,12 @@ jobs:
 
     - name: Disable broken tests
       run: |
-        rm -f docs/source/elf/corefile.rst
         rm -f docs/source/ui.rst
+
+    - name: Enable core dumps
+      run: |
+        ulimit -c unlimited
+        ulimit -c
 
     - name: Manually install non-broken Unicorn
       run:  pip install unicorn==1.0.2rc3


### PR DESCRIPTION
Re-enable Corefile tests in Github Actions

I suspect this will not work because the test runs fail as soon as any process segfaults