### PR TITLE
Don't introduce null bytes in MIPS shellcode.

### DIFF
--- a/pwnlib/shellcraft/templates/mips/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sh.asm
@@ -3,7 +3,7 @@
 
 Example:
 
-    >>> b'\0' in asm(shellcraft.mips.linux.sh())
+    >>> b'\0' in pwnlib.asm.asm(shellcraft.mips.linux.sh())
     False
     >>> p = run_assembly(shellcraft.mips.linux.sh())
     >>> p.sendline(b'echo Hello')

--- a/pwnlib/shellcraft/templates/mips/linux/sh.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sh.asm
@@ -3,6 +3,8 @@
 
 Example:
 
+    >>> b'\0' in asm(shellcraft.mips.linux.sh())
+    False
     >>> p = run_assembly(shellcraft.mips.linux.sh())
     >>> p.sendline(b'echo Hello')
     >>> p.recv()

--- a/pwnlib/shellcraft/templates/mips/pushstr_array.asm
+++ b/pwnlib/shellcraft/templates/mips/pushstr_array.asm
@@ -31,7 +31,7 @@ offset = len(array_str) + word_size
     ${mips.push(reg)} /* null terminate */
 % for i,arg in enumerate(reversed(array)):
     ${mips.mov(reg, offset + word_size*i - len(arg))}
-    add ${reg}, $sp
+    add ${reg}, $sp, ${reg}
     ${mips.push(reg)} /* ${repr(arg)} */
     <% offset -= len(arg) %>\
 % endfor


### PR DESCRIPTION
As a verification, you can run:

```sh
pwn shellcraft mips.linux.sh |pwn phd
```
