### PR TITLE
Library fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.5.1 (`stable`)
 
+- [#1911][1911] Use `ld` to retrieve libraries for ELF files
 - [#1902][1902] Always specify -F and -P for tmux in run_in_new_termianl
 
 [1902]: https://github.com/Gallopsled/pwntools/pull/1902


### PR DESCRIPTION
This is a (partial) fix for #1871. Executing the ELF with this environment flag causes it to instead print the loaded object files. This is the approach used by `ldd`. However, it has the disadvantage of not returning *all* the mappings of procfs (i.e. heap, stack, the binary itself).