### PR TITLE
Gdbserver now correctly accepts multiple libraries in LD_PRELOAD and LD_LIBRARY_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The table below shows which release corresponds to each branch, and what date th
 - Fix syscall instruction lists for SROP on `i386` and `amd64`
 - Fix migration to another ROP
 - [#1673][1673] Add `base=` argument to `ROP.chain()` and `ROP.dump()`
+- [#1674][1674] Gdbserver now correctly accepts multiple libraries in `LD_PRELOAD` and `LD_LIBRARY_PATH`
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -78,6 +79,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1651]: https://github.com/Gallopsled/pwntools/pull/1651
 [1654]: https://github.com/Gallopsled/pwntools/pull/1654
 [1673]: https://github.com/Gallopsled/pwntools/pull/1673
+[1674]: https://github.com/Gallopsled/pwntools/pull/1674
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -241,9 +241,9 @@ def _gdbserver_args(pid=None, path=None, args=None, which=None, env=None):
         env_args = []
         for key in tuple(env):
             if key.startswith('LD_'): # LD_PRELOAD / LD_LIBRARY_PATH etc.
-                env_args.append('{}={}'.format(key, env.pop(key)))
+                env_args.append('{}="{}"'.format(key, env.pop(key)))
             else:
-                env_args.append('{}={}'.format(key, env[key]))
+                env_args.append('{}="{}"'.format(key, env[key]))
         gdbserver_args += ['--wrapper', 'env', '-i'] + env_args + ['--']
 
     gdbserver_args += ['localhost:0']


### PR DESCRIPTION
Consider:
```
cwd = os.getcwd()
libs = ["libc.so.6", "libstdc++.so.6"]
preload = ' '.join(map(lambda l: os.path.join(cwd, l), libs))
env = {'LD_PRELOAD': preload}
io = start(env=env)
```

Normally gdbserver will be given arguments this way:
```
[+] Starting local process '/usr/bin/gdbserver' argv=[b'/usr/bin/gdbserver', b'--multi', b'--no-disable-randomization', b'--wrapper', b'env', b'-i', b'LD_PRELOAD=/home/mzr/sources/pwntools/pwnlib/libc.so.6 /home/mzr/sources/pwntools/pwnlib/libstdc++.so.6', b'--', b'localhost:0', b'/home/mzr/sources/pwntools/pwnlib/cos']  env={} : pid 35944
```
causing it to load binary and other objfiles like that:
```
pwndbg> vmmap
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
    0x7fe85e578000     0x7fe85e60e000 r--p    96000 0      /home/mzr/sources/pwntools/pwnlib/libstdc++.so.6
    0x7fe85e60e000     0x7fe85e6fa000 r-xp    ec000 96000  /home/mzr/sources/pwntools/pwnlib/libstdc++.so.6
    0x7fe85e6fa000     0x7fe85e743000 r--p    49000 182000 /home/mzr/sources/pwntools/pwnlib/libstdc++.so.6
    0x7fe85e744000     0x7fe85e752000 rw-p     e000 1cb000 /home/mzr/sources/pwntools/pwnlib/libstdc++.so.6
    0x7fe85e752000     0x7fe85e755000 rw-p     3000 0      
    0x7ffddc063000     0x7ffddc084000 rw-p    21000 0      [stack]
    0x7ffddc12e000     0x7ffddc132000 r--p     4000 0      [vvar]
    0x7ffddc132000     0x7ffddc134000 r-xp     2000 0      [vdso]
0xffffffffff600000 0xffffffffff601000 --xp     1000 0      [vsyscall]
```

Obviously that's not the intended behavior.

After this change everything should work as intended:
```
[+] Starting local process '/usr/bin/gdbserver' argv=[b'/usr/bin/gdbserver', b'--multi', b'--no-disable-randomization', b'--wrapper', b'env', b'-i', b'LD_PRELOAD="/home/mzr/sources/pwntools/pwnlib/libc.so.6 /home/mzr/sources/pwntools/pwnlib/libstdc++.so.6"', b'--', b'localhost:0', b'/home/mzr/sources/pwntools/pwnlib/cos']  env={} : pid 45554
```