### PR TITLE
Pin autoprogram to v0.1.5 which supports Python2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,4 +14,4 @@ ropgadget>=5.3
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-napoleon
-sphinxcontrib-autoprogram
+sphinxcontrib-autoprogram<=0.1.5


### PR DESCRIPTION
Versions after v0.1.5 drop support for Python2 and use things like type hints, which breaks Python2 CI pipelines.