### PR TITLE
Remove temporary folders created for assembling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.3.1 (`stable`)
 
+- [#1851][1851] Remove temporary folders created for assembling
 - [#1732][1732] Fix shellcraft SSTI vulnerability (first major pwntools vuln!)
 
 [1732]: https://github.com/Gallopsled/pwntools/pull/1732

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -610,7 +610,7 @@ def make_elf(data,
         log.exception("An error occurred while building an ELF:\n%s" % code)
     else:
         atexit.register(lambda: shutil.rmtree(tmpdir))
-
+    shutil.rmtree(tmpdir)
     return retval
 
 @LocalContext
@@ -717,7 +717,7 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
         log.exception("An error occurred while assembling:\n%s" % lines)
     else:
         atexit.register(lambda: shutil.rmtree(tmpdir))
-
+    shutil.rmtree(tmpdir)
     return result
 
 @LocalContext
@@ -810,7 +810,7 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
         log.exception("An error occurred while disassembling:\n%s" % data)
     else:
         atexit.register(lambda: shutil.rmtree(tmpdir))
-
+    shutil.rmtree(tmpdir)
 
     lines = []
     pattern = '^( *[0-9a-f]+: *)', '((?:[0-9a-f]+ )+ *)', '(.*)'


### PR DESCRIPTION
The current behaviour uses an atexit handler, which does not work.
There seems to be no reason to wait until exit to remove these
temporary directories, so this removes them at the conclusion
of the function.

Workaround for the issue in #1850 