### PR TITLE
Remove eval from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,15 @@ The table below shows which release corresponds to each branch, and what date th
   - process also looks now at `env['PATH']` to find the path for the executable
 - [#1742][1742] New `baremetal` os to debug binaries executed with qemu-system-$(arch)
 - [#1757][1757] update cache directories
+- [#1758][1758] Remove eval from cli
 
 [1261]: https://github.com/Gallopsled/pwntools/pull/1261
 [1695]: https://github.com/Gallopsled/pwntools/pull/1695
 [1735]: https://github.com/Gallopsled/pwntools/pull/1735
 [1738]: https://github.com/Gallopsled/pwntools/pull/1738
 [1742]: https://github.com/Gallopsled/pwntools/pull/1742
+[1757]: https://github.com/Gallopsled/pwntools/pull/1757
+[1758]: https://github.com/Gallopsled/pwntools/pull/1758
 
 ## 4.4.0 (`beta`)
 

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -295,7 +295,7 @@ def main(args):
 
     vma = args.address
     if vma:
-        vma = eval(vma)
+        vma = util.safeeval.expr(vma)
 
     if args.format in ['e','elf']:
         args.format = 'default'

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -295,7 +295,7 @@ def main(args):
 
     vma = args.address
     if vma:
-        vma = util.safeeval.expr(vma)
+        vma = pwnlib.util.safeeval.expr(vma)
 
     if args.format in ['e','elf']:
         args.format = 'default'


### PR DESCRIPTION
# Removal `eval()`
POC
```sh
$ pwn shellcraft amd64.crash --address '__import__("os").system("echo hi")'
hi
5f5e5d5b5b5a59584831e4ffe4
```
[`safeeval`](https://github.com/Gallopsled/pwntools/blob/dev/pwnlib/util/safeeval.py) is used elsewhere in pwntools, so it may be helpful to replace the use of `eval()` here with `safeeval.expr()`.

The above test case will (correctly) raise an error when `eval()` is replaced:
```sh
Traceback (most recent call last):
...
    raise ValueError("opcode %s not allowed" % dis.opname[code])
ValueError: opcode LOAD_NAME not allowed
```
And will run as normal with a proper address:
```sh
$ pwn shellcraft amd64.crash --address '0x123'
5f5e5d5b5b5a59584831e4ffe4
```

## Testing
I am struggling to find where to put doctests for this, if they are necessary.

## Changelog
Making after PR.

###### P.S.: I made use of this bug for a local CTF I ran with a few others. You can see the challenge [here](http://challs.sieberrsec.tech:28158/) while it's still up.