### PR TITLE
Enhance py2 32-bit archs support

### DIFF
--- a/pwnlib/adb/bootloader.py
+++ b/pwnlib/adb/bootloader.py
@@ -64,7 +64,7 @@ class BootloaderImage(object):
         Returns:
             Contents of the image.
         """
-        if isinstance(index_or_name, int):
+        if isinstance(index_or_name, six.integer_types):
             index = index_or_name
         else:
             for i in range(len(self.img_info)):

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -399,7 +399,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, **kw
     >>> io.interactive() # doctest: +SKIP
     >>> io.close()
     """
-    if isinstance(args, (int, tubes.process.process, tubes.ssh.ssh_channel)):
+    if isinstance(args, six.integer_types + (tubes.process.process, tubes.ssh.ssh_channel)):
         log.error("Use gdb.attach() to debug a running process")
 
     if isinstance(args, (bytes, six.text_type)):

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -283,7 +283,7 @@ class Logger(object):
         self._logger = logger
 
     def _getlevel(self, levelString):
-        if isinstance(levelString, int):
+        if isinstance(levelString, six.integer_types):
             return levelString
         return logging._levelNames[levelString.upper()]
 

--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -155,17 +155,17 @@ class MemLeak(object):
         Arguments:
             address(int): Base address to calculate offsets from
             field(obj):   Instance of a ctypes field
-            expected(int,str): Expected value
+            expected(int,bytes): Expected value
 
         Return Value:
             The type of the return value will be dictated by
             the type of ``field``.
         """
-        if not isinstance(expected, (int, bytes)):
-            raise TypeError("Expected value must be an int or bytes")
 
-        if isinstance(expected, int):
+        if isinstance(expected, six.integer_types):
             expected = pack(expected, bytes=obj.size)
+        elif not isinstance(expected, bytes):
+            raise TypeError("Expected value must be an int or bytes")
 
         assert obj.size == len(expected)
 

--- a/pwnlib/rop/gadgets.py
+++ b/pwnlib/rop/gadgets.py
@@ -54,12 +54,12 @@ class Gadget(object):
 
     def __getitem__(self, key):
         # Backward compatibility
-        if isinstance(key, int):
+        if isinstance(key, six.integer_types):
             key = self.__indices[key]
         return getattr(self, key)
 
     def __setitem__(self, key, value):
         # Backward compatibility
-        if isinstance(key, int):
+        if isinstance(key, six.integer_types):
             key = self.__indices[key]
         return setattr(self, key, value)

--- a/pwnlib/rop/ret2dlresolve.py
+++ b/pwnlib/rop/ret2dlresolve.py
@@ -65,6 +65,7 @@ You can also use ``Ret2dlresolve`` on AMD64:
     True
 """
 
+import six
 from copy import deepcopy
 
 from pwnlib.context import context
@@ -356,7 +357,7 @@ class Ret2dlresolvePayload(object):
             elif isinstance(top, bytes):
                 top = pack(self.data_addr + len(self.payload) + queue.size())
                 queue.append(MarkedBytes(queue[0]))
-            elif isinstance(top, int):
+            elif isinstance(top, six.integer_types):
                 top = pack(top)
 
             self.payload += top

--- a/pwnlib/shellcraft/__init__.py
+++ b/pwnlib/shellcraft/__init__.py
@@ -155,7 +155,7 @@ class module(ModuleType):
             return hex(n)
 
     def okay(self, s, *a, **kw):
-        if isinstance(s, int):
+        if isinstance(s, six.integer_types):
             s = packing.pack(s, *a, **kw)
         return b'\0' not in s and b'\n' not in s
 

--- a/pwnlib/shellcraft/templates/aarch64/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/stage.asm
@@ -1,4 +1,5 @@
 <%
+import six
 from pwnlib.shellcraft.aarch64 import mov
 from pwnlib.shellcraft.aarch64.linux import read, readn, mmap
 from pwnlib import constants as C
@@ -28,7 +29,7 @@ Example:
     protection = C.PROT_READ | C.PROT_WRITE | C.PROT_EXEC
     flags      = C.MAP_ANONYMOUS | C.MAP_PRIVATE
 
-    assert isinstance(fd, int)
+    assert isinstance(fd, six.integer_types)
 %>
 %if length is None:
     /* How many bytes should we receive? */

--- a/pwnlib/shellcraft/templates/aarch64/xor.asm
+++ b/pwnlib/shellcraft/templates/aarch64/xor.asm
@@ -1,4 +1,5 @@
 <%
+  import six
   from pwnlib.shellcraft import pretty, common, aarch64, registers
   from pwnlib.shellcraft.registers import aarch64 as regs
   from pwnlib.util.packing import pack, unpack
@@ -39,7 +40,7 @@ if not key in regs:
     key_str = key
     key_int = key
 
-    if isinstance(key, int):
+    if isinstance(key, six.integer_types):
         key_str = pack(key, bytes=4)
     else:
         key_int = unpack(key, 'all')

--- a/pwnlib/shellcraft/templates/amd64/linux/egghunter.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/egghunter.asm
@@ -1,4 +1,5 @@
 <%
+import six
 from pwnlib.shellcraft import amd64, pretty, common
 from pwnlib.util.packing import pack, unpack
 from pwnlib.util.lists import group
@@ -24,7 +25,7 @@ done           = common.label('egghunter_done')
 next_page      = common.label('egghunter_nextpage')
 
 egg_str = egg
-if isinstance(egg, int):
+if isinstance(egg, six.integer_types):
     egg_str = pack(egg, bytes=4)
 
 if len(egg_str) % 4:

--- a/pwnlib/shellcraft/templates/amd64/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/stage.asm
@@ -1,4 +1,5 @@
 <%
+import six
 from pwnlib.shellcraft.amd64 import push
 from pwnlib.shellcraft.amd64.linux import read, readn, mmap
 from pwnlib import constants as C
@@ -28,7 +29,7 @@ Example:
     protection = C.PROT_READ | C.PROT_WRITE | C.PROT_EXEC
     flags      = C.MAP_ANONYMOUS | C.MAP_PRIVATE
 
-    assert isinstance(fd, int)
+    assert isinstance(fd, six.integer_types)
 %>
 %if length is None:
     /* How many bytes should we receive? */

--- a/pwnlib/shellcraft/templates/amd64/setregs.asm
+++ b/pwnlib/shellcraft/templates/amd64/setregs.asm
@@ -1,4 +1,5 @@
 <%
+  import six
   from pwnlib.regsort import regsort
   from pwnlib.shellcraft import registers, eval
   from pwnlib.shellcraft.amd64 import mov
@@ -50,7 +51,7 @@ if isinstance(edx, str):
     except NameError:
         pass
 
-if isinstance(eax, int) and isinstance(edx, int) and eax >> 63 == edx:
+if isinstance(eax, six.integer_types) and isinstance(edx, six.integer_types) and eax >> 63 == edx:
     cdq = True
     reg_context.pop('rdx')
 

--- a/pwnlib/shellcraft/templates/amd64/xor.asm
+++ b/pwnlib/shellcraft/templates/amd64/xor.asm
@@ -1,4 +1,5 @@
 <%
+  import six
   from pwnlib.shellcraft import pretty, common, amd64, registers
   from pwnlib.util.packing import pack, unpack
   from pwnlib.context import context as ctx
@@ -45,7 +46,7 @@ else:
     key_str = key
     key_int = key
 
-    if isinstance(key, int):
+    if isinstance(key, six.integer_types):
         key_str = pack(key, bytes=4)
     else:
         key_int = unpack(key, 'all')

--- a/pwnlib/shellcraft/templates/arm/xor.asm
+++ b/pwnlib/shellcraft/templates/arm/xor.asm
@@ -1,4 +1,5 @@
 <%
+  import six
   from pwnlib.shellcraft import pretty, common, arm, registers
   from pwnlib.shellcraft.registers import arm as regs
   from pwnlib.util.packing import pack, unpack
@@ -39,7 +40,7 @@ if not key in regs:
     key_str = key
     key_int = key
 
-    if isinstance(key, int):
+    if isinstance(key, six.integer_types):
         key_str = pack(key, bytes=4)
     else:
         key_int = unpack(key, 'all')

--- a/pwnlib/shellcraft/templates/i386/linux/egghunter.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/egghunter.asm
@@ -1,4 +1,5 @@
 <%
+import six
 from pwnlib.shellcraft import i386, pretty, common
 from pwnlib.util.packing import pack, unpack
 from pwnlib.util.lists import group
@@ -24,7 +25,7 @@ done           = common.label('egghunter_done')
 next_page      = common.label('egghunter_nextpage')
 
 egg_str = egg
-if isinstance(egg, int):
+if isinstance(egg, six.integer_types):
     egg_str = pack(egg)
 
 if len(egg_str) % 4:

--- a/pwnlib/shellcraft/templates/i386/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/stage.asm
@@ -1,4 +1,5 @@
 <%
+import six
 from pwnlib.shellcraft.i386 import push
 from pwnlib.shellcraft.i386.linux import read, readn, mmap
 from pwnlib import constants as C
@@ -29,7 +30,7 @@ Example:
     protection = C.PROT_READ | C.PROT_WRITE | C.PROT_EXEC
     flags      = C.MAP_ANONYMOUS | C.MAP_PRIVATE
 
-    assert isinstance(fd, int)
+    assert isinstance(fd, six.integer_types)
 %>
 %if length is None:
     /* How many bytes should we receive? */

--- a/pwnlib/shellcraft/templates/i386/setregs.asm
+++ b/pwnlib/shellcraft/templates/i386/setregs.asm
@@ -1,4 +1,5 @@
 <%
+  import six
   from pwnlib.regsort import regsort
   from pwnlib.constants import Constant, eval
   from pwnlib.shellcraft import registers
@@ -44,7 +45,7 @@ if isinstance(edx, str):
     except NameError:
         pass
 
-if isinstance(eax, int) and isinstance(edx, int) and eax >> 31 == edx:
+if isinstance(eax, six.integer_types) and isinstance(edx, six.integer_types) and eax >> 31 == edx:
     cdq = True
     reg_context.pop('edx')
 

--- a/pwnlib/shellcraft/templates/i386/xor.asm
+++ b/pwnlib/shellcraft/templates/i386/xor.asm
@@ -1,4 +1,5 @@
 <%
+  import six
   from pwnlib.shellcraft import pretty, common, i386, registers
   from pwnlib.util.packing import pack, unpack
   from pwnlib.context import context as ctx
@@ -44,7 +45,7 @@ else:
     key_str = key
     key_int = key
 
-    if isinstance(key, int):
+    if isinstance(key, six.integer_types):
         key_str = pack(key, bytes=4)
     else:
         key_int = unpack(key, 'all')

--- a/pwnlib/shellcraft/templates/thumb/linux/stage.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/stage.asm
@@ -1,4 +1,5 @@
 <%
+import six
 from pwnlib.shellcraft.thumb import push
 from pwnlib.shellcraft.thumb.linux import read, readn, mmap
 from pwnlib import constants as C
@@ -28,7 +29,7 @@ Example:
     protection = C.PROT_READ | C.PROT_WRITE | C.PROT_EXEC
     flags      = C.MAP_ANONYMOUS | C.MAP_PRIVATE
 
-    assert isinstance(fd, int)
+    assert isinstance(fd, six.integer_types)
 %>
 %if length is None:
     /* How many bytes should we receive? */

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -919,6 +919,10 @@ class ssh(Timeout, Logger):
 #!/usr/bin/env python
 import os, sys, ctypes, resource, platform, stat
 from collections import OrderedDict
+try:
+    integer_types = int, long
+except NameError:
+    integer_types = int,
 exe   = %(executable)r
 argv  = [bytes(a) for a in %(argv)r]
 env   = %(env)r
@@ -993,7 +997,7 @@ for fd, newfd in {0: %(stdin)r, 1: %(stdout)r, 2:%(stderr)r}.items():
         newfd = os.open(newfd, os.O_RDONLY if fd == 0 else (os.O_RDWR|os.O_CREAT))
         os.dup2(newfd, fd)
         os.close(newfd)
-    elif isinstance(newfd, int) and newfd != fd:
+    elif isinstance(newfd, integer_types) and newfd != fd:
         os.dup2(fd, newfd)
 
 if not %(aslr)r:


### PR DESCRIPTION
This was a quick `grep -r isinstance | grep '\<int\>'`.

It can help overcome issues with 32-bit python 2 (which is not officially supported, but why not help people who for some reason use it, namely Jython is officially only python 2, and only 32-bit).