### PR TITLE
ROPGadget multibr hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1673][1673] Add `base=` argument to `ROP.chain()` and `ROP.dump()`
 - [#1675][1675] Gdbserver now correctly accepts multiple libraries in `LD_PRELOAD` and `LD_LIBRARY_PATH`
 - [#1678][1678] ROPGadget multibr
-- [#1679][1679] ROPGadget multibr fix
+- [#1682][1682] ROPGadget multibr fix
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -83,7 +83,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1673]: https://github.com/Gallopsled/pwntools/pull/1673
 [1675]: https://github.com/Gallopsled/pwntools/pull/1675
 [1678]: https://github.com/Gallopsled/pwntools/pull/1678
-[1679]: https://github.com/Gallopsled/pwntools/pull/1679
+[1682]: https://github.com/Gallopsled/pwntools/pull/1679
 
 ## 4.3.0 (`beta`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1673][1673] Add `base=` argument to `ROP.chain()` and `ROP.dump()`
 - [#1675][1675] Gdbserver now correctly accepts multiple libraries in `LD_PRELOAD` and `LD_LIBRARY_PATH`
 - [#1678][1678] ROPGadget multibr
+- [#1679][1679] ROPGadget multibr fix
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -82,6 +83,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1673]: https://github.com/Gallopsled/pwntools/pull/1673
 [1675]: https://github.com/Gallopsled/pwntools/pull/1675
 [1678]: https://github.com/Gallopsled/pwntools/pull/1678
+[1679]: https://github.com/Gallopsled/pwntools/pull/1679
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1360,7 +1360,7 @@ class ROP(object):
         True
         >>> rop.ret is not None
         True
-        >>> with context.local(arch='amd64'):
+        >>> with context.local(arch='amd64', bits='64'):
         ...     r = ROP(ELF.from_assembly('syscall; ret'))
         >>> r.syscall is not None
         True

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1406,7 +1406,7 @@ class ROP(object):
              'syscall': 'syscall',
              'sysenter': 'sysenter'}
             for each in self.gadgets:
-                if self.gadgets[each]['insns'] == [mapping[attr]]:
+                if self.gadgets[each]['insns'][0] == mapping[attr]:
                     return gadget(each, self.gadgets[each])
             return None
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1360,6 +1360,10 @@ class ROP(object):
         True
         >>> rop.ret is not None
         True
+        >>> with context.local(arch='amd64'):
+        ...     r = ROP(ELF.from_assembly('syscall; ret'))
+        >>> r.syscall is not None
+        True
         """
         gadget = collections.namedtuple('gadget', ['address', 'details'])
         bad_attrs = [


### PR DESCRIPTION
cf. https://github.com/Gallopsled/pwntools/pull/1678#issuecomment-696522150

Another single-line PR.

Prior behavior was to search for pure ['syscall'] gadgets. Any gadget that has 'syscall' as it's first instruction will exhibit the same behavior, so this _should_ make everything normal again.