### PR TITLE
[docs] Use older sphinx that doesnt cause recursion errors

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ pypandoc
 pyserial>=2.7
 requests>=2.5.1
 ropgadget>=5.3
-sphinx
+sphinx<3.4
 sphinx_rtd_theme
 sphinxcontrib-napoleon
 sphinxcontrib-autoprogram<=0.1.5


### PR DESCRIPTION
Per these resources:
* https://github.com/sphinx-doc/sphinx/issues/8119
* https://github.com/sphinx-doc/sphinx/pull/8125

Sphinx 3.4.0 now handles autodoc-skip-member differently, causing us to run
some tests multiple times due to imported code getting tested.