### PR TITLE
Allow using GDB Python API (#1617)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
           libc6-dbg \
           $ANDROID_JRE
 
+    - name: Install RPyC for GDB
+      run: |
+        sudo apt-get install -y python3-pip
+        /usr/bin/python3 -m pip install rpyc
+
     - name: Testing Corefiles
       run: |
         ulimit -a

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         set -x
         pip install pylint
+        pip install --upgrade -r requirements.txt
         pylint --exit-zero --errors-only  pwnlib > current.txt
         git fetch origin
         git checkout origin/"$GITHUB_BASE_REF"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     - binutils-s390x-linux-gnu
     - binutils-sparc64-linux-gnu
     - bash-static
+    - python3-pip
 cache:
     - pip
     - directories:
@@ -42,6 +43,7 @@ before_install:
   - source travis/ssh_setup.sh
   - echo $-
 install:
+  - /usr/bin/python3 -m pip install rpyc # for GDB
   - pip install --upgrade pip
   - pip install --upgrade flake8 appdirs # https://github.com/ActiveState/appdirs/issues/89#issuecomment-282326570
   - python setup.py egg_info      # pypa/pip#6275

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1687][1687] Actually import `requests` when doing `from pwn import *`
 - [#1688][1688] Add `__setattr__` and `__call__` interfaces to `ROP` for setting registers
 - [#1692][1692] Remove python2 shebangs where appropriate
+- [#1695][1695] Allow using GDB Python API
 
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
 [1606]: https://github.com/Gallopsled/pwntools/pull/1606

--- a/examples/gdb_api.py
+++ b/examples/gdb_api.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""An example of using GDB Python API with Pwntools."""
+from pwn import *
+
+
+def check_write(gdb, exp_buf):
+    """Check that write() was called with the expected arguments."""
+    fd = gdb.parse_and_eval('$rdi').cast(gdb.lookup_type('int'))
+    assert fd == 1, fd
+    buf_addr = gdb.parse_and_eval('$rsi').cast(gdb.lookup_type('long'))
+    count = gdb.parse_and_eval('$rdx').cast(gdb.lookup_type('long'))
+    buf = gdb.selected_inferior().read_memory(buf_addr, count).tobytes()
+    assert buf == exp_buf, buf
+
+
+def demo_sync_breakpoint(cat, gdb, txt):
+    """Demonstrate a synchronous breakpoint."""
+    # set the synchronous breakpoint on ``write``
+    gdb.Breakpoint('write', temporary=True)
+
+    # resume the program
+    gdb.continue_nowait()
+
+    # send the line
+    cat.sendline(txt)
+
+    # wait until we hit the breakpoint
+    gdb.wait()
+
+    # inspect program state
+    check_write(gdb, (txt + '\n').encode())
+
+    # resume the program
+    gdb.continue_nowait()
+
+    # expect to observe the line we just sent
+    cat.recvuntil(txt)
+
+
+def demo_async_breakpoint(cat, gdb, txt):
+    """Demonstrate asynchronous breakpoint."""
+    # set the asynchronous breakpoint on ``write``
+    class WriteBp(gdb.Breakpoint):
+        def __init__(self):
+            super().__init__('write')
+            self.count = 0
+
+        def stop(self):
+            # called in a separate thread
+            check_write(gdb, (txt + '\n').encode())
+            self.count += 1
+
+    bp = WriteBp()
+
+    # resume the program
+    gdb.continue_nowait()
+
+    # send the line and immediately expect to observe it
+    cat.sendline(txt)
+    cat.recvuntil(txt)
+
+    # check that we hit the breakpoint
+    assert bp.count == 1, bp.count
+
+    # interrupt the program
+    gdb.interrupt_and_wait()
+
+    # delete the breakpoint
+    bp.delete()
+
+    # resume the program
+    gdb.continue_nowait()
+
+
+def main():
+    # start ``cat`` under GDB
+    with gdb.debug('cat', gdbscript='''
+set logging on
+set pagination off
+''', api=True) as cat:
+
+        # the process is stopped
+        # set the synchronous breakpoint on ``read``
+        cat.gdb.Breakpoint('read', temporary=True)
+
+        # resume and wait until we hit it
+        cat.gdb.continue_and_wait()
+
+        # demonstrate a more interesting synchronous breakpoint
+        demo_sync_breakpoint(cat, cat.gdb, 'foo')
+
+        # terminate GDB
+        cat.gdb.quit()
+
+    # now start ``cat`` normally
+    with process('cat') as cat:
+        # attach GDB
+        _, cat_gdb = gdb.attach(cat, gdbscript='''
+set logging on
+set pagination off
+''', api=True)
+
+        # the process is stopped
+        # demonstrate asynchronous breakpoint
+        demo_async_breakpoint(cat, cat_gdb, 'bar')
+
+        # terminate GDB
+        cat_gdb.quit()
+
+
+if __name__ == '__main__':
+    main()

--- a/pwnlib/gdb_api_bridge.py
+++ b/pwnlib/gdb_api_bridge.py
@@ -1,0 +1,101 @@
+"""GDB Python API bridge."""
+import socket
+from threading import Condition
+import time
+
+from rpyc.core.protocol import Connection
+from rpyc.core.service import Service
+from rpyc.lib import spawn
+from rpyc.lib.compat import select_error
+from rpyc.utils.server import ThreadedServer
+
+
+class ServeResult:
+    """Result of serving requests on GDB thread."""
+    def __init__(self):
+        self.cv = Condition()
+        self.done = False
+        self.exc = None
+
+    def set(self, exc):
+        with self.cv:
+            self.done = True
+            self.exc = exc
+            self.cv.notify()
+
+    def wait(self):
+        with self.cv:
+            while not self.done:
+                self.cv.wait()
+            if self.exc is not None:
+                raise self.exc
+
+
+class GdbConnection(Connection):
+    """A Connection implementation that serves requests on GDB thread.
+
+    Serving on GDB thread might not be ideal from the responsiveness
+    perspective, however, it is simple and reliable.
+    """
+    SERVE_TIME = 0.1  # Number of seconds to serve.
+    IDLE_TIME = 0.1  # Number of seconds to wait after serving.
+
+    def serve_gdb_thread(self, serve_result):
+        """Serve requests on GDB thread."""
+        try:
+            deadline = time.time() + self.SERVE_TIME
+            while True:
+                timeout = deadline - time.time()
+                if timeout < 0:
+                    break
+                super().serve(timeout=timeout)
+        except Exception as exc:
+            serve_result.set(exc)
+        else:
+            serve_result.set(None)
+
+    def serve_all(self):
+        """Modified version of rpyc.core.protocol.Connection.serve_all."""
+        try:
+            while not self.closed:
+                serve_result = ServeResult()
+                gdb.post_event(lambda: self.serve_gdb_thread(serve_result))
+                serve_result.wait()
+                time.sleep(self.IDLE_TIME)
+        except (socket.error, select_error, IOError):
+            if not self.closed:
+                raise
+        except EOFError:
+            pass
+        finally:
+            self.close()
+
+
+class GdbService(Service):
+    """A public interface for Pwntools."""
+
+    _protocol = GdbConnection  # Connection subclass.
+    exposed_gdb = gdb  # ``gdb`` module.
+
+    def exposed_set_breakpoint(self, client, has_stop, *args, **kwargs):
+        """Create a breakpoint and connect it with the client-side mirror."""
+        if has_stop:
+            class Breakpoint(gdb.Breakpoint):
+                def stop(self):
+                    return client.stop()
+
+            return Breakpoint(*args, **kwargs)
+        return gdb.Breakpoint(*args, **kwargs)
+
+    def exposed_quit(self):
+        """Terminate GDB."""
+        gdb.post_event(lambda: gdb.execute('quit'))
+
+
+spawn(ThreadedServer(
+    service=GdbService(),
+    socket_path=socket_path,
+    protocol_config={
+        'allow_all_attrs': True,
+    },
+).start)

--- a/pwnlib/gdb_faketerminal.py
+++ b/pwnlib/gdb_faketerminal.py
@@ -2,13 +2,18 @@
 from pwnlib.tubes.process import process
 from time import sleep
 from sys import argv
+from os import environ
 sleep(1)
 if len(argv) == 2:
-	sh = process(argv[1], shell=True)
+    sh = process(argv[1], shell=True)
 else:
-	sh = process(argv[1:])
+    sh = process(argv[1:])
 sh.sendline('set prompt (gdb)')
-res = sh.sendlineafter('(gdb)', 'c')
-while b'The program is not being run.' not in res:
+if environ.get('GDB_FAKETERMINAL') == '0':
+    sh.sendline('set pagination off')
+    sh.recvall()
+else:
     res = sh.sendlineafter('(gdb)', 'c')
+    while b'The program is not being run.' not in res:
+        res = sh.sendlineafter('(gdb)', 'c')
 sh.close()

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -181,7 +181,7 @@ def which(name, all = False):
     else:
         return None
 
-def run_in_new_terminal(command, terminal = None, args = None):
+def run_in_new_terminal(command, terminal = None, args = None, preexec_fn = None):
     """run_in_new_terminal(command, terminal = None) -> None
 
     Run a command in a new terminal.
@@ -205,6 +205,7 @@ def run_in_new_terminal(command, terminal = None, args = None):
         command (str): The command to run.
         terminal (str): Which terminal to use.
         args (list): Arguments to pass to the terminal
+        preexec_fn (callable): Callable to invoke before exec().
 
     Note:
         The command is opened with ``/dev/null`` for stdin, stdout, stderr.
@@ -270,6 +271,8 @@ def run_in_new_terminal(command, terminal = None, args = None):
             os.dup2(devnull.fileno(), 0)
             os.dup2(devnull.fileno(), 1)
             os.dup2(devnull.fileno(), 2)
+        if preexec_fn is not None:
+            preexec_fn()
         os.execv(argv[0], argv)
         os._exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'sortedcontainers',
                         'unicorn>=1.0.2rc1,<1.0.2rc4', # see unicorn-engine/unicorn#1100, unicorn-engine/unicorn#1170, Gallopsled/pwntools#1538
                         'six>=1.12.0',
+                        'rpyc',
 ]
 
 # Check that the user has installed the Python development headers


### PR DESCRIPTION
# Pwntools Pull Request

This PR allows using GDB Python API (https://sourceware.org/gdb/onlinedocs/gdb/Python-API.html) from Pwntools scripts.

## Testing

There are two new doctests for `attach()` and `debug()`; there is also a new example.

There are new PyLint failures, but I believe they are all false positives.

## Target Branch

dev

## Changelog

Added