### PR TITLE
Fix typing in hexdump docstring

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -765,7 +765,7 @@ def hexdump(s, width=16, skip=True, hexii=False, begin=0, style=None,
     Return a hexdump-dump of a string.
 
     Arguments:
-        s(str): The data to hexdump.
+        s(bytes): The data to hexdump.
         width(int): The number of characters per line
         groupsize(int): The number of characters per group
         skip(bool): Set to True, if repeated lines should be replaced by a "*"


### PR DESCRIPTION
When calling `hexdump()` with a string-type `s` you get a BytesWarning:

```
>>> pwn.hexdump("abcd")
<stdin>:1: BytesWarning: Text is not bytes; assuming ASCII, no guarantees. See https://docs.pwntools.com/#bytes
'00000000  61 62 63 64                                         │abcd│\n00000004'
```

Problem being, IDEs get cranky if you call `hexdump()` with a bytes-type `s` due to the docstring.

Adjusted the docstring to indicate we expect bytes.

I'm sure there are many other instances of this worth tending to including the encoders (#1583, #1923 and so on) but this one in particular has been bugging me.