### PR TITLE
Add a few lines to solve muitiple thread bryteforce bugs on Macos with python version >= 3.8

### DIFF
--- a/pwnlib/util/iters.py
+++ b/pwnlib/util/iters.py
@@ -7,6 +7,9 @@ from __future__ import division
 import collections
 import copy
 import multiprocessing
+import sys
+if sys.platform == "darwin" and sys.version_info>=(3,8) : # fix bugs about multiprocessing  in Macos with python version bigger or equal than 3.8, see #1665
+    multiprocessing.set_start_method('fork')    
 import operator
 import random
 import time


### PR DESCRIPTION
It is a dirty hack to fix this issue #1665   in macos with python version after 3.8. The reason is that multiprocessing use “fork” by default before 3.7（So no bus in 3.7）. But it use “spawn” by default ( Of course for security reasons)after python3.8 , which causes the issue.So it is needed to expilicitly set the method to "fork" instead of "spawn".
So, let's use this method temporarily.At least it solves the problem.

See https://chrissardegna.com/blog/multiprocessing-changes-python-3-8/#python-38-safety-on-macos
and https://docs.python.org/3/library/multiprocessing.html


