### PR TITLE
[android] Skip all Android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,27 +44,7 @@ jobs:
         [ "$vsetup" = "$vpwnlib" ]
         [ "$GITHUB_TAG" = "$vsetup" ]
 
-    - name: Detect whether java is needed
-      id: java-needed
-      env:
-        GITHUB_REF: ${{ github.event.ref }}
-      run: |
-        if echo "$GITHUB_REF" | grep -Eq 'staging|tags'; then
-          echo "Found release or important branch ($GITHUB_REF), forcing tests."
-        elif ! git show "origin/$GITHUB_BASE_REF"..HEAD >/dev/null; then
-          echo 'Incorrect commit range, forcing android tests.'
-        elif git log --stat "origin/$GITHUB_BASE_REF"..HEAD | grep -iE 'android|\<adb\>'; then
-          echo 'Found Android-related commits, forcing tests.'
-        else
-          # clear files that cause Android doctests
-          : > docs/source/adb.rst > docs/source/protocols/adb.rst
-          exit 0
-        fi
-        echo ::set-output name=need::openjdk-8-jre-headless
-
     - name: Install Linux dependencies
-      env:
-        ANDROID_JRE: ${{ steps.java-needed.outputs.need }}
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
@@ -79,8 +59,7 @@ jobs:
           binutils-s390x-linux-gnu \
           binutils-sparc64-linux-gnu \
           gcc-multilib \
-          libc6-dbg \
-          $ANDROID_JRE
+          libc6-dbg
 
     - name: Install RPyC for GDB
       run: |
@@ -94,12 +73,6 @@ jobs:
         cat /proc/sys/kernel/core_pattern
         cat /proc/sys/kernel/core_uses_pid
         ( cd $(mktemp -d); sh -c 'kill -11 $$' || true; ls -la ./*core* /var/crash/*.crash;) || true
-
-    - name: Install Android AVD
-      if:  steps.java-needed.outputs.need
-      run: |
-        USER=travis source travis/install.sh
-        set | egrep '^(ANDROID|PATH)' >.android.env
 
     - name: Set up SSH
       run: |
@@ -126,7 +99,6 @@ jobs:
 
     - name: Coverage doctests
       run: |
-        source .android.env || :
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope # required by some gdb doctests
         PWNLIB_NOTERM=1 coverage run -m sphinx -b doctest docs/source docs/build/doctest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1757][1757] update cache directories
 - [#1758][1758] Remove eval from cli
 - [#1780][1780] Re-add Python2 to the official Dockerfile
+- [#1941][1941] Disable all Android tests, `pwnlib.adb` is no longer supported in CI
 
 [1261]: https://github.com/Gallopsled/pwntools/pull/1261
 [1695]: https://github.com/Gallopsled/pwntools/pull/1695
@@ -76,6 +77,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1757]: https://github.com/Gallopsled/pwntools/pull/1757
 [1758]: https://github.com/Gallopsled/pwntools/pull/1758
 [1780]: https://github.com/Gallopsled/pwntools/pull/1780
+[1941]: https://github.com/Gallopsled/pwntools/pull/1941
 
 ## 4.4.0 (`beta`)
 
@@ -225,7 +227,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1001]: https://github.com/Gallopsled/pwntools/pull/1001
 [1389]: https://github.com/Gallopsled/pwntools/pull/1389
 [1241]: https://github.com/Gallopsled/pwntools/pull/1241
-[1218]: https://github.com/Gallopsled/pwntools/pull/1218  
+[1218]: https://github.com/Gallopsled/pwntools/pull/1218
 
 ## 4.0.1
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,6 +92,7 @@ pwnlib.context.ContextType.defaults['log_console'] = stdout()
 github_actions = os.environ.get('USER') == 'runner'
 travis_ci = os.environ.get('USER') == 'travis'
 branch_dev = os.environ.get('GITHUB_BASE_REF') == 'dev'
+skip_android = True
 '''
 
 autoclass_content = 'both'

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -75,10 +75,13 @@ log = getLogger(__name__)
 def adb(argv, *a, **kw):
     r"""Returns the output of an ADB subcommand.
 
-    >>> adb.adb('get-serialno')
-    b'emulator-5554\n'
-    >>> adb.adb(['shell', 'uname']) # it is better to use adb.process
-    b'Linux\n'
+    .. doctest::
+       :skipif: skip_android
+
+        >>> adb.adb('get-serialno')
+        b'emulator-5554\n'
+        >>> adb.adb(['shell', 'uname']) # it is better to use adb.process
+        b'Linux\n'
     """
     if isinstance(argv, (bytes, six.text_type)):
         argv = [argv]
@@ -113,7 +116,8 @@ def current_device(any=False):
     """Returns an ``AdbDevice`` instance for the currently-selected device
     (via ``context.device``).
 
-    Example:
+    .. doctest::
+       :skipif: skip_android
 
         >>> device = adb.current_device(any=True)
         >>> device
@@ -144,7 +148,10 @@ def with_device(f):
 def root():
     """Restarts adbd as root.
 
-    >>> adb.root()
+    .. doctest::
+       :skipif: skip_android
+
+        >>> adb.root()
     """
     log.info("Enabling root on %s" % context.device)
 
@@ -202,6 +209,10 @@ def uptime():
         Uptime of the device, in seconds
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.uptime() > 3 # normally AVD takes ~7 seconds to boot
         True
     """
@@ -217,6 +228,10 @@ def boot_time():
         nearest second.
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
         >>> import time
         >>> adb.boot_time() < time.time()
         True
@@ -230,6 +245,9 @@ class AdbDevice(Device):
     """Encapsulates information about a connected device.
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> device = adb.wait_for_device()
         >>> device.arch
@@ -357,10 +375,13 @@ class AdbDevice(Device):
         """Provides scoped access to ``adb`` module propertise, in the context
         of this device.
 
-        >>> property = 'ro.build.fingerprint'
-        >>> device = adb.wait_for_device()
-        >>> adb.getprop(property) == device.getprop(property)
-        True
+        .. doctest::
+           :skipif: skip_android
+
+            >>> property = 'ro.build.fingerprint'
+            >>> device = adb.wait_for_device()
+            >>> adb.getprop(property) == device.getprop(property)
+            True
         """
         with context.local(device=self):
             g = globals()
@@ -386,6 +407,9 @@ def wait_for_device(kick=False):
         An ``AdbDevice`` instance for the device.
 
     Examples:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> device = adb.wait_for_device()
     """
@@ -496,6 +520,9 @@ def pull(remote_path, local_path=None):
 
     Example:
 
+    .. doctest::
+       :skipif: skip_android
+
         >>> _=adb.pull('/proc/version', './proc-version')
         >>> print(read('./proc-version').decode('utf-8')) # doctest: +ELLIPSIS
         Linux version ...
@@ -526,6 +553,9 @@ def push(local_path, remote_path):
         Remote path of the file.
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> write('./filename', 'contents')
         >>> adb.push('./filename', '/data/local/tmp')
@@ -584,6 +614,9 @@ def read(path, target=None, callback=None):
 
     Examples:
 
+    .. doctest::
+       :skipif: skip_android
+
         >>> print(adb.read('/proc/version').decode('utf-8')) # doctest: +ELLIPSIS
         Linux version ...
         >>> adb.read('/does/not/exist')
@@ -613,6 +646,9 @@ def write(path, data=b''):
 
     Examples:
 
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.write('/dev/null', b'data')
         >>> adb.write('/data/local/tmp/')
     """
@@ -632,6 +668,9 @@ def mkdir(path):
         path(str): Directory to create.
 
     Examples:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> adb.mkdir('/')
 
@@ -673,6 +712,9 @@ def makedirs(path):
 
     Examples:
 
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.makedirs('/data/local/tmp/this/is/a/directory/hierarchy')
         >>> adb.listdir('/data/local/tmp/this/is/a/directory')
         ['hierarchy']
@@ -688,6 +730,9 @@ def exists(path):
     """Return :const:`True` if ``path`` exists on the target device.
 
     Examples:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> adb.exists('/')
         True
@@ -706,6 +751,9 @@ def isdir(path):
 
     Examples:
 
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.isdir('/')
         True
         >>> adb.isdir('/init')
@@ -723,6 +771,9 @@ def unlink(path, recursive=False):
     """Unlinks a file or directory on the target device.
 
     Examples:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> adb.unlink("/does/not/exist")
         Traceback (most recent call last):
@@ -775,6 +826,9 @@ def process(argv, *a, **kw):
 
     Examples:
 
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.root()
         >>> print(adb.process(['cat','/proc/version']).recvall().decode('utf-8')) # doctest: +ELLIPSIS
         Linux version ...
@@ -814,6 +868,9 @@ def which(name, all = False, *a, **kw):
         Either a path, or list of paths
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
 
         >>> adb.which('sh')
         '/system/bin/sh'
@@ -864,6 +921,10 @@ def whoami():
     """Returns current shell user
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
        >>> adb.whoami()
        b'root'
     """
@@ -917,6 +978,10 @@ def proc_exe(pid):
     """Returns the full path of the executable for the provided PID.
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.proc_exe(1)
         b'/init'
     """
@@ -937,6 +1002,10 @@ def getprop(name=None):
         Otherwise, a string is returned with the contents of the named property.
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
         >>> adb.getprop() # doctest: +ELLIPSIS
         {...}
     """
@@ -1052,6 +1121,10 @@ class Kernel(object):
     def address(self):
         """Returns kernel address
         Example:
+
+        .. doctest::
+           :skipif: skip_android
+
             >>> hex(adb.kernel.address) # doctest: +ELLIPSIS
             '0x...000'
         """
@@ -1178,6 +1251,10 @@ class Property(object):
         """Allow simple comparison
 
         Example:
+
+        .. doctest::
+           :skipif: skip_android
+
             >>> adb.properties.ro.build.version.sdk == "24"
             True
         """
@@ -1266,6 +1343,10 @@ def compile(source):
     r"""Compile a source file or project with the Android NDK.
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
         >>> temp = tempfile.mktemp('.c')
         >>> write(temp, '''
         ... #include <stdio.h>
@@ -1390,6 +1471,10 @@ class Partitions(object):
     """Enable access to partitions
 
     Example:
+
+    .. doctest::
+       :skipif: skip_android
+
         >>> hex(adb.partitions.vda.size) # doctest: +ELLIPSIS
         '0x...000'
     """

--- a/pwnlib/protocols/adb/__init__.py
+++ b/pwnlib/protocols/adb/__init__.py
@@ -160,16 +160,22 @@ class AdbClient(Logger):
     @_autoclose
     def kill(self):
         """Kills the remote ADB server"
+        
+        .. doctest::
+           :skipif: skip_android
 
-        >>> c=pwnlib.protocols.adb.AdbClient()
-        >>> c.kill()
+            >>> c=pwnlib.protocols.adb.AdbClient()
+            >>> c.kill()
 
         The server is automatically re-started on the next request,
         if the default host/port are used.
 
-        >>> c.version() > (4,0)
-        True
-        >>> c.wait_for_device() # ensure doctests alive
+        .. doctest::
+           :skipif: skip_android
+
+            >>> c.version() > (4,0)
+            True
+            >>> c.wait_for_device() # ensure doctests alive
         """
         try:
             self.send('host:kill')
@@ -183,6 +189,9 @@ class AdbClient(Logger):
             Tuple containing the ``(major, minor)`` version from the ADB server
 
         Example:
+        
+        .. doctest::
+           :skipif: skip_android
 
             >>> pwnlib.protocols.adb.AdbClient().version() # doctest: +SKIP
             (4, 36)
@@ -230,6 +239,9 @@ class AdbClient(Logger):
 
         Examples:
 
+        .. doctest::
+           :skipif: skip_android
+
             >>> pwnlib.protocols.adb.AdbClient().transport()
         """
 
@@ -264,6 +276,9 @@ class AdbClient(Logger):
             A :class:`pwnlib.tubes.tube.tube` which is connected to the process.
 
         Examples:
+
+        .. doctest::
+           :skipif: skip_android
 
             >>> pwnlib.protocols.adb.AdbClient().execute(['echo','hello']).recvall()
             b'hello\n'
@@ -391,6 +406,9 @@ class AdbClient(Logger):
             'adb root', since adbd then runs in the ``su`` domain.
 
         Examples:
+        
+        .. doctest::
+           :skipif: skip_android
 
             >>> _ = AdbClient().root()
             >>> AdbClient().wait_for_device()
@@ -458,6 +476,9 @@ class AdbClient(Logger):
             If the file cannot be stat() ed, None is returned.
 
         Example:
+        
+        .. doctest::
+           :skipif: skip_android
 
             >>> expected = {'mode': 16749, 'size': 0, 'time': 0}
             >>> pwnlib.protocols.adb.AdbClient().stat('/proc')           == expected

--- a/travis/docker/run.sh
+++ b/travis/docker/run.sh
@@ -6,20 +6,4 @@ sudo service ssh start
 # Enable the IPv6 interface
 echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
 
-case "$ANDROID" in
-    [Yy]* )
-        emulator64-arm -avd android-armeabi-v7a -no-window -no-boot-anim -no-skin -no-audio -no-window -no-snapshot &
-        adb wait-for-device
-        adb shell getprop ro.build.fingerprint
-        ;;
-    [Nn]* )
-        echo "===========================================" >&2
-        echo "  WARNING: Disabling all Android tests !!! " >&2
-        echo "===========================================" >&2
-
-        echo > 'docs/source/adb.rst'
-        echo > 'docs/source/protocols/adb.rst'
-        ;;
-esac
-
 PWNLIB_NOTERM=1 coverage3 run -m sphinx -b doctest docs/source docs/build/doctest $TARGET

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -89,99 +89,6 @@ setup_linux()
     fi
 }
 
-setup_android_emulator()
-{
-    # If we are running on Travis CI, and there were no changes to Android
-    # or ADB code, then we do not need the emulator
-    if [ -n "$TRAVIS" ]; then
-        if [ -z "$TRAVIS_COMMIT_RANGE" ]; then
-            echo "TRAVIS_COMMIT_RANGE is empty, forcing Android Emulator installation"
-        elif ! (git show "$TRAVIS_COMMIT_RANGE" >/dev/null) ; then
-            echo "TRAVIS_COMMIT_RANGE is invalid, forcing Android Emulator installation"
-        elif [[ "$TRAVIS_BRANCH" =~ "staging" ]]; then
-            echo "TRAVIS_BRANCH ($TRAVIS_BRANCH) indicates a branch we care about"
-            echo "Forcing Android Emulator installation"
-        elif [[ -n "$TRAVIS_TAG" ]]; then
-            echo "TRAVIS_TAG ($TRAVIS_TAG) indicates a new relase"
-            echo "Forcing Android Emulator installation"
-        elif (git log --stat "$TRAVIS_COMMIT_RANGE" | grep -iE "android|adb" | grep -v "commit "); then
-            echo "Found Android-related commits, forcing Android Emulator installation"
-        else
-            # In order to avoid running the doctests that require the Android
-            # emulator, while still leaving the code intact, we remove the
-            # RST file that Sphinx searches.
-            rm -f 'docs/source/adb.rst'
-            rm -f 'docs/source/protocols/adb.rst'
-
-            # However, the file needs to be present or else things break.
-            touch 'docs/source/adb.rst'
-            touch 'docs/source/protocols/adb.rst' || true
-
-            echo "Skipping Android emulator install, Android tests disabled."
-            return
-        fi
-    fi
-
-
-    if ! which java; then
-        echo "OpenJDK-8-JRE is required for Android stuff"
-        exit 1
-    fi
-
-    if (uname | grep -i Darwin &>/dev/null); then
-        brew install android-sdk android-ndk
-    else
-        if [ ! -f android-sdk/tools/bin/sdkmanager ]; then
-            # Install the SDK, which gives us the 'android' and 'emulator' commands
-            wget -nv -O sdk-tools-linux.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-            unzip -q sdk-tools-linux.zip
-            rm    -f sdk-tools-linux.zip
-
-            # Travis caching causes this to exist already
-            rm -rf android-sdk
-
-            mkdir android-sdk
-            mv tools android-sdk/
-            file android-sdk/tools/bin/sdk-manager
-        fi
-
-        export PATH="$PWD/android-sdk/tools:$PATH"
-        export PATH="$PWD/android-sdk/tools/bin:$PATH"
-        export PATH="$PWD/android-sdk/platform-tools:$PATH"
-        export ANDROID_SDK_ROOT="$PWD/android-sdk"
-        export ANDROID_HOME="$PWD/android-sdk"
-        which sdkmanager
-    fi
-
-    # Grab prerequisites
-    # Valid ABIs:
-    # - armeabi-v7a
-    # - arm64-v8a
-    # - x86
-    # - x86_64
-    ANDROID_ABI='armeabi-v7a'
-    ANDROIDV=android-24
-    yes | sdkmanager --install platform-tools 'extras;android;m2repository' emulator ndk-bundle \
-          "platforms;$ANDROIDV" "system-images;$ANDROIDV;default;$ANDROID_ABI" >/dev/null
-    yes | sdkmanager --licenses
-
-    # enable NDK for adb.compile()
-    for d in "$PWD/android-sdk/ndk-bundle/"*/; do
-        export PATH="$PATH:$d"
-    done
-
-    # Create our emulator Android Virtual Device (AVD)
-    # --snapshot flag is deprecated, see bitrise-steplib/steps-create-android-emulator#18
-    echo no | avdmanager --silent create avd --name android-$ANDROID_ABI --force --package "system-images;$ANDROIDV;default;$ANDROID_ABI"
-
-    # In the future, it would be nice to be able to use snapshots.
-    # However, I haven't gotten them to work nicely.
-    android-sdk/emulator/emulator -avd android-$ANDROID_ABI -no-window -no-boot-anim -read-only -no-audio -no-window -no-snapshot &
-    adb wait-for-device
-    adb shell id
-    adb shell getprop
-}
-
 setup_osx()
 {
     brew update
@@ -193,7 +100,6 @@ if [[ "$USER" == "travis" ]]; then
 #   setup_travis
     setup_ipv6
     setup_gdbserver
-    setup_android_emulator
 elif [[ "$USER" == "shippable" ]]; then
     sudo apt-get update
     sudo apt-get install openssh-server gcc-multilib
@@ -203,7 +109,6 @@ elif [[ "$(uname)" == "Darwin" ]]; then
     setup_osx
 elif [[ "$(uname)" == "Linux" ]]; then
     setup_linux
-    setup_android_emulator
 fi
 
 set +ex


### PR DESCRIPTION
Currently, we skip Android tests by removing `adb.rst` and `protocols/adb.rst`.

This introduces a `doctest skip` for all of the Android tests, so that the Android emulator should not be required.

The `adb`  module is no longer required, and this is a cleaner way to skip the doctests and setup.

I recommend reviewing the change request with `?w=1` appended to the URL, e.g. https://github.com/Gallopsled/pwntools/pull/1791/files?w=1

This skips all whitespace changes (some of the "tests" needed to be indented a bit more).