### PR TITLE
Fix: TypeError: can't concat str to bytes

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -81,7 +81,7 @@ class ssh_channel(sock):
             process = packing._need_bytes(process, 2, 0x80)
 
         if process and wd:
-            process = b'cd ' + sh_string(wd) + b' >/dev/null 2>&1; ' + process
+            process = b'cd ' + sh_string(wd).encode('utf-8') + b' >/dev/null 2>&1; ' + process
 
         if process and env:
             for name, value in env.items():
@@ -1836,7 +1836,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 self.error("Could not generate a temporary directory (%i)\n%s" % (status, wd))
 
         else:
-            cmd = b'ls ' + sh_string(wd)
+            cmd = 'ls ' + sh_string(wd)
             _, status = self.run_to_end(cmd, wd = '.')
 
             if status:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -81,7 +81,7 @@ class ssh_channel(sock):
             process = packing._need_bytes(process, 2, 0x80)
 
         if process and wd:
-            process = b'cd ' + sh_string(packing._need_bytes(wd, 2, 0x80)) + b' >/dev/null 2>&1; ' + packing._need_bytes(process, 2, 0x80)
+            process = b'cd ' + sh_string(wd) + b' >/dev/null 2>&1; ' + process
 
         if process and env:
             for name, value in env.items():
@@ -1827,6 +1827,9 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             symlink = os.path.join(self.pwd(), b'*')
         if not hasattr(symlink, 'encode') and hasattr(symlink, 'decode'):
             symlink = symlink.decode('utf-8')
+            
+        if isinstance(wd, six.text_type):
+            wd = packing._need_bytes(wd, 2, 0x80)
 
         if not wd:
             wd, status = self.run_to_end('x=$(mktemp -d) && cd $x && chmod +x . && echo $PWD', wd='.')
@@ -1836,7 +1839,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 self.error("Could not generate a temporary directory (%i)\n%s" % (status, wd))
 
         else:
-            cmd = b'ls ' + sh_string(packing._need_bytes(wd, 2, 0x80))
+            cmd = b'ls ' + sh_string(wd)
             _, status = self.run_to_end(cmd, wd = '.')
 
             if status:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1836,7 +1836,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 self.error("Could not generate a temporary directory (%i)\n%s" % (status, wd))
 
         else:
-            cmd = 'ls ' + sh_string(wd)
+            cmd = b'ls ' + sh_string(packing._need_bytes(wd, 2, 0x80))
             _, status = self.run_to_end(cmd, wd = '.')
 
             if status:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -81,7 +81,7 @@ class ssh_channel(sock):
             process = packing._need_bytes(process, 2, 0x80)
 
         if process and wd:
-            process = b'cd ' + sh_string(wd).encode('utf-8') + b' >/dev/null 2>&1; ' + process
+            process = b'cd ' + packing._need_bytes(sh_string(wd), 2, 0x80) + b' >/dev/null 2>&1; ' + packing._need_bytes(process, 2, 0x80)
 
         if process and env:
             for name, value in env.items():

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -81,7 +81,7 @@ class ssh_channel(sock):
             process = packing._need_bytes(process, 2, 0x80)
 
         if process and wd:
-            process = b'cd ' + packing._need_bytes(sh_string(wd), 2, 0x80) + b' >/dev/null 2>&1; ' + packing._need_bytes(process, 2, 0x80)
+            process = b'cd ' + sh_string(packing._need_bytes(wd, 2, 0x80)) + b' >/dev/null 2>&1; ' + packing._need_bytes(process, 2, 0x80)
 
         if process and env:
             for name, value in env.items():


### PR DESCRIPTION
sh_string returns a string, but two lines in the `ssh.py` try to concat it with bytes, which throws a TypeError.  Either convert them all to bytes or all to string.

## Testing

This is more of a bug fix for an error.  You can test the error easily enough by doing this in Python3, which is what one of the lines fixes.

```
from pwnlib.util import sh_string
cmd = b'ls' + sh_string("test")
```

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `stable` | Bug fixes that affect the current `stable` branch

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request

## Changelog

I'm not aware that the issue has been reported, but I ran into it while trying to do something like this...  So not sure if you do a changelog for each minor bug fix as I don't follow the repo.  But figured you can add it if you want.
```
if shell is not None:
    shell.set_working_directory(os.path.dirname(remote_path))
```
