### PR TITLE
[travis] Switch to a different server that still has the magic gdbserver, make RPyC tests work

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -782,8 +782,8 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
 
             Observe the forced line
 
-            >>> s = io.recvline()
-            >>> assert s == b'Hello from process debugger!\n', s
+            >>> io.recvline()
+            b'Hello from process debugger!\n'
 
             Interact with the program in a regular way
 
@@ -791,7 +791,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
 
             Observe the results
 
-            >>> s = io.recvall()
+            >>> io.recvall()
             b'Hello from bash\n'
 
         Attach to the remote process from a :class:`.remote` or :class:`.listen` tube,

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -1047,7 +1047,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
         retriable = ConnectionRefusedError, FileNotFoundError
 
     t = Timeout()
-    with t.countdown(5):
+    with t.countdown(10):
         while t.timeout:
             try:
                 conn = unix_connect(socket_path)

--- a/pwnlib/gdb_api_bridge.py
+++ b/pwnlib/gdb_api_bridge.py
@@ -1,4 +1,6 @@
 """GDB Python API bridge."""
+import gdb
+
 import socket
 from threading import Condition
 import time

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -80,18 +80,13 @@ setup_gdbserver()
 # Contents borrowed from Pwndbg setup.sh
 setup_rpyc()
 {
-    INSTALLFLAGS="--user"
-
     # Find the Python version used by GDB.
     PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.python_version_tuple()[:2]))')
     PYTHON+=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
     PYTHON+="${PYVER}"
 
-    # Upgrade pip itself
-    ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade pip
-
     # Install rpyc
-    ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade rpyc
+    ${PYTHON} -m pip install --user --upgrade rpyc
 }
 
 setup_linux()

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -72,7 +72,8 @@ setup_ipv6()
 setup_gdbserver()
 {
     # https://docs.improbable.io/reference/14.3/shared/debug-cloud-workers#common-issues
-    wget http://archive.ubuntu.com/ubuntu/pool/main/g/gdb/gdbserver_8.3-0ubuntu1_amd64.deb
+    # wget http://archive.ubuntu.com/ubuntu/pool/main/g/gdb/gdbserver_8.3-0ubuntu1_amd64.deb
+    wget https://launchpad.net/ubuntu/+source/gdb/8.3-0ubuntu1/+build/16807407/+files/gdbserver_8.3-0ubuntu1_amd64.deb
     sudo apt-get install ./gdbserver_8.3-0ubuntu1_amd64.deb
 }
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -77,6 +77,23 @@ setup_gdbserver()
     sudo apt-get install ./gdbserver_8.3-0ubuntu1_amd64.deb
 }
 
+# Contents borrowed from Pwndbg setup.sh
+setup_rpyc()
+{
+    INSTALLFLAGS="--user"
+
+    # Find the Python version used by GDB.
+    PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.python_version_tuple()[:2]))')
+    PYTHON+=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
+    PYTHON+="${PYVER}"
+
+    # Upgrade pip itself
+    ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade pip
+
+    # Install rpyc
+    ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade rpyc
+}
+
 setup_linux()
 {
     sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
@@ -101,6 +118,7 @@ if [[ "$USER" == "travis" ]]; then
 #   setup_travis
     setup_ipv6
     setup_gdbserver
+    setup_rpyc
 elif [[ "$USER" == "shippable" ]]; then
     sudo apt-get update
     sudo apt-get install openssh-server gcc-multilib


### PR DESCRIPTION
I'm not sure why we need this magic version, but it's easier to change a URL than to figure It out.

This is currently blocking Travis CI builds, making them fail immediately.