### PR TITLE
tubes/remote: Support Server Name Indication and enable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1616][1616] Fix `cyclic` cli for 64 bit integers
 - [#1632][1632] Enable usage of Pwntools in jupyter
 - [#1633][1633] Open a shell if `pwn template` cannot download the remote file
+- [#1644][1644] Enable and support SNI for SSL-wrapped tubes
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606


### PR DESCRIPTION
Motivation: Allow tubes to connect to TLS services that do server name based matching.

This allows customizing the server_name via `sni="custom.com"` or sending
the name specified in the host parameter via `sni=True`.

---
Implementation:

This switches to the SSLContext.wrap_socket API because ssl.wrap_socket is
deprecated and does not support SNI.

Unfortunately, SSLContext.wrap_socket dropped some of the parameters
that are supported by ssl.wrap_socket. These parameters have been moved
to the SSLContext API and can now be used by passing a custom SSLContext
to the ssl_context parameter of `remote`.

---

This PR changes the default settings for all `tls=True` tubes and includes backwards-incompatible changes! Feel free to close/reject.