### PR TITLE
Fix MIPS PLT on newer Unicorn versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ install_requires     = ['paramiko>=1.15.2',
                         'psutil>=3.3.0',
                         'intervaltree>=3.0',
                         'sortedcontainers',
-                        'unicorn>=1.0.2rc1,<1.0.2rc4', # see unicorn-engine/unicorn#1100, unicorn-engine/unicorn#1170, Gallopsled/pwntools#1538
+                        # see unicorn-engine/unicorn#1100 and #1170
+                        'unicorn>=1.0.2rc1',
                         'six>=1.12.0',
                         'rpyc',
                         'colored_traceback',


### PR DESCRIPTION
Apparently it is us who used unicorn The Wrong Way,
e.g. trying to fetch instructions @ 0xdbdbdbdb,
which is both unaligned and high-address-space.
Unicorn just changed the exception to throw exception with the address
of an offending jump instruction, instead of the incorrect address.
Making the debugs actually work and changing address to 0x7c7c7c7c
solves the issue.

Closes #1538
Ping pentoo/pentoo-overlay#734 @blshkv