### PR TITLE
Add `__setattr__` and `__call__` interfaces to `ROP` for setting registers (closes #1636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1673][1673] Add `base=` argument to `ROP.chain()` and `ROP.dump()`
 - [#1675][1675] Gdbserver now correctly accepts multiple libraries in `LD_PRELOAD` and `LD_LIBRARY_PATH`
 - [#1678][1678] ROPGadget multibr
+- [#1688][1688] Add `__setattr__` and `__call__` interfaces to `ROP` for setting registers
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -84,6 +85,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1673]: https://github.com/Gallopsled/pwntools/pull/1673
 [1675]: https://github.com/Gallopsled/pwntools/pull/1675
 [1678]: https://github.com/Gallopsled/pwntools/pull/1678
+[1688]: https://github.com/Gallopsled/pwntools/pull/1688
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -740,6 +740,7 @@ class ROP(object):
         """
         Generates padding to be inserted into the ROP stack.
 
+        >>> context.clear(arch='i386')
         >>> rop = ROP([])
         >>> val = rop.generatePadding(5,15)
         >>> cyclic_find(val[:4])
@@ -1098,6 +1099,7 @@ class ROP(object):
         Arguments:
             data(int/str): The raw value to put onto the rop chain.
 
+        >>> context.clear(arch='i386')
         >>> rop = ROP([])
         >>> rop.raw('AAAAAAAA')
         >>> rop.raw('BBBBBBBB')
@@ -1387,6 +1389,7 @@ class ROP(object):
         Also provides a shorthand for ``.call()``:
             ``rop.function(args)`` is equivalent to ``rop.call(function, args)``
 
+        >>> context.clear(arch='i386')
         >>> elf=ELF(which('bash'))
         >>> rop=ROP([elf])
         >>> rop.rdi     == rop.search(regs=['rdi'], order = 'regs')


### PR DESCRIPTION
This implements #1636 which introduces the `__setattr__` interface for setting registers in `ROP`, one at a time:


        >>> context.clear(arch='amd64')
        >>> assembly = 'pop rax; pop rdi; pop rsi; ret; pop rax; ret;'
        >>> e = ELF.from_assembly(assembly)
        >>> r = ROP(e)
        >>> r.rax = 0xdead
        >>> r.rdi = 0xbeef
        >>> r.rsi = 0xcafe
        >>> print(r.dump())
        0x0000:       0x10000004 pop rax; ret
        0x0008:           0xdead
        0x0010:       0x10000001 pop rdi; pop rsi; ret
        0x0018:           0xbeef
        0x0020:      b'iaaajaaa' <pad rsi>
        0x0028:       0x10000002 pop rsi; ret
        0x0030:           0xcafe

As discussed, a more flexible `__call__` interface has also been implemented:

        >>> context.clear(arch='amd64')
        >>> assembly = 'pop rax; pop rdi; pop rsi; ret; pop rax; ret;'
        >>> e = ELF.from_assembly(assembly)
        >>> r = ROP(e)
        >>> r(rax=0xdead, rdi=0xbeef, rsi=0xcafe)
        >>> print(r.dump())
        0x0000:       0x10000000
        0x0008:           0xdead
        0x0010:           0xbeef
        0x0018:           0xcafe
        >>> r = ROP(e)
        >>> r({'rax': 0xdead, 'rdi': 0xbeef, 'rsi': 0xcafe})
        >>> print(r.dump())
        0x0000:       0x10000000
        0x0008:           0xdead
        0x0010:           0xbeef
        0x0018:           0xcafe

