### PR TITLE
Fix detection of WSL2 to open new terminal

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -235,7 +235,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
             is_wsl = False
             if os.path.exists('/proc/sys/kernel/osrelease'):
                 with open('/proc/sys/kernel/osrelease', 'rb') as f:
-                    is_wsl = b'Microsoft' in f.read()
+                    is_wsl = b'icrosoft' in f.read()
             if is_wsl and which('cmd.exe') and which('wsl.exe') and which('bash.exe'):
                 terminal = 'cmd.exe'
                 args     = ['/c', 'start', 'bash.exe', '-c']


### PR DESCRIPTION
The osrelease is e.g., `4.19.104-microsoft-standard` in WSL2. `microsoft` being lowercase. Ignore casing for detection.