### PR TITLE
ROP: add base= argument for .chain() and .dump()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1654][1654] Docker images (`pwntools/pwntools:stable` etc) now use Python3 by default, and includes assemblers for a few common architectures
 - Fix syscall instruction lists for SROP on `i386` and `amd64`
 - Fix migration to another ROP
+- [#1673][1673] Add `base=` argument to `ROP.chain()` and `ROP.dump()`
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -76,6 +77,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1644]: https://github.com/Gallopsled/pwntools/pull/1644
 [1651]: https://github.com/Gallopsled/pwntools/pull/1651
 [1654]: https://github.com/Gallopsled/pwntools/pull/1654
+[1673]: https://github.com/Gallopsled/pwntools/pull/1673
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -925,17 +925,28 @@ class ROP(object):
     def find_stack_adjustment(self, slots):
         self.search(move=slots * context.bytes)
 
-    def chain(self):
+    def chain(self, base=None):
         """Build the ROP chain
+        
+        Arguments:
+            base(int):
+                The base address to build the rop-chain from. Defaults to
+                :attr:`base`.
 
         Returns:
             str containing raw ROP bytes
         """
-        return packing.flat(self.build())
+        return packing.flat(self.build(base=base))
 
-    def dump(self):
-        """Dump the ROP chain in an easy-to-read manner"""
-        return self.build().dump()
+    def dump(self, base=None):
+        """Dump the ROP chain in an easy-to-read manner
+        
+        Arguments:
+            base(int):
+                The base address to build the rop-chain from. Defaults to
+                :attr:`base`.
+        """
+        return self.build(base=base).dump()
 
     def regs(self, registers=None, **kw):
         if registers is None:


### PR DESCRIPTION
`ROP.build()` has an optional `base=` argument, but `.chain()` and `.dump()` (currently) lack a `base=` parameter to pass on to `.build()`.