### PR TITLE
Change the regex for the rop verifier to handle 2 character registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1839][1839] run_in_new_terminal now creates a runner script if given a list or tuple
 - [#1833][1833] Add pwnlib.filesystem module
 - [#1852][1852] Fix `atexit` on Python 3
+- [#1883][1883] ROP gadget verifier accounts for 2 character registers
 
 [1261]: https://github.com/Gallopsled/pwntools/pull/1261
 [1695]: https://github.com/Gallopsled/pwntools/pull/1695
@@ -123,6 +124,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1839]: https://github.com/Gallopsled/pwntools/pull/1839
 [1833]:  https://github.com/Gallopsled/pwntools/pull/1833
 [1852]: https://github.com/Gallopsled/pwntools/pull/1852
+[1883]: https://github.com/Gallopsled/pwntools/pull/1883
 
 ## 4.4.0
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1194,7 +1194,7 @@ class ROP(object):
         # https://github.com/JonathanSalwan/ROPgadget/issues/53
         #
 
-        pop   = re.compile(r'^pop (.{3})')
+        pop   = re.compile(r'^pop (.{2,3})')
         add   = re.compile(r'^add [er]sp, ((?:0[xX])?[0-9a-fA-F]+)$')
         ret   = re.compile(r'^ret$')
         leave = re.compile(r'^leave$')


### PR DESCRIPTION
# Pwntools Pull Request

This is a fix for #1883 where the register verification regex is too limiting.

## Target Branch

`stable` Bug fixes that affect the current `stable` branch