### PR TITLE
Add to `fiddling.hexdump` a way to suppress the total at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,14 @@ To be released on Jun 30, 2020.
 - [#1592][1592] Fix over-verbose logging of process() environment
 - [#1593][1593] Colorize output of `pwn template`
 - [#1601][1601] Add `pwn version` command line tool
+- [#1605][1605] Add to `fiddling.hexdump` a way to suppress the total at the end
 
 [1576]: https://github.com/Gallopsled/pwntools/pull/1576
 [1584]: https://github.com/Gallopsled/pwntools/pull/1584
 [1592]: https://github.com/Gallopsled/pwntools/pull/1592
 [1593]: https://github.com/Gallopsled/pwntools/pull/1593
 [1601]: https://github.com/Gallopsled/pwntools/pull/1601
+[1605]: https://github.com/Gallopsled/pwntools/pull/1605
 
 ## 4.2.0 (`beta`)
 

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -933,6 +933,13 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0, style=None,
         00000000  41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41  │AAAAAAAAAAAAAAAA│
         00000010  41 41 41 41 41 41 41 41                          │AAAAAAAA│
         00000018
+
+        >>> print(hexdump('A'*24, width=16, total=False))
+        00000000  41 41 41 41  41 41 41 41  41 41 41 41  41 41 41 41  │AAAA│AAAA│AAAA│AAAA│
+        00000010  41 41 41 41  41 41 41 41                            │AAAA│AAAA│
+        >>> print(hexdump('A'*24, width=16, groupsize=8, total=False))
+        00000000  41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41  │AAAAAAAA│AAAAAAAA│
+        00000010  41 41 41 41 41 41 41 41                           │AAAAAAAA│
     """
     s = packing.flat(s)
     return '\n'.join(hexdump_iter(BytesIO(s),

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -592,9 +592,9 @@ def update_cyclic_pregenerated(size):
         cyclic_pregen += packing._p8lu(next(de_bruijn_gen))
 
 def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
-                 highlight=None, cyclic=False, groupsize=4):
-    r"""hexdump_iter(s, width = 16, skip = True, hexii = False, begin = 0,
-                    style = None, highlight = None, cyclic = False, groupsize=4) -> str generator
+                 highlight=None, cyclic=False, groupsize=4, total=True):
+    r"""hexdump_iter(s, width = 16, skip = True, hexii = False, begin = 0, style = None,
+                    highlight = None, cyclic = False, groupsize=4, total = True) -> str generator
 
     Return a hexdump-dump of a string as a generator of lines.  Unless you have
     massive amounts of data you probably want to use :meth:`hexdump`.
@@ -609,6 +609,7 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
         style(dict): Color scheme to use.
         highlight(iterable): Byte values to highlight.
         cyclic(bool): Attempt to skip consecutive, unmodified cyclic lines
+        total(bool): Set to True, if total bytes should be printed
 
     Returns:
         A generator producing the hexdump-dump one line at a time.
@@ -750,13 +751,14 @@ def hexdump_iter(fd, width=16, skip=True, hexii=False, begin=0, style=None,
         line = line_fmt % {'offset': offset, 'hexbytes': hexbytes, 'printable': printable}
         yield line
 
-    line = "%08x" % (begin + numb)
-    yield line
+    if total:
+        line = "%08x" % (begin + numb)
+        yield line
 
-def hexdump(s, width=16, skip=True, hexii=False, begin=0,
-            style=None, highlight=None, cyclic=False, groupsize=4):
-    r"""hexdump(s, width = 16, skip = True, hexii = False, begin = 0,
-               style = None, highlight = None, cyclic = False, groupsize=4) -> str generator
+def hexdump(s, width=16, skip=True, hexii=False, begin=0, style=None,
+            highlight=None, cyclic=False, groupsize=4, total=True):
+    r"""hexdump(s, width = 16, skip = True, hexii = False, begin = 0, style = None,
+                highlight = None, cyclic = False, groupsize=4, total = True) -> str
 
     Return a hexdump-dump of a string.
 
@@ -770,6 +772,7 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0,
         style(dict): Color scheme to use.
         highlight(iterable): Byte values to highlight.
         cyclic(bool): Attempt to skip consecutive, unmodified cyclic lines
+        total(bool): Set to True, if total bytes should be printed
 
     Returns:
         A hexdump-dump in the form of a string.
@@ -940,7 +943,8 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0,
                                   style,
                                   highlight,
                                   cyclic,
-                                  groupsize))
+                                  groupsize,
+                                  total))
 
 def negate(value, width = None):
     """


### PR DESCRIPTION
Fixes #1506 as suggested by @zachriggle 