### PR TITLE
Add colored_traceback for colorized exception tracebacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1780][1780] Re-add Python2 to the official Dockerfile
 - [#1941][1941] Disable all Android tests, `pwnlib.adb` is no longer supported in CI
 - [#1811][1811] Remove unnecessary `pwn.toplevel.__all__`
+- [#1841][1841] Add colored_traceback
 
 [1261]: https://github.com/Gallopsled/pwntools/pull/1261
 [1695]: https://github.com/Gallopsled/pwntools/pull/1695
@@ -79,7 +80,9 @@ The table below shows which release corresponds to each branch, and what date th
 [1758]: https://github.com/Gallopsled/pwntools/pull/1758
 [1780]: https://github.com/Gallopsled/pwntools/pull/1780
 [1941]: https://github.com/Gallopsled/pwntools/pull/1941
+
 [1811]: https://github.com/Gallopsled/pwntools/pull/1811
+[1841]: https://github.com/Gallopsled/pwntools/pull/1841
 
 ## 4.4.0 (`beta`)
 

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -17,6 +17,7 @@ import tempfile
 import threading
 import time
 
+import colored_traceback
 from pprint import pprint
 
 import pwnlib
@@ -82,6 +83,8 @@ warn    = log.warning
 info    = log.info
 debug   = log.debug
 success = log.success
+
+colored_traceback.add_hook()
 
 # Equivalence with the default behavior of "from import *"
 # __all__ = [x for x in tuple(globals()) if not x.startswith('_')]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'unicorn>=1.0.2rc1,<1.0.2rc4', # see unicorn-engine/unicorn#1100, unicorn-engine/unicorn#1170, Gallopsled/pwntools#1538
                         'six>=1.12.0',
                         'rpyc',
+                        'colored_traceback',
 ]
 
 # Check that the user has installed the Python development headers


### PR DESCRIPTION
Makes stack traces much more readable!

<img width="681" alt="Screen Shot 2021-03-04 at 9 52 02 PM" src="https://user-images.githubusercontent.com/66139157/110060766-6ae38880-7d34-11eb-85df-efd5e329bdff.png">
