### PR TITLE
Added basic support for bare-metal ARM by adding pattern for finding binutils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,24 +65,26 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1733][1733] Update libc headers -> more syscalls available!
 - [#1876][1876] add `self.message` and change `sys.exc_type` to `sys.exec_info()` in PwnlibException
 - [#1877][1877] encoders error message handles when `avoid` is bytes in python3
+- [#1891][1891] Keep ROP gadgets when setting registers via setattr/call
 - [#1892][1892] Silence SIGPIPE error for "pwn phd"
 - [#1893][1893] Fix bytes warning in "pwn cyclic"
 - [#1897][1897] Add basic support for RISC-V
 - [#1903][1903] Add zsh completion script
 - [#1904][1904] Add bash completion script
 - [#1906][1906] Defer import of several modules to save on startup time
-- [#1891][1891] Keep ROP gadgets when setting registers via setattr/call
+- [#1921][1921] Add basic support for the bare-metal ARM specific toolchain
 
 [1733]: https://github.com/Gallopsled/pwntools/pull/1733
 [1876]: https://github.com/Gallopsled/pwntools/pull/1876
 [1877]: https://github.com/Gallopsled/pwntools/pull/1877
+[1891]: https://github.com/Gallopsled/pwntools/pull/1891
 [1892]: https://github.com/Gallopsled/pwntools/pull/1892
 [1893]: https://github.com/Gallopsled/pwntools/pull/1893
 [1897]: https://github.com/Gallopsled/pwntools/pull/1897
 [1903]: https://github.com/Gallopsled/pwntools/pull/1903
 [1904]: https://github.com/Gallopsled/pwntools/pull/1904
 [1906]: https://github.com/Gallopsled/pwntools/pull/1906
-[1891]: https://github.com/Gallopsled/pwntools/pull/1891
+[1921]: https://github.com/Gallopsled/pwntools/pull/1921
 
 ## 4.6.0 (`beta`)
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -199,6 +199,7 @@ def which_binutils(util):
             else:
                 patterns = ['%s*linux*-%s' % (arch, gutil),
                             '%s*-elf-%s' % (arch, gutil),
+                            '%s-none*-%s' % (arch, gutil),
                             '%s-%s' % (arch, gutil)]
 
             for pattern in patterns:


### PR DESCRIPTION
# Pwntools Pull Request

## High Level Explanation

Added a pattern in `which_binutils()` for finding bare-metal arm specific binutils. Previously, if this was installed but neither of the Linux ARM toolchain was not installed, then it wouldn't be able to find the utilities necessary for pwntools to work. 

## Testing

From what I have seen, this didn't break any of the existing tests. I can create a new one if necessary. 

## Target Branch

The target branch for this will be `dev` as this is an enhancing the support for `bare-metal ARM`. 

