### PR TITLE
Remove unused import from toplevel

### DIFF
--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -30,7 +30,7 @@ from pwnlib.elf.corefile import Core, Corefile, Coredump
 from pwnlib.elf.elf import ELF, load
 from pwnlib.encoders import *
 from pwnlib.exception import PwnlibException
-from pwnlib.gdb import attach, debug, debug_assembly, debug_shellcode
+from pwnlib.gdb import attach, debug_assembly, debug_shellcode
 from pwnlib.filepointer import *
 from pwnlib.flag import *
 from pwnlib.fmtstr import FmtStr, fmtstr_payload, fmtstr_split


### PR DESCRIPTION
Removes unused `debug` imported from `pwnlib.gdb`.
`debug` is overwritten by line 82 — `debug   = log.debug`.