### PR TITLE
[term] Automatically set PWNLIB_NOTERM when running inside Jupyter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,11 @@ The table below shows which release corresponds to each branch, and what date th
 
 - [#1606][1606] Fix `asm()` and `disasm()` for MSP430, S390
 - [#1616][1616] Fix `cyclic` cli for 64 bit integers
+- [#1632][1632] Enable usage of Pwntools in jupyter
 
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
 [1616]: https://github.com/Gallopsled/pwntools/pull/1616
+[1632]: https://github.com/Gallopsled/pwntools/pull/1632
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/term/__init__.py
+++ b/pwnlib/term/__init__.py
@@ -39,7 +39,7 @@ def can_init():
 
     # Check fancy REPLs
     mods = sys.modules.keys()
-    for repl in ['IPython', 'bpython', 'dreampielib']:
+    for repl in ['IPython', 'bpython', 'dreampielib', 'jupyter_client._version']:
         if repl in mods:
             return False
 

--- a/pwnlib/term/unix_termcap.py
+++ b/pwnlib/term/unix_termcap.py
@@ -45,6 +45,14 @@ def get(cap, *args, **kwargs):
 def init():
     global cache
 
+    # Detect running under Jupyter
+    try:
+        if get_ipython().__class__.__name__ == 'ZMQInteractiveShell':
+            os.environ['PWNLIB_NOTERM'] = '1'
+            os.environ['JUPYTER_DETECTED'] ='yes'
+    except NameError:
+        pass
+
     if 'PWNLIB_NOTERM' not in os.environ:
         # Fix for BPython
         try:


### PR DESCRIPTION
Enable Pwntools to run under Jupyter without exploding due to curses /  terminal stuff.

Tested locally with `jupyter notebook` and `from pwn import *`

<img width="1146" alt="Screen Shot 2020-07-10 at 12 45 58 AM" src="https://user-images.githubusercontent.com/66139157/87120729-c5305600-c246-11ea-8f5c-50be4c0a0f9a.png">


Fixes #826 
Fixes #1339 