### PR TITLE
fix #1684 (ROP gadget loading fails when it matches "add esp, esi")

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1101,7 +1101,7 @@ class ROP(object):
         #
         # - leave
         # - pop reg
-        # - add $sp, value
+        # - add $sp, <hexadecimal value>
         # - ret
         #
         # Currently, ROPgadget does not detect multi-byte "C2" ret.
@@ -1125,6 +1125,8 @@ class ROP(object):
         # False
         # >>> valid('add esp, 0x24')
         # True
+        # >>> valid('add esp, esi')
+        # False
         #
         valid = lambda insn: any(map(lambda pattern: pattern.match(insn), [pop,add,ret,leave,int80,syscall,sysenter]))
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1109,7 +1109,7 @@ class ROP(object):
         #
 
         pop   = re.compile(r'^pop (.{3})')
-        add   = re.compile(r'^add [er]sp, (\S+)$')
+        add   = re.compile(r'^add [er]sp, ((?:0[xX])?[0-9a-fA-F]+)$')
         ret   = re.compile(r'^ret$')
         leave = re.compile(r'^leave$')
         int80 = re.compile(r'int +0x80')


### PR DESCRIPTION
Howdy!  This fixes an issue when loading a gadget in the pattern "add $sp, value" where value is not a valid hexadecimal integer.  It gets parsed as a hex integer so I modified the matching regex to ensure it only matches hex numbers.  Details on reproducing it can be found in #1684.  I added to the existing documentation on which instructions are "valid" or not "valid" but they aren't automatically executed by the testing suite and I couldn't figure out how to make that happen (because __load is a private function, I think?).  