### PR TITLE
Add a bfdname for msp430 to make asm and disasm work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
           binutils-aarch64-linux-gnu \
           binutils-arm-linux-gnueabihf \
           binutils-mips-linux-gnu \
+          binutils-msp430 \
           binutils-powerpc-linux-gnu \
+          binutils-s390x-linux-gnu \
           binutils-sparc64-linux-gnu \
           gcc-multilib \
           libc6-dbg \

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ addons:
     - binutils-aarch64-linux-gnu
     - binutils-arm-linux-gnueabihf
     - binutils-mips-linux-gnu
+    - binutils-msp430
     - binutils-powerpc-linux-gnu
+    - binutils-s390x-linux-gnu
     - binutils-sparc64-linux-gnu
     - bash-static
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.4.0 (`dev`)
 
+- [#1606][1606] Fix `asm()` and `disasm()` for MSP430, S390
+
+[1606]: https://github.com/Gallopsled/pwntools/pull/1606
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -648,6 +648,10 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
         b'H\xc7\xc0\x17\x00\x00\x00'
         >>> asm("mov r0, #SYS_select", arch = 'arm', os = 'linux', bits=32)
         b'R\x00\xa0\xe3'
+        >>> asm("mov #42, r0", arch = 'msp430')
+        b'0@*\x00'
+        >>> asm("la %r0, 42", arch = 's390', bits=64)
+        b'A\x00\x00*'
     """
     result = ''
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -334,6 +334,7 @@ def _bfdname():
         'cris'    : 'elf32-cris',
         'ia64'    : 'elf64-ia64-%s' % E,
         'm68k'    : 'elf32-m68k',
+        'msp430'  : 'elf32-msp430',
         'powerpc' : 'elf32-powerpc',
         'powerpc64' : 'elf64-powerpc',
         'vax'     : 'elf32-vax',

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -338,6 +338,7 @@ def _bfdname():
         'powerpc' : 'elf32-powerpc',
         'powerpc64' : 'elf64-powerpc',
         'vax'     : 'elf32-vax',
+        's390'    : 'elf%d-s390' % context.bits,
         'sparc'   : 'elf32-sparc',
         'sparc64' : 'elf64-sparc',
     }


### PR DESCRIPTION
Not sure whether you consider this a bugfix, or new functionality...

Currently, out of the architectures that pwntools supports, `msp430` and `s390` error out with a missing bfd name. This PR resolves it for the former, but I couldn't determine what bfdname should be used for the latter - I have found two options: `elf32-s390` and `elf64-s390`.

This is confusing, as all the other architectures use a separate name for their 64-bit variant. It seems that the 64-bit s390 is called the s390x, does this mean that pwntools only supports the 32-bit variant?