### PR TITLE
Add more doctests for context module around handling verbosity

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -552,16 +552,16 @@ class ContextType(object):
 
         Example:
 
-            Note that only the ERROR statement outputs anything.
+            Let's assume the normal situation, where log_level is INFO.
+
+            >>> context.clear(log_level='info')
+
+            Note that only the log levels below ERROR do not print anything.
 
             >>> with context.quiet:
             ...     log.debug("DEBUG")
             ...     log.info("INFO")
             ...     log.warn("WARN")
-            ...     log.error("ERR") # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ...
-            PwnlibException: ERR
 
             Next let's try with the debugging level set to 'debug' before we
             enter the context handler:
@@ -571,11 +571,9 @@ class ContextType(object):
             ...         log.debug("DEBUG")
             ...         log.info("INFO")
             ...         log.warn("WARN")
-            ...         log.error("ERR") # doctest: +ELLIPSIS
             [DEBUG] DEBUG
             [*] INFO
             [!] WARN
-            [ERROR] ERR
         """
         level = 'error'
         if context.log_level <= logging.DEBUG:
@@ -592,7 +590,7 @@ class ContextType(object):
 
             >>> def loud(): log.info("Loud")
             >>> @context.quietfunc
-            >>> def quiet(): log.info("Quiet")
+            ... def quiet(): log.info("Quiet")
 
             If we set the logging level to 'info', the loud function
             prints its contents.
@@ -635,6 +633,7 @@ class ContextType(object):
 
             Note that the function does not emit any information by default
 
+            >>> context.clear()
             >>> def func(): log.debug("Hello")
             >>> func()
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -548,7 +548,35 @@ class ContextType(object):
     @property
     def quiet(self, function=None):
         """Disables all non-error logging within the enclosed scope,
-        *unless* the debugging level is set to 'debug' or lower."""
+        *unless* the debugging level is set to 'debug' or lower.
+
+        Example:
+
+            Note that only the ERROR statement outputs anything.
+
+            >>> with context.quiet:
+            ...     log.debug("DEBUG")
+            ...     log.info("INFO")
+            ...     log.warn("WARN")
+            ...     log.error("ERR") # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ...
+            PwnlibException: ERR
+
+            Next let's try with the debugging level set to 'debug' before we
+            enter the context handler:
+
+            >>> with context.local(log_level='debug'):
+            ...     with context.quiet:
+            ...         log.debug("DEBUG")
+            ...         log.info("INFO")
+            ...         log.warn("WARN")
+            ...         log.error("ERR") # doctest: +ELLIPSIS
+            [DEBUG] DEBUG
+            [*] INFO
+            [!] WARN
+            [ERROR] ERR
+        """
         level = 'error'
         if context.log_level <= logging.DEBUG:
             level = None
@@ -595,6 +623,27 @@ class ContextType(object):
     @property
     def verbose(self):
         """Enable all logging within the enclosed scope.
+
+        This is the opposite of :attr:`.quiet` and functionally equivalent to:
+
+        .. code-block:: python
+
+            with context.local(log_level='debug'):
+                ...
+
+        Example:
+
+            Note that the function does not emit any information by default
+
+            >>> def func(): log.debug("Hello")
+            >>> func()
+
+            But if we put it inside a :attr:`.verbose` context manager, the
+            information is printed.
+
+            >>> with context.verbose: func()
+            [DEBUG] Hello
+
         """
         return self.local(log_level='debug')
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -555,7 +555,33 @@ class ContextType(object):
         return self.local(function, log_level=level)
 
     def quietfunc(self, function):
-        """Similar to :attr:`quiet`, but wraps a whole function."""
+        """Similar to :attr:`quiet`, but wraps a whole function.
+
+        Example:
+
+            Let's set up two functions, which are the same but one is
+            wrapped with :attr:`quietfunc`.
+
+            >>> def loud(): log.info("Loud")
+            >>> @context.quietfunc
+            >>> def quiet(): log.info("Quiet")
+
+            If we set the logging level to 'info', the loud function
+            prints its contents.
+
+            >>> with context.local(log_level='info'): loud()
+            [*] Loud
+
+            However, the quiet function does not, since :attr:`quietfunc`
+            silences all output unless the log level is DEBUG.
+
+            >>> with context.local(log_level='info'): quiet()
+
+            Now let's try again with debugging enabled.
+
+            >>> with context.local(log_level='debug'): quiet()
+            [*] Quiet
+        """
         @functools.wraps(function)
         def wrapper(*a, **kw):
             level = 'error'


### PR DESCRIPTION
Specifically adds docs for:

- context.quiet
- context.quietfunc (which we should make more use of)
- context.verbose (which we should use to replace `context.local(log_level='debug')`