### PR TITLE
[shellcraft] Avoid recursive walk of all templates for command line

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -31,4 +31,6 @@ jobs:
         git fetch origin
         git checkout origin/"$GITHUB_BASE_REF"
         pylint --exit-zero --errors-only  pwnlib > base.txt
-        diff base.txt current.txt
+        if diff base.txt current.txt | grep '>'; then
+          false
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,12 +63,14 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1632][1632] Enable usage of Pwntools in jupyter
 - [#1633][1633] Open a shell if `pwn template` cannot download the remote file
 - [#1644][1644] Enable and support SNI for SSL-wrapped tubes
+- [#1651][1651] Make `pwn shellcraft` faster
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
 [1616]: https://github.com/Gallopsled/pwntools/pull/1616
 [1632]: https://github.com/Gallopsled/pwntools/pull/1632
 [1633]: https://github.com/Gallopsled/pwntools/pull/1633
+[1651]: https://github.com/Gallopsled/pwntools/pull/1651
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -199,11 +199,9 @@ def main(args):
         exit()
 
     try:
-        template = get_template(args.shellcode)
+        func = get_template(args.shellcode)
     except AttributeError:
         log.error("Unknown shellcraft template %r. Use --list to see available shellcodes." % args.shellcode)
-
-    func = get_template(args.shellcode)
 
     if args.show:
         # remove doctests

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -198,7 +198,9 @@ def main(args):
         common.parser.print_usage()
         exit()
 
-    if args.shellcode not in shellcraft.templates:
+    try:
+        template = get_template(args.shellcode)
+    except AttributeError:
         log.error("Unknown shellcraft template %r. Use --list to see available shellcodes." % args.shellcode)
 
     func = get_template(args.shellcode)


### PR DESCRIPTION
This mechanism is much faster (up to ~5x)

Before: `pwn shellcraft i386.linux.sh  0.57s user 1.47s system 20% cpu 10.060 total`
After: `pwn shellcraft i386.linux.sh  0.42s user 0.27s system 25% cpu 2.722 total`

This also has the  side-effect of allowing e.g. `shellcraft amd64.open` which mimics the in-Python behavior:

```
$ shellcraft amd64.open '/dev/null' 0 0
6a6c48b82f6465762f6e756c504889e731d231f66a02580f05
```

Fixes #1650