### PR TITLE
Fix #1966: Add arch alias: x86-64 -> amd64

### DIFF
--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -762,6 +762,7 @@ class ContextType(object):
         # We have to make sure that x86_64 appears before x86 for this to work correctly.
         transform = [('ppc64', 'powerpc64'),
                      ('ppc', 'powerpc'),
+                     ('x86-64', 'amd64'),
                      ('x86_64', 'amd64'),
                      ('x86', 'i386'),
                      ('i686', 'i386'),


### PR DESCRIPTION
While we have an alias for "x86_64" some software (like Pwndbg) uses the "x86-64" string.
