### PR TITLE
[gdb] Add a timeout to GDB faketerminal operations

### DIFF
--- a/pwnlib/gdb_faketerminal.py
+++ b/pwnlib/gdb_faketerminal.py
@@ -5,15 +5,15 @@ from sys import argv
 from os import environ
 sleep(1)
 if len(argv) == 2:
-    sh = process(argv[1], shell=True)
+    sh = process(argv[1], shell=True, timeout=30)
 else:
-    sh = process(argv[1:])
+    sh = process(argv[1:], timeout=30)
 sh.sendline('set prompt (gdb)')
 if environ.get('GDB_FAKETERMINAL') == '0':
     sh.sendline('set pagination off')
     sh.recvall()
 else:
     res = sh.sendlineafter('(gdb)', 'c')
-    while b'The program is not being run.' not in res:
+    while res and b'The program is not being run.' not in res:
         res = sh.sendlineafter('(gdb)', 'c')
 sh.close()


### PR DESCRIPTION
It seems that sometimes the GDB that we spawn gets stuck, or is in an infinite loop, or crashes.

This adds a 30 second timeout, so that CI builds don't completely get stuck / hung.
