### PR TITLE
fix: Use `os.makedirs()` to create cache dir

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1239,12 +1239,10 @@ class ContextType(object):
             return None
 
         cache = os.path.join(xdg_cache_home, '.pwntools-cache-%d.%d' % sys.version_info[:2])
-
-        if not os.path.exists(cache):
-            try:
-                os.mkdir(cache)
-            except OSError:
-                return None
+        try:
+            os.makedirs(cache, exist_ok=True)
+        except OSError:
+            return None
 
         # Some wargames e.g. pwnable.kr have created dummy directories
         # which cannot be modified by the user account (owned by root).


### PR DESCRIPTION
This change ensures that the cache directory will be created along with
any missing intermediate path components. This fixes a misbehaviour
where the cache would not be created if, e.g. `$HOME/.cache` does not
already exist. `exist_ok=True` is used to ensure that we allow the use
of an existing cache directory while still capturing other `OSError`s
such as permissions errors when we attempt to create it.

If we fail to create the cache directory (likely due to permission
issues) or it ends up being unwritable we return `None` and expect other
modules to handle this situation gracefully.

This PR is an alternative to #1784 
