### PR TITLE
Re-enable Corefile testing on Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,15 @@ jobs:
           libc6-dbg \
           $ANDROID_JRE
 
-    - name: Install android avd
+    - name: Testing Corefiles
+      run: |
+        ulimit -a
+        ulimit -c unlimited
+        cat /proc/sys/kernel/core_pattern
+        cat /proc/sys/kernel/core_uses_pid
+        ( cd $(mktemp -d); sh -c 'kill -11 $$' || true; ls -la ./*core* /var/crash/*.crash;) || true
+
+    - name: Install Android AVD
       if:  steps.java-needed.outputs.need
       run: |
         USER=travis source travis/install.sh
@@ -100,10 +108,6 @@ jobs:
 
     - name: Install documentation dependencies
       run:  pip install -r docs/requirements.txt
-
-    - name: Disable broken tests
-      run: |
-        rm -f docs/source/elf/corefile.rst
 
     - name: Manually install non-broken Unicorn
       run:  pip install unicorn==1.0.2rc3

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -431,7 +431,7 @@ class Corefile(ELF):
 
         Corefiles can also be pulled from remote machines via SSH!
 
-        >>> s = ssh(host='example.pwnme')
+        >>> s = ssh(user='travis', host='example.pwnme', password='demopass')
         >>> _ = s.set_working_directory()
         >>> elf = ELF.from_assembly(shellcraft.trap())
         >>> path = s.upload(elf.path)

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -981,7 +981,7 @@ def corefile(process):
     # This is effectively the same as what the 'gcore' binary does
     gdb_args = ['-batch',
                 '-q',
-                '--nx',
+                '-nx',
                 '-ex', '"set pagination off"',
                 '-ex', '"set height 0"',
                 '-ex', '"set width 0"',
@@ -992,7 +992,14 @@ def corefile(process):
     with context.local(terminal = ['sh', '-c']):
         with context.quiet:
             pid = attach(process, gdb_args=gdb_args)
-            os.waitpid(pid, 0)
+            log.debug("Got GDB pid %d", pid)
+            try:
+                os.waitpid(pid, 0)
+            except Exception:
+                pass
+
+    if not os.path.exists(corefile_path):
+        log.error("Could not generate a corefile for process %d", process.pid)
 
     return elf.corefile.Core(corefile_path)
 


### PR DESCRIPTION
It looks like Core files can successfully be generated, so the Corefile tests should work appropriately.