### PR TITLE
Check binutils version is GNU or Clang

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -249,8 +249,12 @@ def _assembler():
         checked_assembler_version[gas] = True
         result = subprocess.check_output([gas, '--version','/dev/null'],
                                          stderr=subprocess.STDOUT, universal_newlines=True)
-        version = re.search(r' (\d\.\d+)', result).group(1)
-        if version < '2.19':
+        version = re.search(r' (\d+\.\d+)', result).group(1)
+        if 'clang' in result:
+            log.warn_once('Your binutils is clang version and may not work!\n'
+                'Try install with: https://docs.pwntools.com/en/stable/install/binutils.html\n'
+                'Reported Version: %r', result.strip())
+        elif version < '2.19':
             log.warn_once('Your binutils version is too old and may not work!\n'
                 'Try updating with: https://docs.pwntools.com/en/stable/install/binutils.html\n'
                 'Reported Version: %r', result.strip())


### PR DESCRIPTION
Currently, it only checks for the GNU version (e.g., `GNU assembler 2.34`).

It will cause an error for the macOS clang version.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/pwnlib/context/__init__.py", line 1449, in setter
    return function(*a, **kw)
  File "/usr/local/lib/python3.9/site-packages/pwnlib/asm.py", line 666, in asm
    assembler = _assembler()
  File "/usr/local/lib/python3.9/site-packages/pwnlib/asm.py", line 252, in _assembler
    version = re.search(r' (\d\.\d+)', result).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

Because clang version number doesn't match ` \d\.\d+` rule.
```
$ as --version
Apple clang version 12.0.5 (clang-1205.0.22.9)
Target: x86_64-apple-darwin20.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

This PR allows more than one digit in major version number and warn for clang version.