### PR TITLE
Fix ROP call miscalculating offsets

### DIFF
--- a/docs/source/rop/call.rst
+++ b/docs/source/rop/call.rst
@@ -1,0 +1,10 @@
+.. testsetup:: *
+
+   from pwn import *
+   from pwnlib.rop.call import *
+
+:mod:`pwnlib.rop.call` --- Return Oriented Programming Function Calling
+=======================================================================
+
+.. automodule:: pwnlib.rop.call
+   :members:

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -435,7 +435,7 @@ class ROP(object):
     >>> context.clear(arch = "i386", kernel = 'amd64')
     >>> assembly = 'int 0x80; ret; add esp, 0x10; ret; pop eax; ret'
     >>> e = ELF.from_assembly(assembly)
-    >>> e.symbols['funcname'] = e.address + 0x1234
+    >>> e.symbols['funcname'] = e.entry + 0x1234
     >>> r = ROP(e)
     >>> r.funcname(1, 2)
     >>> r.funcname(3)
@@ -944,7 +944,7 @@ class ROP(object):
 
             elif isinstance(slot, AppendedArgument):
                 stack[i] = stack.next
-                stack.extend(slot.resolve(stack.next + len(slot) - context.bytes))
+                stack.extend(slot.resolve(stack.next))
 
             elif isinstance(slot, CurrentStackPointer):
                 stack[i] = slot_address


### PR DESCRIPTION
This mainly enables the doctests for rop.call, which have quite always been incorrect.