### PR TITLE
Permit negative indices in fit() and flat()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ To be released on Jun 30, 2020.
 - [#1605][1605] Add to `fiddling.hexdump` a way to suppress the total at the end
 - [#1613][1613] Permit `--password` for `pwn template`
 - [#1564][1564] Fix `asm()` and `disasm()` for PowerPC64, MIPS64, Sparc64
+- [#1621][1621] Permit negative values in flat() and fit()
 
 [1576]: https://github.com/Gallopsled/pwntools/pull/1576
 [1584]: https://github.com/Gallopsled/pwntools/pull/1584
@@ -74,6 +75,7 @@ To be released on Jun 30, 2020.
 [1605]: https://github.com/Gallopsled/pwntools/pull/1605
 [1613]: https://github.com/Gallopsled/pwntools/pull/1613
 [1564]: https://github.com/Gallopsled/pwntools/pull/1564
+[1621]: https://github.com/Gallopsled/pwntools/pull/1621
 
 ## 4.2.0 (`beta`)
 

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -548,20 +548,21 @@ def _fit(pieces, preprocessor, packer, filler):
         out += _flat([v], preprocessor, packer, filler)
 
     # Now do negative indices
-    out_negative = b''
-    most_negative = min(negative.keys())
-    for k, v in sorted(negative.items()):
-        k += -most_negative
+    if negative:
+        out_negative = b''
+        most_negative = min(negative.keys())
+        for k, v in sorted(negative.items()):
+            k += -most_negative
 
-        if k < len(out_negative):
-            raise ValueError("flat(): data at offset %d overlaps with previous data which ends at offset %d" % (k, len(out)))
+            if k < len(out_negative):
+                raise ValueError("flat(): data at offset %d overlaps with previous data which ends at offset %d" % (k, len(out)))
 
-        # Fill up to offset
-        while len(out_negative) < k:
-            out_negative += p8(next(filler))
+            # Fill up to offset
+            while len(out_negative) < k:
+                out_negative += p8(next(filler))
 
-        # Recursively flatten data
-        out_negative += _flat([v], preprocessor, packer, filler)
+            # Recursively flatten data
+            out_negative += _flat([v], preprocessor, packer, filler)
 
     return filler, out_negative + out
 

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -548,8 +548,8 @@ def _fit(pieces, preprocessor, packer, filler):
         out += _flat([v], preprocessor, packer, filler)
 
     # Now do negative indices
+    out_negative = b''
     if negative:
-        out_negative = b''
         most_negative = min(negative.keys())
         for k, v in sorted(negative.items()):
             k += -most_negative


### PR DESCRIPTION
Negative indices can be useful when dealing with offsets and stack addresses from IDA, so we may as well support it.  This now works:

```py
>>> flat({-4: 'x', -1: 'A', 0: '0', 4:'y'})
b'xaaA0aaay'
```
