### PR TITLE
encoders: support `avoid == bytes` in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1753][1753] major change: less unconditional imports in pwnlib
 - [#1776][1776] mips: do not use $t0 temporary variable in dupio
 - [#1846][1846] support launching GDB in more different terminals
+- [#1877][1877] encoders error message handles when `avoid` is bytes in python3
 
 [1429]: https://github.com/Gallopsled/pwntools/pull/1429
 [1566]: https://github.com/Gallopsled/pwntools/pull/1566
@@ -80,6 +81,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1753]: https://github.com/Gallopsled/pwntools/pull/1753
 [1776]: https://github.com/Gallopsled/pwntools/pull/1776
 [1846]: https://github.com/Gallopsled/pwntools/pull/1846
+[1877]: https://github.com/Gallopsled/pwntools/pull/1877
 
 ## 4.6.0 (`beta`)
 

--- a/pwnlib/encoders/encoder.py
+++ b/pwnlib/encoders/encoder.py
@@ -97,7 +97,7 @@ def encode(raw_bytes, avoid=None, expr=None, force=0, pcreg=''):
     elif expr:
         avoid_errmsg = repr(expr)
     else:
-        avoid_errmsg = ''.join(repr(avoid))
+        avoid_errmsg = repr(bytes(avoid))
 
     args = (context.arch, avoid_errmsg, hexdump(raw_bytes))
     msg = "No encoders for %s which can avoid %s for\n%s" % args

--- a/pwnlib/encoders/encoder.py
+++ b/pwnlib/encoders/encoder.py
@@ -97,7 +97,7 @@ def encode(raw_bytes, avoid=None, expr=None, force=0, pcreg=''):
     elif expr:
         avoid_errmsg = repr(expr)
     else:
-        avoid_errmsg = ''.join(avoid)
+        avoid_errmsg = ''.join(repr(avoid))
 
     args = (context.arch, avoid_errmsg, hexdump(raw_bytes))
     msg = "No encoders for %s which can avoid %s for\n%s" % args


### PR DESCRIPTION
Mention'd in #1875. Python3 specific

Fixes an issue where encoder error message raises an exception when `avoid` is bytes like so:

`encode(sc, avoid='\x01')` vs `encode(sc, avoid=b'\x01')`