### PR TITLE
Fix SSL timeout error on py2

### DIFF
--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -48,6 +48,8 @@ class sock(tube):
                     raise EOFError
                 elif e.errno == errno.EINTR:
                     continue
+                elif 'timed out' in e.message:
+                    return None
                 else:
                     raise
 


### PR DESCRIPTION
Turns out that python 2 does not raise correct socket.timeout, but
SSLError instead.  With no errno.  Just a message that might be
localized in some circumstances.

**THIS IS NOT THE ONLY TIME PYTHON 2 IS CAUSING PROBLEMS.**
Time to stop using it, dear exploit developers.  It is dead now.
But here you are: the simple fix.

Closes #1356