### PR TITLE
Function for ROP class that automatically packs the parameter

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1070,7 +1070,7 @@ class ROP(object):
         """Packs an integer and appends it to the ropchain
         
         Arguments:
-            data(int/str): The value to be packed then put onto the rop chain.
+            data(int): The value to be packed then put onto the rop chain.
         """
 
         self.raw(packing.flat(value))

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -967,8 +967,28 @@ class ROP(object):
             addr = resolvable
             resolvable = ''
 
+        log.info(str(type(arguments)))
+        
+        ####################### Changes
+        args = list(arguments)
+
+        for i, arg in enumerate(args):
+            if isinstance(arg, str):
+                arg += '\x00' if arg[-1] != '\x00'
+
+                log.progress(f'Fetching {arg}'s address')
+
+                arg_addr = next(self.elfs[0].search(arg.encode()))
+                log.success(f'Grabbed {arg} from {hex(arg_addr)}')
+
+                args[i] = arg_addr
+        
+        args = tuple(args)
+        #######################
+
         if addr:
-            self.raw(Call(resolvable, addr, arguments, abi))
+            #self.raw(Call(resolvable, addr, arguments, abi))
+            self.raw(Call(resolvable, addr, args, abi))
 
         # Otherwise, if it is a syscall we might be able to call it
         elif not self._srop_call(resolvable, arguments):

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -967,28 +967,8 @@ class ROP(object):
             addr = resolvable
             resolvable = ''
 
-        log.info(str(type(arguments)))
-        
-        ####################### Changes
-        args = list(arguments)
-
-        for i, arg in enumerate(args):
-            if isinstance(arg, str):
-                arg += '\x00' if arg[-1] != '\x00'
-
-                log.progress(f'Fetching {arg}'s address')
-
-                arg_addr = next(self.elfs[0].search(arg.encode()))
-                log.success(f'Grabbed {arg} from {hex(arg_addr)}')
-
-                args[i] = arg_addr
-        
-        args = tuple(args)
-        #######################
-
         if addr:
-            #self.raw(Call(resolvable, addr, arguments, abi))
-            self.raw(Call(resolvable, addr, args, abi))
+            self.raw(Call(resolvable, addr, arguments, abi))
 
         # Otherwise, if it is a syscall we might be able to call it
         elif not self._srop_call(resolvable, arguments):

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1071,19 +1071,9 @@ class ROP(object):
         
         Arguments:
             data(int/str): The value to be packed then put onto the rop chain.
-
-        elf = context.binary = ELF('./vuln')
-
-        >>> rop = ROP([])
-        >>> rop.raw('AAAAAAAA')
-        >>> rop.raw('BBBBBBBB')
-        >>> rop.raw('CCCCCCCC')
-        >>> print(rop.dump())
         """
 
-        if self.migrated:
-            log.error('Cannot append to a migrated chain')
-        self._chain.append(packing.flat(value))
+        self.raw(packing.flat(value))
 
     def migrate(self, next_base):
         """Explicitly set $sp, by using a ``leave; ret`` gadget"""

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1066,6 +1066,25 @@ class ROP(object):
             log.error('Cannot append to a migrated chain')
         self._chain.append(value)
 
+    def packed(self, value: int):
+        """Packs an integer and appends it to the ropchain
+        
+        Arguments:
+            data(int/str): The value to be packed then put onto the rop chain.
+
+        elf = context.binary = ELF('./vuln')
+
+        >>> rop = ROP([])
+        >>> rop.raw('AAAAAAAA')
+        >>> rop.raw('BBBBBBBB')
+        >>> rop.raw('CCCCCCCC')
+        >>> print(rop.dump())
+        """
+
+        if self.migrated:
+            log.error('Cannot append to a migrated chain')
+        self._chain.append(packing.flat(value))
+
     def migrate(self, next_base):
         """Explicitly set $sp, by using a ``leave; ret`` gadget"""
         if isinstance(next_base, ROP):


### PR DESCRIPTION
It's not exactly a huge change, but when appending canaries or other integers that need to be packed you currently (I believe - please correct me if I'm wrong!) need to do something along the lines of `rop.raw(flat(canary))`.

The PR is insanely basic and simply implements a `packed()` function for the ROP class. This takes in an integer and packs it using `packing.flat()` (which uses context, allowing it to adapt) before passing it as a parameter for `self.raw()` which appends it to the chain.

This just makes scripts slightly more readable.

This is my first PR to a public repo, I hope somebody finds it useful, and of course please give feedback if changes can be made :)