### PR TITLE
Actually import `requests` when doing `from pwn import *`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1673][1673] Add `base=` argument to `ROP.chain()` and `ROP.dump()`
 - [#1675][1675] Gdbserver now correctly accepts multiple libraries in `LD_PRELOAD` and `LD_LIBRARY_PATH`
 - [#1678][1678] ROPGadget multibr
+- [#1687][1687] Actually import `requests` when doing `from pwn import *`
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -84,6 +85,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1673]: https://github.com/Gallopsled/pwntools/pull/1673
 [1675]: https://github.com/Gallopsled/pwntools/pull/1675
 [1678]: https://github.com/Gallopsled/pwntools/pull/1678
+[1687]: https://github.com/Gallopsled/pwntools/pull/1687
 
 ## 4.3.0 (`beta`)
 

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -5,6 +5,7 @@ import math
 import operator
 import os
 import re
+import requests
 import socks
 import signal
 import string


### PR DESCRIPTION
As per documentation, we claim to be importing `requests` globally
(https://github.com/Gallopsled/pwntools/blame/dev/docs/source/globals.rst#L100)

We should actually do this :)

Although this does affect `stable`, I am not sure if it warrants a hotfix.