### PR TITLE
Keep gadgets when setting registers via setattr/call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1903][1903] Add zsh completion script
 - [#1904][1904] Add bash completion script
 - [#1906][1906] Defer import of several modules to save on startup time
+- [#1891][1891] Keep ROP gadgets when setting registers via setattr/call
 
 [1733]: https://github.com/Gallopsled/pwntools/pull/1733
 [1876]: https://github.com/Gallopsled/pwntools/pull/1876
@@ -79,6 +80,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1903]: https://github.com/Gallopsled/pwntools/pull/1903
 [1904]: https://github.com/Gallopsled/pwntools/pull/1904
 [1906]: https://github.com/Gallopsled/pwntools/pull/1906
+[1891]: https://github.com/Gallopsled/pwntools/pull/1891
 
 ## 4.6.0 (`beta`)
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -720,21 +720,24 @@ class ROP(object):
         >>> r = ROP(e)
         >>> r(rax=0xdead, rdi=0xbeef, rsi=0xcafe)
         >>> print(r.dump())
-        0x0000:       0x10000000
+        0x0000:       0x10000000 pop rax; pop rdi; pop rsi; ret
         0x0008:           0xdead
         0x0010:           0xbeef
         0x0018:           0xcafe
         >>> r = ROP(e)
         >>> r({'rax': 0xdead, 'rdi': 0xbeef, 'rsi': 0xcafe})
         >>> print(r.dump())
-        0x0000:       0x10000000
+        0x0000:       0x10000000 pop rax; pop rdi; pop rsi; ret
         0x0008:           0xdead
         0x0010:           0xbeef
         0x0018:           0xcafe
         """
         if len(args) == 1 and isinstance(args[0], dict):
-            for value, _ in self.setRegisters(args[0]):
-                self.raw(value)
+            for value, name in self.setRegisters(args[0]):
+                if isinstance(name, Gadget):
+                    self.raw(name)
+                else:
+                    self.raw(value)
         else:
             self(kwargs)
 


### PR DESCRIPTION
Adding the gadgets to the chain (instead of their address) generates slightly better descriptions when the gadget corresponds to a symbol (and avoids having to go through `unresolve`).

To take the example from the doctest in `__call__`:

        >>> context.clear(arch='amd64')
        >>> assembly = 'pop rax; pop rdi; pop rsi; ret; pop rax; ret;'
        >>> e = ELF.from_assembly(assembly)
        >>> r = ROP(e)
        >>> r(rax=0xdead, rdi=0xbeef, rsi=0xcafe)
        >>> print(r.dump())
        0x0000:       0x10000000 pop rax; pop rdi; pop rsi; ret
        0x0008:           0xdead
        0x0010:           0xbeef
        0x0018:           0xcafe

The first item in the chain previously had no description, because there is an unnamed symbol with that address.