### PR TITLE
Enable PWNLIB_COLOR=always environment variable

### DIFF
--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import functools
+import os
 import sys
 import types
 
@@ -11,7 +12,7 @@ from pwnlib.term import termcap
 def eval_when(when):
     if hasattr(when, 'isatty') or \
       when in ('always', 'never', 'auto', sys.stderr, sys.stdout):
-        if   when == 'always':
+        if os.environ.get('PWNLIB_COLOR') == 'always' or when == 'always':
             return True
         elif when == 'never':
             return False


### PR DESCRIPTION
This allows piping with color into tools like ansifilter, which take
ANSI-escape-coded colorized text and emits data in other formats,
notably HTML.

This is useful for writing blog posts with PWNLIB_DEBUG=1 to display
hex-dumped data written to stdout that would not normally be colorized.

Currently this ONLY works for the environment variable PWNLIB_COLOR,
and does not make use of pwnlib.args due to cyclic imports.