### PR TITLE
Add baremetal os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,11 +63,13 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1735][1735] Python 3.9 support in safeeval
 - [#1738][1738] Which function support custom search path
   - process also looks now at `env['PATH']` to find the path for the executable
+- [#1742][1742] New `baremetal` os to debug binaries executed with qemu-system-$(arch)
 
 [1261]: https://github.com/Gallopsled/pwntools/pull/1261
 [1695]: https://github.com/Gallopsled/pwntools/pull/1695
 [1735]: https://github.com/Gallopsled/pwntools/pull/1735
 [1738]: https://github.com/Gallopsled/pwntools/pull/1738
+[1742]: https://github.com/Gallopsled/pwntools/pull/1742
 
 ## 4.4.0 (`beta`)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -368,7 +368,7 @@ class ContextType(object):
     }
 
     #: Valid values for :meth:`pwnlib.context.ContextType.os`
-    oses = sorted(('linux','freebsd','windows','cgc','android'))
+    oses = sorted(('linux','freebsd','windows','cgc','android','baremetal'))
 
     big_32    = {'endian': 'big', 'bits': 32}
     big_64    = {'endian': 'big', 'bits': 64}
@@ -602,7 +602,7 @@ class ContextType(object):
 
     @property
     def native(self):
-        if context.os in ('android', 'cgc'):
+        if context.os in ('android', 'baremetal', 'cgc'):
             return False
 
         arch = context.arch
@@ -1018,7 +1018,7 @@ class ContextType(object):
             >>> context.os = 'foobar' #doctest: +ELLIPSIS
             Traceback (most recent call last):
             ...
-            AttributeError: os must be one of ['android', 'cgc', 'freebsd', 'linux', 'windows']
+            AttributeError: os must be one of ['android', 'baremetal', 'cgc', 'freebsd', 'linux', 'windows']
         """
         os = os.lower()
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -509,7 +509,10 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, api=
         sysroot = sysroot or qemu.ld_prefix(env=env)
         if not qemu_user:
             log.error("Cannot debug %s binaries without appropriate QEMU binaries" % context.arch)
-        qemu_args = [qemu_user, '-g', str(qemu_port)]
+        if context.os == 'baremetal':
+            qemu_args = [qemu_user, '-S', '-gdb', 'tcp::' + str(qemu_port)]
+        else:
+            qemu_args = [qemu_user, '-g', str(qemu_port)]
         if sysroot:
             qemu_args += ['-L', sysroot]
         args = qemu_args + args
@@ -830,7 +833,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
         if context.os == 'android':
             pre += 'set gnutarget ' + _bfdname() + '\n'
 
-        if exe:
+        if exe and context.os != 'baremetal':
             pre += 'file %s\n' % exe
 
     # let's see if we can find a pid to attach to

--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -119,14 +119,19 @@ def user_path():
     'qemu-arm-static'
     """
     arch   = archname()
+    system = 'qemu-system-' + arch
     normal = 'qemu-' + arch
     static = normal + '-static'
 
-    if misc.which(static):
-        return static
+    if context.os == 'baremetal':
+        if misc.which(system):
+            return system
+    else:
+        if misc.which(static):
+            return static
 
-    if misc.which(normal):
-        return normal
+        if misc.which(normal):
+            return normal
 
     log.warn_once("Neither %r nor %r are available" % (normal, static))
 
@@ -137,6 +142,9 @@ def ld_prefix(path=None, env=None):
     >>> pwnlib.qemu.ld_prefix(arch='arm')
     '/etc/qemu-binfmt/arm'
     """
+    if context.os == 'baremetal':
+        return ""
+
     if path is None:
         path = user_path()
 


### PR DESCRIPTION
This allows to run and debug a raw binary, e.g. an MBR, with
the help of qemu-system-$(arch).

Tested with:
```python
pwn.context.arch = "i386"
pwn.context.os = "baremetal"
pwn.gdb.debug(["./mbr.bin"])
```