### PR TITLE
add self.message and change sys.exc_type to sys.exec_info() in Pwnlib…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1753][1753] major change: less unconditional imports in pwnlib
 - [#1776][1776] mips: do not use $t0 temporary variable in dupio
 - [#1846][1846] support launching GDB in more different terminals
+- [#1876][1876] add `self.message` and change `sys.exc_type` to `sys.exec_info()` in PwnlibException
 
 [1429]: https://github.com/Gallopsled/pwntools/pull/1429
 [1566]: https://github.com/Gallopsled/pwntools/pull/1566
@@ -80,6 +81,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1753]: https://github.com/Gallopsled/pwntools/pull/1753
 [1776]: https://github.com/Gallopsled/pwntools/pull/1776
 [1846]: https://github.com/Gallopsled/pwntools/pull/1846
+[1876]: https://github.com/Gallopsled/pwntools/pull/1876
 
 ## 4.6.0 (`beta`)
 

--- a/pwnlib/exception.py
+++ b/pwnlib/exception.py
@@ -20,7 +20,7 @@ class PwnlibException(Exception):
         if self.reason:
             s += '\nReason:\n'
             s += ''.join(traceback.format_exception(*self.reason))
-        elif sys.exc_info() not in [None, KeyboardInterrupt]:
+        elif sys.exc_info()[0] not in [None, KeyboardInterrupt]:
             s += '\n'
             s += ''.join(traceback.format_exc())
         return s

--- a/pwnlib/exception.py
+++ b/pwnlib/exception.py
@@ -13,13 +13,14 @@ class PwnlibException(Exception):
         Exception.__init__(self, msg)
         self.reason = reason
         self.exit_code = exit_code
+        self.message = msg
 
     def __repr__(self):
         s = 'PwnlibException: %s' % self.message
         if self.reason:
             s += '\nReason:\n'
             s += ''.join(traceback.format_exception(*self.reason))
-        elif sys.exc_type not in [None, KeyboardInterrupt]:
+        elif sys.exc_info() not in [None, KeyboardInterrupt]:
             s += '\n'
             s += ''.join(traceback.format_exc())
         return s


### PR DESCRIPTION
Fixes an issue where a `PwnlibException` object cannot be passed to `repr`.

Changes:
* set `self.message` and change `sys.exc_type` to `sys.exc_info()` in `PwnlibException` class. A raised `PwnlibException`  object can now be passed to `repr`

Bug behavior referenced in #1875 as `Wierd behavior 2`