### PR TITLE
fix an obsolete error catch style

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -752,7 +752,7 @@ class process(tube):
             # ValueError: I/O operation on closed file
             raise EOFError
         except select.error as v:
-            if v[0] == errno.EINTR:
+            if v.errno == errno.EINTR:
                 return False
 
     def connected_raw(self, direction):


### PR DESCRIPTION
current error handling style is wrong in this snippet. Just a little fix.
Error message:
~~~
Traceback (most recent call last):
  File "/home/user/src/pwntools/pwnlib/tubes/process.py", line 742, in can_recv_raw
    return select.select([self.proc.stdout], [], [], timeout) == ([self.proc.stdout], [], [])
OSError: [Errno 9] Bad file descriptor

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/...", line 64, in update
    output = self.kernel.recv(timeout=self.timeout)
  File "/home/user/src/pwntools/pwnlib/tubes/tube.py", line 82, in recv
    return self._recv(numb, timeout) or b''
  File "/home/user/src/pwntools/pwnlib/tubes/tube.py", line 160, in _recv
    if not self.buffer and not self._fillbuffer(timeout):
  File "/home/user/src/pwntools/pwnlib/tubes/tube.py", line 131, in _fillbuffer
    data = self.recv_raw(self.buffer.get_fill_size())
  File "/home/user/src/pwntools/pwnlib/tubes/process.py", line 698, in recv_raw
    if not self.can_recv_raw(self.timeout):
  File "/home/user/src/pwntools/pwnlib/tubes/process.py", line 752, in can_recv_raw
    if v[0] == errno.EINTR:
TypeError: 'OSError' object is not subscriptable
~~~