### PR TITLE
Fix cyclic cli for 64 bit integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.4.0 (`dev`)
 
+- [#1616][1616] Fix `cyclic` cli for 64 bit integers
+
+[1616]: https://github.com/Gallopsled/pwntools/pull/1616
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -70,7 +70,7 @@ def main(args):
             pat = int(pat, 0)
         except ValueError:
             pass
-        pat = flat(pat, word_size=8 * args.length)
+        pat = flat(pat, bytes=args.length)
 
         if len(pat) != subsize:
             log.critical('Subpattern must be %d bytes' % subsize)

--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -70,7 +70,7 @@ def main(args):
             pat = int(pat, 0)
         except ValueError:
             pass
-        pat = flat(pat)
+        pat = flat(pat, word_size=8 * args.length)
 
         if len(pat) != subsize:
             log.critical('Subpattern must be %d bytes' % subsize)


### PR DESCRIPTION
Before this change, `pwn cyclic -n 8 -l 0x6161616161616178` outputs:
```
Traceback (most recent call last):
  File "/home/tyilo/.local/bin/pwn", line 8, in <module>
    sys.exit(main())
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/commandline/main.py", line 54, in main
    commands[args.command](args)
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/commandline/cyclic.py", line 73, in main
    pat = flat(pat)
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/context/__init__.py", line 1460, in setter
    return function(*a, **kw)
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/util/packing.py", line 732, in flat
    out = _flat(args, preprocessor, make_packer(), filler)
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/util/packing.py", line 560, in _flat
    val = packer(arg)
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/util/packing.py", line 426, in <lambda>
    return lambda number: pack(number, word_size, endianness, sign)
  File "/home/tyilo/.local/lib/python3.8/site-packages/pwnlib/util/packing.py", line 145, in pack
    raise ValueError("pack(): number does not fit within word_size [%i, %r, %r]" % (0, number, limit))
ValueError: pack(): number does not fit within word_size [0, 7016996765293437304, 4294967296]
```