### PR TITLE
Fix download_dir method when using an ssh tube

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1523,29 +1523,24 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             local: Local directory
             remote: Remote directory
         """
-        remote   = remote or self.cwd
-
+        remote = packing._encode(remote or self.cwd)
 
         if self.sftp:
-            remote = str(self.sftp.normalize(remote))
+            remote = packing._encode(self.sftp.normalize(remote))
         else:
             with context.local(log_level='error'):
-                remote = self.system('readlink -f ' + sh_string(remote))
+                remote = self.system(b'readlink -f ' + sh_string(remote))
 
-        basename = os.path.basename(remote)
+        local = local or '.'
+        local = os.path.expanduser(local)
 
-
-        local    = local or '.'
-        local    = os.path.expanduser(local)
-
-        self.info("Downloading %r to %r" % (basename,local))
+        self.info("Downloading %r to %r" % (remote, local))
 
         with context.local(log_level='error'):
             remote_tar = self.mktemp()
-            cmd = 'tar -C %s -czf %s %s' % \
+            cmd = b'tar -C %s -czf %s .' % \
                   (sh_string(remote),
-                   sh_string(remote_tar),
-                   sh_string(basename))
+                   sh_string(remote_tar))
             tar = self.system(cmd)
 
             if 0 != tar.wait():
@@ -1686,10 +1681,8 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             local(str): Local path to store the data.
                 By default, uses the current directory.
         """
-        if not self.sftp:
-            self.error("Cannot determine remote file type without SFTP")
-
-        with self.system('test -d ' + sh_string(file_or_directory)) as io:
+        file_or_directory = packing._encode(file_or_directory)
+        with self.system(b'test -d ' + sh_string(file_or_directory)) as io:
             is_dir = io.wait()
 
         if 0 == is_dir:


### PR DESCRIPTION
Hi, I think I have found a bug in the method `download_dir` when using an ssh tube.

There are 2 problems:

1. The `cmd` string is not well-formatted because the type of the variable `remote_tar` is `bytes` while `cmd` is `str`. Using the string formatting here makes the representation `b'<value_of_remote_str>'` ending up inside `cmd`.

2.  The tar command first changes the directory to the target folder `remote` using the option `-C` and then it tries to compress the basename of `remote`.  This makes the command fail because the basename won't exist anymore after changing directory.

To put into an example: I was trying to download the directory `/tmp/pit` on my remote system using the `download_dir('/tmp/pit', local='/tmp/dump')`. The current version of the method generates `cmd` as `tar -C /tmp/pit -czf b'tmp_1234' pit` (assuming `remote_tar == b'tmp_1234`). Tar will then error out because `pit` does not exist inside `/tmp/pit` and because the name of the tartget `tar.gz` is not well formatted.

This PR solves these 2 issues.

Signed-off-by: Sebastiano Mariani <smariani@vmware.com>