### PR TITLE
Update libcdb buildid offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1687][1687] Actually import `requests` when doing `from pwn import *`
 - [#1688][1688] Add `__setattr__` and `__call__` interfaces to `ROP` for setting registers
 - [#1692][1692] Remove python2 shebangs where appropriate
+- [#1703][1703] Update libcdb buildid offsets for amd64 and i386
 
 [1541]: https://github.com/Gallopsled/pwntools/pull/1541
 [1602]: https://github.com/Gallopsled/pwntools/pull/1602
@@ -94,6 +95,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1687]: https://github.com/Gallopsled/pwntools/pull/1687
 [1688]: https://github.com/Gallopsled/pwntools/pull/1688
 [1692]: https://github.com/Gallopsled/pwntools/pull/1692
+[1703]: https://github.com/Gallopsled/pwntools/pull/1703
 
 ## 4.3.0 (`beta`)
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -46,7 +46,7 @@ def search_by_hash(hex_encoded_id, hash_type='build_id'):
             log.info_once("Using cached data from %r", cache)
             return cache
         else:
-            log.info_once("Skipping unavialable libc %s", hex_encoded_id)
+            log.info_once("Skipping unavailable libc %s", hex_encoded_id)
             return None
 
     # Build the URL using the requested hash type
@@ -186,7 +186,7 @@ def get_build_id_offsets():
     return {
     # $ check_arch 80386
     #     181 Displaying notes found at file offset 0x00000174 with length 0x00000024:
-        'i386': [0x174],
+        'i386': [0x174, 0x1b4, 0x1d4],
     # $ check_arch "ARM, EABI5"
     #      69 Displaying notes found at file offset 0x00000174 with length 0x00000024:
         'arm':  [0x174],
@@ -197,7 +197,7 @@ def get_build_id_offsets():
     # $ check_arch "x86-64"
     #       6 Displaying notes found at file offset 0x00000174 with length 0x00000024:
     #      82 Displaying notes found at file offset 0x00000270 with length 0x00000024:
-        'amd64': [0x270, 0x174, 0x2e0],
+        'amd64': [0x270, 0x174, 0x2e0, 0x370],
     # $ check_arch "PowerPC or cisco"
     #      88 Displaying notes found at file offset 0x00000174 with length 0x00000024:
         'powerpc': [0x174],


### PR DESCRIPTION
Recent libcs from Debian and Ubuntu have different offsets for the build id.
Running the following to count buildid offsets on a local libc-database with ubuntu and debian:

```bash
function check_arch() {
readelf -SW $(file -L * | grep -i "$1" | cut -d ':' -f 1) \
      | grep .note.gnu.build-id \
      | sort \
      | uniq -c
}
```

```
$ check_arch 80386
     83   [ 1] .note.gnu.build-id NOTE            00000174 000174 000024 00   A  0   0  4
     19   [ 1] .note.gnu.build-id NOTE            000001b4 0001b4 000024 00   A  0   0  4
     16   [ 1] .note.gnu.build-id NOTE            000001d4 0001d4 000024 00   A  0   0  4
```

```
$ check_arch "x86-64"
     84   [ 1] .note.gnu.build-id NOTE            0000000000000270 000270 000024 00   A  0   0  4
     14   [ 1] .note.gnu.build-id NOTE            00000000000002e0 0002e0 000024 00   A  0   0  4
     16   [ 2] .note.gnu.build-id NOTE            0000000000000370 000370 000024 00   A  0   0  4
```