### PR TITLE
[ci] Disable Android and ADB protocol tests for Dockerfile-based CI

### DIFF
--- a/travis/docker/doctest2
+++ b/travis/docker/doctest2
@@ -28,6 +28,10 @@ fi
 # Disable these tests until we can get them working.
 echo > ~/pwntools/docs/source/gdb.rst
 
+# Android tests are disabled in general, support is deprecateds
+echo > ~/pwntools/docs/source/adb.rst
+echo > ~/pwntools/docs/source/protocols.rst
+
 export PWNLIB_NOTERM=1 
 coverage-2.7 run -m sphinx -b doctest $HOME/pwntools/docs/source $HOME/pwntools/docs/build/doctest $TARGET
 

--- a/travis/docker/doctest3
+++ b/travis/docker/doctest3
@@ -27,6 +27,8 @@ fi
 # GDB tests currently don't work inside Docker for unknown reasons.
 # Disable these tests until we can get them working.
 echo > ~/pwntools/docs/source/gdb.rst
+echo > ~/pwntools/docs/source/adb.rst
+echo > ~/pwntools/docs/source/protocols.rst
 
 export PWNLIB_NOTERM=1 
 coverage3 run -m sphinx -b doctest $HOME/pwntools/docs/source $HOME/pwntools/docs/build/doctest $TARGET


### PR DESCRIPTION
These modules are deprecated, so we don't test them anymore, and
the Docker image does not perform any setup to install an Android
SDK or AVD.
