### PR TITLE
Wrong doc for recvline_endswith()

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -589,13 +589,13 @@ class tube(Timeout, Logger):
     def recvline_endswith(self, delims, keepends=False, timeout=default):
         r"""recvline_endswith(delims, keepends=False, timeout=default) -> bytes
 
-        Keep receiving lines until one is found that starts with one of
+        Keep receiving lines until one is found that ends with one of
         `delims`.  Returns the last line received.
 
         If the request is not satisfied before ``timeout`` seconds pass,
         all data is buffered and an empty string (``''``) is returned.
 
-        See :meth:`recvline_startswith` for more details.
+        See :meth:`recvline_endswith` for more details.
 
         Examples:
 

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -595,7 +595,7 @@ class tube(Timeout, Logger):
         If the request is not satisfied before ``timeout`` seconds pass,
         all data is buffered and an empty string (``''``) is returned.
 
-        See :meth:`recvline_endswith` for more details.
+        See :meth:`recvline_startswith` for more details.
 
         Examples:
 


### PR DESCRIPTION
Documentation fix: recvline_endswith() wrongly had the same description of recvline_startswith()