### PR TITLE
[ci] Fix broken tests for libcdb by removing them

### DIFF
--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -144,9 +144,6 @@ def search_by_build_id(hex_encoded_id):
         '0xda260'
         >>> None == search_by_build_id('XX')
         True
-        >>> filename = search_by_build_id('a5a3c3f65fd94f4c7f323a175707c3a79cbbd614')
-        >>> hex(ELF(filename).symbols.read)
-        '0xeef40'
     """
     return search_by_hash(hex_encoded_id, 'build_id')
 
@@ -167,9 +164,6 @@ def search_by_md5(hex_encoded_id):
         '0xda260'
         >>> None == search_by_md5('XX')
         True
-        >>> filename = search_by_md5('74f2d3062180572fc8bcd964b587eeae')
-        >>> hex(ELF(filename).symbols.read)
-        '0xeef40'
     """
     return search_by_hash(hex_encoded_id, 'md5')
 
@@ -190,9 +184,6 @@ def search_by_sha1(hex_encoded_id):
         '0xda260'
         >>> None == search_by_sha1('XX')
         True
-        >>> filename = search_by_sha1('0041d2f397bc2498f62aeb4134d522c5b2635e87')
-        >>> hex(ELF(filename).symbols.read)
-        '0xeef40'
     """
     return search_by_hash(hex_encoded_id, 'sha1')
 
@@ -214,9 +205,6 @@ def search_by_sha256(hex_encoded_id):
         '0xda260'
         >>> None == search_by_sha256('XX')
         True
-        >>> filename = search_by_sha256('5d78fc60054df18df20480c71f3379218790751090f452baffb62ac6b2aff7ee')
-        >>> hex(ELF(filename).symbols.read)
-        '0xeef40'
     """
     return search_by_hash(hex_encoded_id, 'sha256')
 


### PR DESCRIPTION
This should make at LEAST github actions be reliable and passing.

Failures are because a secondary libdb source was added, and its API is down.  We cannot rely on flaky services for our CI.