### PR TITLE
[ssh] Minor enhancements

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -16,7 +16,7 @@ import time
 import types
 
 from pwnlib import term
-from pwnlib.context import context
+from pwnlib.context import context, LocalContext
 from pwnlib.log import Logger
 from pwnlib.log import getLogger
 from pwnlib.term import text
@@ -80,7 +80,7 @@ class ssh_channel(sock):
             process = context._encode(process)
 
         if process and wd:
-            process = b'cd ' + sh_string(wd) + b' >/dev/null 2>&1;' + process
+            process = b'cd ' + sh_string(wd) + b' &>/dev/null;' + process
 
         if process and env:
             for name, value in env.items():
@@ -1319,11 +1319,12 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         or attr.startswith('_'):
             raise AttributeError
 
+        @LocalContext
         def runner(*args):
             if len(args) == 1 and isinstance(args[0], (list, tuple)):
                 command = [attr] + args[0]
             else:
-                command = ' '.join((attr,) + args)
+                command = ' '.join((attr,) + tuple(map(six.ensure_str, args)))
 
             return self.run(command).recvall().strip()
         return runner


### PR DESCRIPTION
- ssh.runner() now accepts mixed bytes and strings, by forcing everything to a string
- ssh.runner() now takes e.g. log_level='debug' as a kwarg
- Simplify ">/dev/null 2>&1" into "&>/dev/null"
