### PR TITLE
Make commandline unhex tool accept '0x' prefixed hex strings

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -37,6 +37,7 @@ def unhex(s):
         b'\x0f'
     """
     s = s.strip()
+    s = s.lstrip("0x")
     if len(s) % 2 != 0:
         s = '0' + s
     return binascii.unhexlify(s)


### PR DESCRIPTION
This is a quality of life improvement making converting extracted hex strings
to character strings using `pwn unhex` more comfortable. I was annoyed by always having to remove
the "0x" prefix before using this tool.

# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
