### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         ulimit -c unlimited
         cat /proc/sys/kernel/core_pattern
         cat /proc/sys/kernel/core_uses_pid
-        ( cd $(mktemp -d); sh -c 'kill -11 $$' || true; ls -la ./*core* /var/crash/*.crash;) || true
+        ( cd $(mktemp -d); sh -c 'kill -11 $$' || true; ls -la ./*core* /var/crash/*.crash /var/lib/apport/coredump/core*) || true
 
     - name: Set up SSH
       run: |

--- a/pwnlib/commandline/unhex.py
+++ b/pwnlib/commandline/unhex.py
@@ -28,6 +28,7 @@ def main(args):
             o.write(unhex(''.join(args.hex)))
     except TypeError as e:
         sys.stderr.write(str(e) + '\n')
+        raise
 
 if __name__ == '__main__':
     common.main(__file__)

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -1335,7 +1335,7 @@ def version(program='gdb'):
     program = misc.which(program)
     expr = br'([0-9]+\.?)+'
 
-    with tubes.process.process([program, '--version'], level='error') as gdb:
+    with tubes.process.process([program, '--version'], level='error', stdout=tubes.process.PIPE) as gdb:
         version = gdb.recvline()
 
     versions = re.search(expr, version).group()

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -117,9 +117,9 @@ class process(tube):
 
     Examples:
 
-        >>> p = process('python2')
-        >>> p.sendline(b"print 'Hello world'")
-        >>> p.sendline(b"print 'Wow, such data'");
+        >>> p = process('python')
+        >>> p.sendline(b"print('Hello world')")
+        >>> p.sendline(b"print('Wow, such data')")
         >>> b'' == p.recv(timeout=0.01)
         True
         >>> p.shutdown('send')

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1079,7 +1079,7 @@ os.execve(exe, argv, env)
             if result == 0:
                 self.error("%r does not exist or is not executable" % executable)
             elif result == 3:
-                self.error(error_message)
+                self.error("%r" % error_message)
             elif result == 2:
                 self.error("python is not installed on the remote system %r" % self.host)
             elif result != 1:


### PR DESCRIPTION
The main change is a new apport core file behaviour.
Actually, they probably updated their docker (or VM) images last weeks-ish,
then Github got it, and we started getting failures because of using 'latest'.
They totally changed the logic of that 'apport' thing,
and it now drops core files in `/var/lib/apport/coredump`
instead of the current working directory.

Ubuntu, why are you doing this to us?
I seriously mean that Ubuntu is the most silly distro out there.
Debian? Wonderful. Mageia? Usable. Gentoo? Never had any problems with that. Arch? It quite works, btw.
Ubuntu? Uhm... ever heard of optimizing UX of new users at the expense of everyone else? That's Ubuntu.

I seriously had to do a fresh install of newest Ububububu 21.10 in a VM to debug that, because core file pattern is a per-kernel feature, and is not namespace-tunable, thus untestable in containers.

Why is that even... ugh.  Nevermind.  It works now, at least.
But for how long?