### PR TITLE
Enhance gdb error message when unable to launch binary

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -263,7 +263,10 @@ def _gdbserver_port(gdbserver, ssh):
             'Failed to spawn process under gdbserver. gdbserver error message: %s' % process_created
         )
 
-    gdbserver.pid   = int(process_created.split()[-1], 0)
+    try:
+        gdbserver.pid   = int(process_created.split()[-1], 0)
+    except ValueError:
+        log.error('gdbserver did not output its pid (maybe chmod +x?): %s', process_created.decode())
 
     listening_on = b''
     while b'Listening' not in listening_on:

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -266,7 +266,7 @@ def _gdbserver_port(gdbserver, ssh):
     try:
         gdbserver.pid   = int(process_created.split()[-1], 0)
     except ValueError:
-        log.error('gdbserver did not output its pid (maybe chmod +x?): %s', process_created.decode())
+        log.error('gdbserver did not output its pid (maybe chmod +x?): %s', six.ensure_str(process_created))
 
     listening_on = b''
     while b'Listening' not in listening_on:


### PR DESCRIPTION
A common issue is when the binary is not executable,
or the binary is simply missing.