### PR TITLE
Re-enable UI tests in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
     - name: Disable broken tests
       run: |
         rm -f docs/source/elf/corefile.rst
-        rm -f docs/source/ui.rst
 
     - name: Manually install non-broken Unicorn
       run:  pip install unicorn==1.0.2rc3


### PR DESCRIPTION
I suspect this will not work because of curses failing to initialize in GHA
