### PR TITLE
Fix for hanging on "Waiting for debugger" after calling gdb.attach

### DIFF
--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -333,7 +333,7 @@ def wait_for_debugger(pid, debugger_pid=None):
     t = Timeout()
     with t.countdown(timeout=15):
         with log.waitfor('Waiting for debugger') as l:
-            while debugger_pid:
+            while debugger_pid and tracer(pid) is None:
                 debugger = psutil.Process(debugger_pid)
                 while t.timeout and tracer(pid) is None:
                     try:


### PR DESCRIPTION
Steps to reproduce issue:
>>from pwn import *
>>proc = process('bash')
>>gdb.attach(proc)

Without the above changes the first terminal will hang on the "Waiting for debugger line" .
See comments in the PR where issue is discussed #1717 