### PR TITLE
Fix races in server tube from #1067 and apply #1569

### DIFF
--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -79,8 +79,6 @@ class listen(sock):
         super(listen, self).__init__(*args, **kwargs)
 
         port = int(port)
-        fam  = {socket.AF_INET: 'ipv4',
-                socket.AF_INET6: 'ipv6'}.get(fam, fam)
 
         fam = self._get_family(fam)
         typ = self._get_type(typ)


### PR DESCRIPTION
The events were used in a racy way, which was not necessary at all, since python already has an atomic queue interface.

Also, `fam` parsing is not necessary, since the magic conversion methods already do the trick.

Furthermore, #1552 also affected `server` tubes, which was not mentioned in its description.