### PR TITLE
Fix CI failures

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ pypandoc
 pyserial>=2.7
 requests>=2.5.1
 ropgadget>=5.3
-sphinx<3.4
+sphinx>=3.5.4
 sphinx_rtd_theme
 sphinxcontrib-napoleon
 sphinxcontrib-autoprogram<=0.1.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 capstone
 coveralls
 doc2dash
+docutils<0.18
 isort
 mako>=1.0.0
 paramiko>=1.15.2
@@ -11,7 +12,7 @@ pypandoc
 pyserial>=2.7
 requests>=2.5.1
 ropgadget>=5.3
-sphinx>=3.5.4
+sphinx<3.4
 sphinx_rtd_theme
 sphinxcontrib-napoleon
 sphinxcontrib-autoprogram<=0.1.5


### PR DESCRIPTION
Apparently docutils released a version for Python 2, which breaks compatibility with sphinx. Pin it down to the last working version.