### PR TITLE
Use dual-stack sockets when family is 'any'

### DIFF
--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -35,12 +35,20 @@ class listen(sock):
         >>> r.recvline()
         b'Hello\n'
 
+        >>> # It works with ipv4 by default
         >>> l = listen()
         >>> l.spawn_process('/bin/sh')
-        >>> r = remote('localhost', l.lport)
+        >>> r = remote('127.0.0.1', l.lport)
         >>> r.sendline(b'echo Goodbye')
         >>> r.recvline()
         b'Goodbye\n'
+
+        >>> # and it works with ipv6 by defaut, too!
+        >>> l = listen()
+        >>> r = remote('::1', l.lport)
+        >>> r.sendline(b'Bye-bye')
+        >>> l.recvline()
+        b'Bye-bye\n'
     """
 
     #: Local port
@@ -66,8 +74,8 @@ class listen(sock):
 
     _accepter = None
 
-    def __init__(self, port=0, bindaddr = "0.0.0.0",
-                 fam = "any", typ = "tcp", *args, **kwargs):
+    def __init__(self, port=0, bindaddr='::',
+                 fam='any', typ='tcp', *args, **kwargs):
         super(listen, self).__init__(*args, **kwargs)
 
         port = int(port)
@@ -77,8 +85,8 @@ class listen(sock):
         fam = self._get_family(fam)
         typ = self._get_type(typ)
 
-        if fam == socket.AF_INET6 and bindaddr == '0.0.0.0':
-            bindaddr = '::'
+        if fam == socket.AF_INET and bindaddr == '::':
+            bindaddr = '0.0.0.0'
 
         h = self.waitfor('Trying to bind to %s on port %d' % (bindaddr, port))
 
@@ -91,6 +99,11 @@ class listen(sock):
             h.status("Trying %s" % self.sockaddr[0])
             listen_sock = socket.socket(self.family, self.type, self.proto)
             listen_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if self.family == socket.AF_INET6:
+                try:
+                    listen_sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, fam == socket.AF_INET6)
+                except (socket.error, AttributeError):
+                    self.warn("could not set socket to accept also IPV4")
             listen_sock.bind(self.sockaddr)
             self.lhost, self.lport = listen_sock.getsockname()[:2]
             if self.type == socket.SOCK_STREAM:

--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -43,7 +43,7 @@ class sock(tube):
             except IOError as e:
                 if e.errno == errno.EAGAIN:
                     return None
-                elif e.errno in [errno.ECONNREFUSED, errno.ECONNRESET]:
+                elif e.errno in (errno.ECONNREFUSED, errno.ECONNRESET):
                     self.shutdown("recv")
                     raise EOFError
                 elif e.errno == errno.EINTR:
@@ -64,7 +64,7 @@ class sock(tube):
         try:
             self.sock.sendall(data)
         except IOError as e:
-            eof_numbers = [errno.EPIPE, errno.ECONNRESET, errno.ECONNREFUSED]
+            eof_numbers = (errno.EPIPE, errno.ECONNRESET, errno.ECONNREFUSED)
             if e.errno in eof_numbers or 'Socket is closed' in e.args:
                 self.shutdown("send")
                 raise EOFError
@@ -122,7 +122,7 @@ class sock(tube):
             >>> r.connected()
             True
             >>> l.close()
-            >>> time.sleep(1) # Avoid race condition
+            >>> time.sleep(0.1) # Avoid race condition
             >>> r.connected()
             False
         """
@@ -208,8 +208,8 @@ class sock(tube):
         if False not in self.closed.values():
             self.close()
 
-    def _get_family(self, fam):
-
+    @classmethod
+    def _get_family(cls, fam):
         if isinstance(fam, six.integer_types):
             pass
         elif fam == 'any':
@@ -220,13 +220,13 @@ class sock(tube):
             fam = socket.AF_INET6
         else:
             self.error("%s(): socket family %r is not supported",
-                       self.__class__.__name__,
+                       cls.__name__,
                        fam)
 
         return fam
 
-    def _get_type(self, typ):
-
+    @classmethod
+    def _get_type(cls, typ):
         if isinstance(typ, six.integer_types):
             pass
         elif typ == "tcp":
@@ -235,7 +235,7 @@ class sock(tube):
             typ = socket.SOCK_DGRAM
         else:
             self.error("%s(): socket type %r is not supported",
-                       self.__class__.__name__,
+                       cls.__name__,
                        typ)
 
         return typ

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -14,6 +14,35 @@ log = getLogger(__name__)
 
 all_pids = psutil.pids
 
+def sock_match(local, remote, fam=socket.AF_UNSPEC, typ=0):
+    def sockinfos(addr, f, t):
+        if not addr:
+            return set()
+        if f not in (socket.AF_UNSPEC, socket.AF_INET, socket.AF_INET6):
+            return {addr}
+        infos = set(socket.getaddrinfo(addr[0], addr[1], f, t))
+
+        # handle mixed IPv4-to-IPv6 and the other way round connections
+        for f, t, proto, _canonname, sockaddr in tuple(infos):
+            if f == socket.AF_INET and t != socket.SOCK_RAW:
+                infos |= set(socket.getaddrinfo(sockaddr[0], sockaddr[1], socket.AF_INET6, t, proto, socket.AI_V4MAPPED))
+        return infos
+
+    if local is not None:
+        local = sockinfos(local, fam, typ)
+    remote = sockinfos(remote, fam, typ)
+
+    def match(c):
+        laddrs = sockinfos(c.laddr, c.family, c.type)
+        raddrs = sockinfos(c.raddr, c.family, c.type)
+        if not (raddrs & remote):
+            return False
+        if local is None:
+            return True
+        return bool(laddrs & local)
+
+    return match
+
 def pidof(target):
     """pidof(target) -> int list
 
@@ -41,29 +70,20 @@ def pidof(target):
         return [target.pid]
 
     elif isinstance(target, tubes.sock.sock):
-         local  = target.sock.getsockname()
-         remote = target.sock.getpeername()
-
-         def match(c):
-             return (c.raddr, c.laddr, c.status) == (local, remote, 'ESTABLISHED')
-
-         return [c.pid for c in psutil.net_connections() if match(c)]
+        local  = target.sock.getsockname()
+        remote = target.sock.getpeername()
+        match = sock_match(remote, local, target.family, target.type)
+        return [c.pid for c in psutil.net_connections() if match(c)]
 
     elif isinstance(target, tuple):
-        host, port = target
-
-        host = socket.gethostbyname(host)
-
-        def match(c):
-            return c.raddr == (host, port)
-
+        match = sock_match(None, target)
         return [c.pid for c in psutil.net_connections() if match(c)]
 
     elif isinstance(target, tubes.process.process):
-         return [target.proc.pid]
+        return [target.proc.pid]
 
     else:
-         return pid_by_name(target)
+        return pid_by_name(target)
 
 def pid_by_name(name):
     """pid_by_name(name) -> int list

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -9,39 +9,11 @@ import psutil
 
 from pwnlib import tubes
 from pwnlib.log import getLogger
+from .net import sock_match
 
 log = getLogger(__name__)
 
 all_pids = psutil.pids
-
-def sock_match(local, remote, fam=socket.AF_UNSPEC, typ=0):
-    def sockinfos(addr, f, t):
-        if not addr:
-            return set()
-        if f not in (socket.AF_UNSPEC, socket.AF_INET, socket.AF_INET6):
-            return {addr}
-        infos = set(socket.getaddrinfo(addr[0], addr[1], f, t))
-
-        # handle mixed IPv4-to-IPv6 and the other way round connections
-        for f, t, proto, _canonname, sockaddr in tuple(infos):
-            if f == socket.AF_INET and t != socket.SOCK_RAW:
-                infos |= set(socket.getaddrinfo(sockaddr[0], sockaddr[1], socket.AF_INET6, t, proto, socket.AI_V4MAPPED))
-        return infos
-
-    if local is not None:
-        local = sockinfos(local, fam, typ)
-    remote = sockinfos(remote, fam, typ)
-
-    def match(c):
-        laddrs = sockinfos(c.laddr, c.family, c.type)
-        raddrs = sockinfos(c.raddr, c.family, c.type)
-        if not (raddrs & remote):
-            return False
-        if local is None:
-            return True
-        return bool(laddrs & local)
-
-    return match
 
 def pidof(target):
     """pidof(target) -> int list


### PR DESCRIPTION
Also a minor cleanup in sock.py.
Tested on Linux and FreeBSD.
Closes #1552
