### PR TITLE
fixed pack() overflow bug in fmtstr offset_find

### DIFF
--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -861,7 +861,7 @@ class FmtStr(object):
         marker = cyclic(20)
         for off in range(1,1000):
             leak = self.leak_stack(off, marker)
-            leak = pack(leak)
+            leak = pack(leak, max(32, leak.bit_length()))
 
             pad = cyclic_find(leak[:4])
             if pad >= 0 and pad < 20:


### PR DESCRIPTION
On my x86_64 Ubuntu system the automatic offset_find function behind the FmtStr function in the fmtstr.py does not work.
```
Python 3.8.5 (default, Jul 28 2020, 12:59:40)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pwn import *
>>>
>>> target = process("./format")
[x] Starting local process './format'
[+] Starting local process './format': pid 3012
>>>
>>> def exec_fmt(payload):
...     target.sendline(payload)
...     out = target.recvline()
...     return out
...
>>> autofmt = FmtStr(exec_fmt)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ulrich/devel/pwntools/pwnlib/fmtstr.py", line 844, in __init__
    self.offset, self.padlen = self.find_offset()
  File "/home/ulrich/devel/pwntools/pwnlib/fmtstr.py", line 864, in find_offset
    leak = pack(leak)
  File "/home/ulrich/devel/pwntools/pwnlib/util/packing.py", line 148, in pack
    raise ValueError("pack(): number does not fit within word_size [%i, %r, %r]" % (0, number, limit))
ValueError: pack(): number does not fit within word_size [0, 139650330561027, 4294967296]
```
The cause is the 64-bit values printed out by `%p` in the printf function.
In this test case the number 0x7f4dac347a03 in the byte string b'aaaabaaacaaadaaaeaaaSTART0x7f4dac347a03END\n' was parsed and should be packed with a pack() call with default word size 32.bit.

With the word size `max(32, leak.bit_length())` the bug is fixed. The word size 'all' does not work because at least 4 bytes are expected in the next code lines.

After the bug fix the FmtStr call works as expected:
```
Python 3.8.5 (default, Jul 28 2020, 12:59:40)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pwn import *
>>>
>>> target = process("./format")
[x] Starting local process './format'
[+] Starting local process './format': pid 3027
>>>
>>> def exec_fmt(payload):
...     target.sendline(payload)
...     out = target.recvline()
...     return out
...
>>> autofmt = FmtStr(exec_fmt)
[*] Found format string offset: 6
```
