### PR TITLE
call() and raw() return self for method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1733][1733] Update libc headers -> more syscalls available!
 - [#1876][1876] add `self.message` and change `sys.exc_type` to `sys.exec_info()` in PwnlibException
 - [#1877][1877] encoders error message handles when `avoid` is bytes in python3
+- [#1890][1890] `call()` and `raw()` return `self` for method chaining
 
 [1733]: https://github.com/Gallopsled/pwntools/pull/1733
 [1876]: https://github.com/Gallopsled/pwntools/pull/1876

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -597,7 +597,7 @@ class ROP(object):
         regset = set(registers)
 
         bad_instructions = set(('syscall', 'sysenter', 'int 0x80'))
-
+        
         # Collect all gadgets which use these registers
         # Also collect the "best" gadget for each combination of registers
         gadgets = []
@@ -974,7 +974,7 @@ class ROP(object):
 
     def chain(self, base=None):
         """Build the ROP chain
-
+        
         Arguments:
             base(int):
                 The base address to build the rop-chain from. Defaults to
@@ -987,7 +987,7 @@ class ROP(object):
 
     def dump(self, base=None):
         """Dump the ROP chain in an easy-to-read manner
-
+        
         Arguments:
             base(int):
                 The base address to build the rop-chain from. Defaults to

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -597,7 +597,7 @@ class ROP(object):
         regset = set(registers)
 
         bad_instructions = set(('syscall', 'sysenter', 'int 0x80'))
-        
+
         # Collect all gadgets which use these registers
         # Also collect the "best" gadget for each combination of registers
         gadgets = []
@@ -974,7 +974,7 @@ class ROP(object):
 
     def chain(self, base=None):
         """Build the ROP chain
-        
+
         Arguments:
             base(int):
                 The base address to build the rop-chain from. Defaults to
@@ -987,7 +987,7 @@ class ROP(object):
 
     def dump(self, base=None):
         """Dump the ROP chain in an easy-to-read manner
-        
+
         Arguments:
             base(int):
                 The base address to build the rop-chain from. Defaults to
@@ -1031,6 +1031,8 @@ class ROP(object):
         # Otherwise, if it is a syscall we might be able to call it
         elif not self._srop_call(resolvable, arguments):
             log.error('Could not resolve %r.' % resolvable)
+
+        return self
 
 
 
@@ -1124,6 +1126,7 @@ class ROP(object):
         if self.migrated:
             log.error('Cannot append to a migrated chain')
         self._chain.append(value)
+        return self
 
     def migrate(self, next_base):
         """Explicitly set $sp, by using a ``leave; ret`` gadget"""


### PR DESCRIPTION
# Pwntools Pull Request

I want to chain `call()` and `raw()` like so:

```
rop.call(rdi).raw(addr)
```

This allows for formatting the code to be a bit similar to assembly syntax, making scripts more readable. It also allows for building a ROP chain in a single line, which is nice.
