### PR TITLE
Add jmp_esp/jmp_rsp attribute to ROP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The table below shows which release corresponds to each branch, and what date th
 
 To be released on Jun 30, 2020.
 
+- [#1584][1584] Add `jmp_esp`/`jmp_rsp` attribute to `ROP`
+
+[1584]: https://github.com/Gallopsled/pwntools/pull/1584
+
 ## 4.2.0 (`beta`)
 
 To be released on Jun 5, 2020.

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -96,6 +96,9 @@ ROP also detects 'jmp $sp' gadget to help exploit binaries with NX disabled.
     >>> jmp_gadget = rop.jmp_esp
     >>> elf.read(jmp_gadget.address, 2) == asm('jmp esp')
     True
+    >>> rop = ROP(elf, badchars=b'\x02\x06')
+    >>> rop.jmp_esp == None
+    True
 
 ROP Example
 -------------------

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -88,6 +88,14 @@ You can also append complex arguments onto stack when the stack pointer is known
     0x7fffe038:       b'-c\x00$'
     0x7fffe03c:       b'ls\x00$'
 
+ROP also detects 'jmp $sp' gadget to help exploit binaries with NX disabled.
+
+    >>> context.clear(arch='amd64')
+    >>> elf = ELF.from_assembly('nop; mov rax, 0x10; jmp rsp; ret')
+    >>> rop = ROP(elf)
+    >>> jmp_gadget = rop.jmp_rsp
+    >>> elf.read(jmp_gadget.address,2) == asm('jmp rsp')
+    True
 
 ROP Example
 -------------------

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -89,15 +89,34 @@ You can also append complex arguments onto stack when the stack pointer is known
     0x7fffe03c:       b'ls\x00$'
 
 ROP also detects 'jmp $sp' gadget to help exploit binaries with NX disabled.
+You can get this gadget on 'i386':
+
+    >>> context.clear(arch='i386')
+    >>> elf = ELF.from_assembly('nop; jmp esp; ret')
+    >>> rop = ROP(elf)
+    >>> jmp_gadget = rop.jmp_esp
+    >>> elf.read(jmp_gadget.address, 2) == asm('jmp esp')
+    True
+
+You can also get this gadget on 'amd64':
+
+    >>> context.clear(arch='amd64')
+    >>> elf = ELF.from_assembly('nop; jmp rsp; ret')
+    >>> rop = ROP(elf)
+    >>> jmp_gadget = rop.jmp_rsp
+    >>> elf.read(jmp_gadget.address, 2) == asm('jmp rsp')
+    True
+
+Gadgets whose address has badchar are filtered out:
 
     >>> context.clear(arch='i386')
     >>> elf = ELF.from_assembly('nop; pop eax; jmp esp; int 0x80; jmp esp; ret')
     >>> rop = ROP(elf, badchars=b'\x02')
-    >>> jmp_gadget = rop.jmp_esp
+    >>> jmp_gadget = rop.jmp_esp    # It returns the second gadget
     >>> elf.read(jmp_gadget.address, 2) == asm('jmp esp')
     True
     >>> rop = ROP(elf, badchars=b'\x02\x06')
-    >>> rop.jmp_esp == None
+    >>> rop.jmp_esp == None         # The address of both gadgets has badchar
     True
 
 ROP Example

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -90,11 +90,11 @@ You can also append complex arguments onto stack when the stack pointer is known
 
 ROP also detects 'jmp $sp' gadget to help exploit binaries with NX disabled.
 
-    >>> context.clear(arch='amd64')
-    >>> elf = ELF.from_assembly('nop; mov rax, 0x10; jmp rsp; ret')
-    >>> rop = ROP(elf)
-    >>> jmp_gadget = rop.jmp_rsp
-    >>> elf.read(jmp_gadget.address,2) == asm('jmp rsp')
+    >>> context.clear(arch='i386')
+    >>> elf = ELF.from_assembly('nop; pop eax; jmp esp; int 0x80; jmp esp; ret')
+    >>> rop = ROP(elf, badchars=b'\x02')
+    >>> jmp_gadget = rop.jmp_esp
+    >>> elf.read(jmp_gadget.address, 2) == asm('jmp esp')
     True
 
 ROP Example


### PR DESCRIPTION
Fixes #1528 

I've used `setattr` to set a different attribute name based on the architecture context.
Is there any better way to do this?

I've thought about using `jmp_sp` instead of `jmp_esp`/`jmp_rsp`, but I've decided to solve as the issue title suggests.