### PR TITLE
[ui] Colorize output of "pwn template" if it is a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,11 @@ To be released on Jun 30, 2020.
 
 - [#1576][1576] Add `executable=` argument to `ELF.search`
 - [#1584][1584] Add `jmp_esp`/`jmp_rsp` attribute to `ROP`
+- [#1593][1593] Colorize output of `pwn template`
 
 [1576]: https://github.com/Gallopsled/pwntools/pull/1576
 [1584]: https://github.com/Gallopsled/pwntools/pull/1584
+[1593]: https://github.com/Gallopsled/pwntools/pull/1593
 
 ## 4.2.0 (`beta`)
 

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -21,6 +21,7 @@ parser.add_argument('--user', help='SSH Username')
 parser.add_argument('--pass', help='SSH Password', dest='password')
 parser.add_argument('--path', help='Remote path of file on SSH server')
 parser.add_argument('--quiet', help='Less verbose template comments', action='store_true')
+parser.add_argument('--color', help='Print the output in color', choices=['never', 'always', 'auto'], default='auto')
 
 def main(args):
     cache = None
@@ -57,8 +58,16 @@ def main(args):
     # Fix Mako formatting bs
     output = re.sub('\n\n\n', '\n\n', output)
 
+    # Colorize the output if it's a TTY
+    if args.color == 'always' or (args.color == 'auto' and sys.stdout.isatty()):
+        from pygments import highlight
+        from pygments.formatters import TerminalFormatter
+        from pygments.lexers.python import PythonLexer
+        output = highlight(output, PythonLexer(), TerminalFormatter())
+
     print(output)
 
+    # If redirected to a file, make the resulting script executable
     if not sys.stdout.isatty():
         try: os.fchmod(sys.stdout.fileno(), 0o700)
         except OSError: pass


### PR DESCRIPTION
This uses `pygments` to colorize the exploit script if it's generated directly to a TTY.
<img width="712" alt="Screen Shot 2020-06-22 at 8 06 16 PM" src="https://user-images.githubusercontent.com/66139157/85349333-d72e9c80-b4c3-11ea-8ed9-a975b567c4c9.png">

