### PR TITLE
Make ELF symbol dict accept bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,13 @@ The table below shows which release corresponds to each branch, and what date th
 [1939]: https://github.com/Gallopsled/pwntools/pull/1939
 [1981]: https://github.com/Gallopsled/pwntools/pull/1981
 
-## 4.7.0 (`stable`)
+## 4.7.1 (`stable`)
+
+- [#1973][1973] ELF symbols can be looked up by bytes values
+
+[1973]: https://github.com/Gallopsled/pwntools/pull/1973
+
+## 4.7.0
 
 - [#1733][1733] Update libc headers -> more syscalls available!
 - [#1876][1876] add `self.message` and change `sys.exc_type` to `sys.exec_info()` in PwnlibException

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -157,6 +157,12 @@ class dotdict(dict):
         >>> x.bar.baz
         4
     """
+    def __missing__(self, name):
+        if isinstance(name, (bytes, bytearray)):
+            name = packing._decode(name)
+            return self[name]
+        raise KeyError(name)
+
     def __getattr__(self, name):
         if name in self:
             return self[name]


### PR DESCRIPTION
# Pwntools Pull Request

Resolves #1951 DynElf symbol lookup uses string as key for a string-key dictionary now
