### PR TITLE
Fix broken shellcraft linux templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,10 @@ The table below shows which release corresponds to each branch, and what date th
 
 - [#1625][1625] GDB now properly loads executables with QEMU
 - [#1663][1663] Change lookup algorithm of `adb.which`
+- [#1699][1699] Fix broken linux shellcraft templates
 
 [1625]: https://github.com/Gallopsled/pwntools/pull/1625
+[1699]: https://github.com/Gallopsled/pwntools/pull/1699
 
 ## 4.2.0
 

--- a/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
@@ -20,22 +20,22 @@ ${acceptloop}:
     /*  Socket file descriptor is placed in EBP */
 
     /*  sock = socket(AF_INET, SOCK_STREAM, 0) */
-    ${i386.linux.push(0)}
-    ${i386.linux.push('SOCK_STREAM')}
-    ${i386.linux.push('AF_INET')}
+    ${i386.push(0)}
+    ${i386.push('SOCK_STREAM')}
+    ${i386.push('AF_INET')}
     ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_socket', 'esp')}
 
-    ${i386.linux.mov('esi', 'eax')}      /* keep socket fd */
+    ${i386.mov('esi', 'eax')}      /* keep socket fd */
 
     /*  bind(sock, &addr, sizeof addr); // sizeof addr == 0x10 */
-    ${i386.linux.push(0)}
+    ${i386.push(0)}
     /* ${htons(port)} == htons(${port}) */
-    ${i386.linux.push('AF_INET | (%d << 16)' % htons(port))}
-    ${i386.linux.mov('ecx', 'esp')}
+    ${i386.push('AF_INET | (%d << 16)' % htons(port))}
+    ${i386.mov('ecx', 'esp')}
 
-    ${i386.linux.push(0x10)}    /* sizeof addr */
-    ${i386.linux.push('ecx')}   /* &addr */
-    ${i386.linux.push('eax')}   /* sock */
+    ${i386.push(0x10)}    /* sizeof addr */
+    ${i386.push('ecx')}   /* &addr */
+    ${i386.push('eax')}   /* sock */
     ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_bind', 'esp')}
 
     /*  listen(sock, whatever) */
@@ -44,17 +44,17 @@ ${acceptloop}:
 
 ${looplabel}:
     /*  accept(sock, NULL, NULL) */
-    ${i386.linux.push(0x0)}
-    ${i386.linux.push('esi')} /* sock */
+    ${i386.push(0x0)}
+    ${i386.push('esi')} /* sock */
     ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_accept', 'esp')}
 
-    ${i386.linux.mov('ebp', 'eax')}      /* keep in-coming socket fd */
+    ${i386.mov('ebp', 'eax')}      /* keep in-coming socket fd */
 
     ${i386.linux.syscall('SYS_fork')}
     xchg eax, edi
 
     test edi, edi
-    ${i386.linux.mov('ebx', 'ebp')}
+    ${i386.mov('ebx', 'ebp')}
     cmovz ebx, esi /*  on child we close the server sock instead */
 
     /*  close(sock) */

--- a/pwnlib/shellcraft/templates/i386/linux/mprotect_all.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/mprotect_all.asm
@@ -22,6 +22,6 @@
 %endif
 ${label}:
     ${i386.linux.syscall('SYS_mprotect', 'ebx', 'ecx', 'PROT_READ | PROT_WRITE | PROT_EXEC')}
-    ${i386.linux.mov('ecx', 0x1000)}
+    ${i386.mov('ecx', 0x1000)}
     add ebx, ecx
     jnz ${label}


### PR DESCRIPTION
A couple of the shellcraft templates do not actually compile currently possibly due to a change moving i386.mov and i386.push out of i386.linux. This change allows the templates to compile and be used.