### PR TITLE
FmtStr module enhancement

### DIFF
--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -886,7 +886,7 @@ class FmtStr(object):
         })
 
         leak = self.execute_fmt(fmtstr)
-        leak = re.findall(br"START(.*?)END", leak, re.MULTILINE | re.DOTALL)[0]
+        leak = re.findall(br"START(.*)END", leak, re.MULTILINE | re.DOTALL)[0]
 
         leak += b"\x00"
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -851,7 +851,7 @@ class FmtStr(object):
         payload = b"START%%%d$pEND" % offset
         leak = self.execute_fmt(prefix + payload)
         try:
-            leak = re.findall(br"START(.*)END", leak, re.MULTILINE | re.DOTALL)[0]
+            leak = re.findall(br"START(.*?)END", leak, re.MULTILINE | re.DOTALL)[0]
             leak = int(leak, 16)
         except ValueError:
             leak = 0
@@ -886,7 +886,7 @@ class FmtStr(object):
         })
 
         leak = self.execute_fmt(fmtstr)
-        leak = re.findall(br"START(.*)END", leak, re.MULTILINE | re.DOTALL)[0]
+        leak = re.findall(br"START(.*?)END", leak, re.MULTILINE | re.DOTALL)[0]
 
         leak += b"\x00"
 


### PR DESCRIPTION
Current `FmtStr` uses `START(.*)END` to look for formatter output. But if the program output contains `END` in it, this regex fails. 

For example, if the data is `START0x6161616161616161END\nHELLO END`, the whole thing will be returned and pwntools will fail to parse the number because we found the wrong `END` label. By using the non-greedy operator, we can find the first `END`. Since we know that our formatter does not generate `END` string, it's safe to use the first `END` as our end label.

## Target Branch

dev
