### PR TITLE
Remove a stale workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: focal
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - zsh
     - pandoc
     - gdb
+    - gdbserver
     - socat
     - sshpass
     - binutils

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -69,13 +69,6 @@ setup_ipv6()
     echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
 }
 
-setup_gdbserver()
-{
-    # https://docs.improbable.io/reference/14.3/shared/debug-cloud-workers#common-issues
-    wget http://archive.ubuntu.com/ubuntu/pool/main/g/gdb/gdbserver_8.3-0ubuntu1_amd64.deb
-    sudo apt-get install ./gdbserver_8.3-0ubuntu1_amd64.deb
-}
-
 setup_linux()
 {
     sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
@@ -192,7 +185,6 @@ setup_osx()
 if [[ "$USER" == "travis" ]]; then
 #   setup_travis
     setup_ipv6
-    setup_gdbserver
     setup_android_emulator
 elif [[ "$USER" == "shippable" ]]; then
     sudo apt-get update


### PR DESCRIPTION
Travis CI no longer uses ancient images; GHA uses even newer; the pinned gdbserver version is no longer supported in any ubuntu distro.