### PR TITLE
Make cyclic_find work with large int values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1922][1922] Fix logic in `wait_for_debugger`
 - [#1828][1828] libcdb: Load debug info and unstrip libc binary
 - [#1939][1939] Fix error in validating log levels
+- [#1981][1981] Fix `cyclic_find()` to make it work with large int values
 
 [1922]: https://github.com/Gallopsled/pwntools/pull/1922
 [1828]: https://github.com/Gallopsled/pwntools/pull/1828
 [1939]: https://github.com/Gallopsled/pwntools/pull/1939
+[1981]: https://github.com/Gallopsled/pwntools/pull/1981
 
 ## 4.7.0 (`beta`)
 

--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -221,10 +221,10 @@ def cyclic_find(subseq, alphabet = None, n = None):
         if subseq >= 2**(8*n):
             # Assumption: The user has given an integer that is more than 2**(8n) bits, but would otherwise fit within
             #  a register of size 2**(8m) where m is a multiple of four
-            notice = ("cyclic_find() expected an integer argument < {cap:#x}, you gave {gave:#x}\n"
+            notice = ("cyclic_find() expected an integer argument <= {cap:#x}, you gave {gave:#x}\n"
                       "Unless you specified cyclic(..., n={fits}), you probably just want the first {n} bytes.\n"
                       "Truncating the data at {n} bytes.  Specify cyclic_find(..., n={fits}) to override this.").format(
-                cap=2**(8*n),
+                cap=2**(8*n)-1,
                 gave=subseq,
                 # The number of bytes needed to represent subseq, rounded to the next 4
                 fits=int(round(float(subseq.bit_length()) / 32 + 0.5) * 32) // 8,

--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -197,6 +197,16 @@ def cyclic_find(subseq, alphabet = None, n = None):
         >>> cyclic_find(0x61616162, endian='big')
         1
 
+        Similarly to the case where you can provide a bytes value that is longer
+        than four bytes, you can provided an integer value that is larger than
+        what can be held in four bytes. If such a large value is given, it is
+        automatically truncated.
+
+        >>> cyclic_find(0x6161616361616162)
+        4
+        >>> cyclic_find(0x6261616163616161, endian='big')
+        4
+
         You can use anything for the cyclic pattern, including non-printable
         characters.
 
@@ -208,14 +218,32 @@ def cyclic_find(subseq, alphabet = None, n = None):
         n = context.cyclic_size
 
     if isinstance(subseq, six.integer_types):
+        if subseq >= 2**(8*n):
+            # Assumption: The user has given an integer that is more than 2**(8n) bits, but would otherwise fit within
+            #  a register of size 2**(8m) where m is a multiple of four
+            notice = ("cyclic_find() expected an integer argument < {cap:#x}, you gave {gave:#x}\n"
+                      "Unless you specified cyclic(..., n={fits}), you probably just want the first {n} bytes.\n"
+                      "Truncating the data at {n} bytes.  Specify cyclic_find(..., n={fits}) to override this.").format(
+                cap=2**(8*n),
+                gave=subseq,
+                # The number of bytes needed to represent subseq, rounded to the next 4
+                fits=int(round(float(subseq.bit_length()) / 32 + 0.5) * 32) // 8,
+                n=n,
+            )
+            log.warn_once(notice)
+            if context.endian == 'little':
+                subseq &= 2**(8*n) - 1
+            else:
+                while subseq >= 2**(8*n):
+                    subseq >>= 8*n
         subseq = packing.pack(subseq, bytes=n)
     subseq = packing._need_bytes(subseq, 2, 0x80)
 
     if len(subseq) != n:
-        log.warn_once("cyclic_find() expects %i-byte subsequences by default, you gave %r\n"
-            "Unless you specified cyclic(..., n=%i), you probably just want the first 4 bytes.\n"
-            "Truncating the data at 4 bytes.  Specify cyclic_find(..., n=%i) to override this.",
-            n, subseq, len(subseq), len(subseq))
+        log.warn_once("cyclic_find() expected a %i-byte subsequence, you gave %r\n"
+            "Unless you specified cyclic(..., n=%i), you probably just want the first %d bytes.\n"
+            "Truncating the data at %d bytes.  Specify cyclic_find(..., n=%i) to override this.",
+            n, subseq, len(subseq), n, n, len(subseq))
         subseq = subseq[:n]
 
     if alphabet is None:


### PR DESCRIPTION
This resolves #1965 by making `cyclic_find()` work with integers larger than what could fit in n bytes.

It does so by truncating the integer value, similarly to how `cyclic_find()` has been truncating long bytes-type values. It honours `context.endianness` in its truncation.

I also tidied up the warning in the case of overly long bytes-type values. It was printing `4` instead of pulling from `n`.

# Demo

Old behavior:

```plain
>>> import pwn

>>> pwn.cyclic_find(b"baaa")
4

>>> pwn.cyclic_find(b"baaacaaa")
[!] cyclic_find() expects 4-byte subsequences by default, you gave b'baaacaaa'
    Unless you specified cyclic(..., n=8), you probably just want the first 4 bytes.
    Truncating the data at 4 bytes.  Specify cyclic_find(..., n=8) to override this.
4

>>> pwn.cyclic_find(pwn.u32(b"baaa"))
4

>>> pwn.cyclic_find(pwn.u64(b"baaacaaa"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/pwntools/pwnlib/context/__init__.py", line 1547, in setter
    return function(*a, **kw)
  File "/opt/pwntools/pwnlib/util/cyclic.py", line 211, in cyclic_find
    subseq = packing.pack(subseq, bytes=n)
  File "/opt/pwntools/pwnlib/util/packing.py", line 149, in pack
    raise ValueError("pack(): number does not fit within word_size [%i, %r, %r]" % (0, number, limit))
ValueError: pack(): number does not fit within word_size [0, 7016996773883371874, 4294967296]
```

Even setting `endian.context` doesn't resolve it:

```plain
>>> with pwn.context.local(arch="amd64"):
...   pwn.cyclic_find(pwn.u64(b"baaacaaa"))
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/opt/pwntools/pwnlib/context/__init__.py", line 1547, in setter
    return function(*a, **kw)
  File "/opt/pwntools/pwnlib/util/cyclic.py", line 211, in cyclic_find
    subseq = packing.pack(subseq, bytes=n)
  File "/opt/pwntools/pwnlib/util/packing.py", line 149, in pack
    raise ValueError("pack(): number does not fit within word_size [%i, %r, %r]" % (0, number, limit))
ValueError: pack(): number does not fit within word_size [0, 7016996773883371874, 4294967296]
```

New behavior:

```plain
>>> import pwn

>>> pwn.cyclic_find(b"baaa")
4

>>> pwn.cyclic_find(b"baaacaaa")
[!] cyclic_find() expected a 4-byte subsequence, you gave b'baaacaaa'
    Unless you specified cyclic(..., n=8), you probably just want the first 4 bytes.
    Truncating the data at 4 bytes.  Specify cyclic_find(..., n=8) to override this.
4

>>> pwn.cyclic_find(pwn.u32(b"baaa"))
4

>>> pwn.cyclic_find(pwn.u64(b"baaacaaa"))
[!] cyclic_find() expected an integer argument < 0x100000000, you gave 0x6161616361616162
    Unless you specified cyclic(..., n=8), you probably just want the first 4 bytes.
    Truncating the data at 4 bytes.  Specify cyclic_find(..., n=8) to override this.
4

>>> pwn.cyclic_find(pwn.u64(b"baaacaaa", endian="big"), endian="big")
[!] cyclic_find() expected an integer argument < 0x100000000, you gave 0x6261616163616161
    Unless you specified cyclic(..., n=8), you probably just want the first 4 bytes.
    Truncating the data at 4 bytes.  Specify cyclic_find(..., n=8) to override this.
4

```

While I filed #1965 as a bug, I'm not sure this warrants backporting to stable. It is behaviour that has been completely blowing up on users so far, so they'd be used to routing around it.