### PR TITLE
docs: fix simple typo, inforation -> information

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -264,7 +264,7 @@ class Mapping(object):
         return result + self.address
 
 class Corefile(ELF):
-    r"""Enhances the inforation available about a corefile (which is an extension
+    r"""Enhances the information available about a corefile (which is an extension
     of the ELF format) by permitting extraction of information about the mapped
     data segments, and register state.
 


### PR DESCRIPTION
There is a small typo in pwnlib/elf/corefile.py.

Should read `information` rather than `inforation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md