### PR TITLE
Remove python2 shebangs where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1678][1678] ROPGadget multibr
 - [#1682][1682] ROPGadget multibr fix
 - [#1688][1688] Add `__setattr__` and `__call__` interfaces to `ROP` for setting registers
+- [#1692][1692] Remove python2 shebangs where appropriate
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606
@@ -88,6 +89,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1678]: https://github.com/Gallopsled/pwntools/pull/1678
 [1682]: https://github.com/Gallopsled/pwntools/pull/1679
 [1688]: https://github.com/Gallopsled/pwntools/pull/1688
+[1692]: https://github.com/Gallopsled/pwntools/pull/1692
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/args.py
+++ b/pwnlib/args.py
@@ -1,5 +1,3 @@
-
-#!/usr/bin/env python2
 """
 Pwntools exposes several magic command-line arguments and environment
 variables when operating in `from pwn import *` mode.

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
 Implements context management so that nested/scoped contexts and threaded

--- a/pwnlib/encoders/i386/xor.py
+++ b/pwnlib/encoders/i386/xor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # Source:
 # http://www.iodigitalsec.com/python-cascading-xor-polymorphic-shellcode-generator/
 #

--- a/pwnlib/encoders/mips/xor.py
+++ b/pwnlib/encoders/mips/xor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # Source:
 # https://github.com/zcutlip/bowcaster/blob/master/src/bowcaster/encoders/mips.py
 #

--- a/pwnlib/term/readline.py
+++ b/pwnlib/term/readline.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division

--- a/pwnlib/timeout.py
+++ b/pwnlib/timeout.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
 Timeout encapsulation, complete with countdowns and scope managers.

--- a/pwnlib/tubes/buffer.py
+++ b/pwnlib/tubes/buffer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import absolute_import
 from __future__ import division
 

--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 r"""
 Routines here are for getting any NULL-terminated sequence of bytes evaluated


### PR DESCRIPTION
Closes https://github.com/Gallopsled/pwntools/issues/1404
All non-scripts have had the shebang removed.
Other than the `pwnlib/commandline` directory, these scripts were found (so the shebang was not removed):

```
pwnlib/data/useragents/download-useragents.py
pwnlib/data/syscalls/generate.py
```

The empty files mentioned in https://github.com/Gallopsled/pwntools/issues/1404 appear to be used. `__doc__` files in `shellcraft` are used in https://github.com/Gallopsled/pwntools/blob/45eb8bcc8186ff6c8b7a435a92c941f25318ce14/pwnlib/shellcraft/__init__.py#L37
`pwnlib/encoders/arm/alphanumeric/alphanumeric.py` is indirectly imported through https://github.com/Gallopsled/pwntools/blob/55dfe9b5e4df51987d173f85164bfbdc327abaad/pwnlib/encoders/__init__.py#L12
This means the empty files were not removed.