### PR TITLE
[template] Drop into a shell if downloading the file fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1602][1602] Fix bytes handling in ssh tubes
 - [#1606][1606] Fix `asm()` and `disasm()` for MSP430, S390
 - [#1616][1616] Fix `cyclic` cli for 64 bit integers
+- [#1633][1633] Open a shell if `pwn template` cannot download the remote file
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
 [1616]: https://github.com/Gallopsled/pwntools/pull/1616
+[1633]: https://github.com/Gallopsled/pwntools/pull/1633
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -41,7 +41,14 @@ def main(args):
             log.error("Must specify --path or a exe")
 
         s = ssh(args.user, args.host, args.port or 22, args.password or None)
-        s.download(args.path or args.exe)
+
+        try:
+            remote = args.path or args.exe
+            s.download(remote)
+        except Exception:
+            log.warning("Could not download file %r, opening a shell", remote)
+            s.interactive()
+            return
 
         if not args.exe:
             args.exe = os.path.basename(args.path)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1430,7 +1430,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         total, exitcode = self.run_to_end(cmd)
 
         if exitcode != 0:
-            h.failure("%r does not exist or is not accessible" % remote)
+            h.error("%r does not exist or is not accessible" % remote)
             return
 
         total = int(total)
@@ -1480,7 +1480,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             self._download_raw(remote, local, p)
 
             if not self._verify_local_fingerprint(fingerprint):
-                p.failure('Could not download file %r' % remote)
+                p.error('Could not download file %r' % remote)
 
         return local
 


### PR DESCRIPTION
This change makes SSH download failures raise an exception, rather than silently failing with waitfor.failure().

If `pwn template` is  unable to download the remote file, a shell is now popped by default.