### PR TITLE
Replace reserved argument names in syscalls

### DIFF
--- a/pwnlib/data/syscalls/generate.py
+++ b/pwnlib/data/syscalls/generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 from __future__ import division
 import argparse
 import keyword
@@ -137,6 +137,7 @@ def can_be_string(arg):
     if arg.type == 'void' and arg.derefcnt == 1:
         return True
 
+
 def can_be_array(arg):
     if arg.type == 'char' and arg.derefcnt == 2:
         return True
@@ -160,10 +161,12 @@ def fix_bad_arg_names(func, arg):
 def get_arg_default(arg):
     return 0
 
+
 def fix_rt_syscall_name(name):
     if name.startswith('rt_'):
         return name[3:]
     return name
+
 
 def fix_syscall_names(name):
     # Do not use old_mmap
@@ -179,6 +182,7 @@ def main(target):
     for arch in ARCHITECTURES:
         with context.local(arch=arch):
             generate_one(target)
+
 
 def generate_one(target):
     SYSCALL_NAMES = [c for c in dir(constants) if c.startswith('SYS_')]
@@ -214,13 +218,33 @@ def generate_one(target):
 
         # Set up the argument string for Mako
         argument_names = []
+        argument_names_ = []
         argument_defaults = []
+
+        string_arguments = []
+        array_arguments = []
+        arg_docs = []
 
         #
 
         for arg in function.args:
-            argname = fix_bad_arg_names(function, arg)
+            argname_ = fix_bad_arg_names(function, arg)
+            argname = argname_.rstrip('_')
             default = get_arg_default(arg)
+
+            if can_be_array(arg):
+                array_arguments.append(argname)
+
+            if can_be_string(arg):
+                string_arguments.append(argname)
+
+            argtype = str(arg.type) + ('*' * arg.derefcnt)
+            arg_docs.append(
+                '    {argname_}({argtype}): {argname}'.format(
+                    argname_=argname_,
+                    argname=argname,
+                    argtype=argtype,
+                ))
 
             # Mako is unable to use *vararg and *kwarg, so we just stub in
             # a whole bunch of additional arguments.
@@ -228,32 +252,16 @@ def generate_one(target):
                 for j in range(5):
                     argname = 'vararg_%i' % j
                     argument_names.append(argname)
+                    argument_names_.append(argname)
                     argument_defaults.append('%s=%s' % (argname, None))
                 break
 
             argument_names.append(argname)
-            argument_defaults.append('%s=%s' % (argname, default))
+            argument_names_.append(argname_)
+            argument_defaults.append('%s=%s' % (argname_, default))
 
         arguments_default_values = ', '.join(argument_defaults)
-        arguments_comma_separated = ', '.join(argument_names)
-
-        string_arguments = []
-        array_arguments = []
-        arg_docs = []
-
-        for arg in function.args:
-
-            if can_be_array(arg):
-                array_arguments.append(arg.name)
-
-            if can_be_string(arg):
-                string_arguments.append(arg.name)
-
-            argname = arg.name
-            argtype = str(arg.type) + ('*' * arg.derefcnt)
-            arg_docs.append(
-                '    {argname}({argtype}): {argname}'.format(argname=argname,
-                                                             argtype=argtype))
+        arguments_comma_separated = ', '.join(argument_names_)
 
         return_type = str(function.type) + ('*' * function.derefcnt)
         arg_docs = '\n'.join(arg_docs)
@@ -281,6 +289,7 @@ def generate_one(target):
             name += '_'
         with open(os.path.join(target, name + '.asm'), 'wt') as f:
             f.write('\n'.join(map(str.strip, lines)) + '\n')
+
 
 if __name__ == '__main__':
     p = argparse.ArgumentParser()

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/arm_fadvise64_64.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/arm_fadvise64_64.asm
@@ -15,7 +15,7 @@ Arguments:
     fd(int): fd
     advice(int): advice
     offset(loff_t): offset
-    len(loff_t): len
+    length(loff_t): length
 Returns:
     long
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/bind.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/bind.asm
@@ -14,7 +14,7 @@ See 'man 2 bind' for more information.
 Arguments:
     fd(int): fd
     addr(CONST_SOCKADDR_ARG): addr
-    len(socklen_t): len
+    length(socklen_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/connect.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/connect.asm
@@ -14,7 +14,7 @@ See 'man 2 connect' for more information.
 Arguments:
     fd(int): fd
     addr(CONST_SOCKADDR_ARG): addr
-    len(socklen_t): len
+    length(socklen_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/fallocate.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/fallocate.asm
@@ -15,7 +15,7 @@ Arguments:
     fd(int): fd
     mode(int): mode
     offset(off_t): offset
-    len(off_t): len
+    length(off_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/getpeername.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/getpeername.asm
@@ -14,7 +14,7 @@ See 'man 2 getpeername' for more information.
 Arguments:
     fd(int): fd
     addr(SOCKADDR_ARG): addr
-    len(socklen_t*): len
+    length(socklen_t*): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/getsockname.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/getsockname.asm
@@ -14,7 +14,7 @@ See 'man 2 getsockname' for more information.
 Arguments:
     fd(int): fd
     addr(SOCKADDR_ARG): addr
-    len(socklen_t*): len
+    length(socklen_t*): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/ioperm.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/ioperm.asm
@@ -12,7 +12,7 @@ Invokes the syscall ioperm.
 See 'man 2 ioperm' for more information.
 
 Arguments:
-    from(unsigned): from
+    from_(unsigned): from
     num(unsigned): num
     turn_on(int): turn_on
 Returns:
@@ -28,7 +28,7 @@ Returns:
     can_pushstr = []
     can_pushstr_array = []
 
-    argument_names = ['from_', 'num', 'turn_on']
+    argument_names = ['from', 'num', 'turn_on']
     argument_values = [from_, num, turn_on]
 
     # Load all of the arguments into their destination registers / stack slots.

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/link.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/link.asm
@@ -12,7 +12,7 @@ Invokes the syscall link.
 See 'man 2 link' for more information.
 
 Arguments:
-    from(char*): from
+    from_(char*): from
     to(char*): to
 Returns:
     int
@@ -27,7 +27,7 @@ Returns:
     can_pushstr = ['from', 'to']
     can_pushstr_array = []
 
-    argument_names = ['from_', 'to']
+    argument_names = ['from', 'to']
     argument_values = [from_, to]
 
     # Load all of the arguments into their destination registers / stack slots.

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/linkat.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/linkat.asm
@@ -13,7 +13,7 @@ See 'man 2 linkat' for more information.
 
 Arguments:
     fromfd(int): fromfd
-    from(char*): from
+    from_(char*): from
     tofd(int): tofd
     to(char*): to
     flags(int): flags
@@ -30,7 +30,7 @@ Returns:
     can_pushstr = ['from', 'to']
     can_pushstr_array = []
 
-    argument_names = ['fromfd', 'from_', 'tofd', 'to', 'flags']
+    argument_names = ['fromfd', 'from', 'tofd', 'to', 'flags']
     argument_values = [fromfd, from_, tofd, to, flags]
 
     # Load all of the arguments into their destination registers / stack slots.

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/lookup_dcookie.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/lookup_dcookie.asm
@@ -14,7 +14,7 @@ See 'man 2 lookup_dcookie' for more information.
 Arguments:
     cookie(u64): cookie
     buffer(char*): buffer
-    len(size_t): len
+    length(size_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/madvise.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/madvise.asm
@@ -13,7 +13,7 @@ See 'man 2 madvise' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
     advice(int): advice
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/mbind.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/mbind.asm
@@ -13,7 +13,7 @@ See 'man 2 mbind' for more information.
 
 Arguments:
     addr(void*): addr
-    len(unsigned): len
+    length(unsigned): length
     mode(int): mode
     nodemask(unsigned*): nodemask
     maxnode(unsigned): maxnode

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/mincore.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/mincore.asm
@@ -13,7 +13,7 @@ See 'man 2 mincore' for more information.
 
 Arguments:
     start(void*): start
-    len(size_t): len
+    length(size_t): length
     vec(unsigned*): vec
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/mlock.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/mlock.asm
@@ -13,7 +13,7 @@ See 'man 2 mlock' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/mlock2.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/mlock2.asm
@@ -13,7 +13,7 @@ See 'man 2 mlock2' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
     flags(int): flags
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/mmap.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/mmap.asm
@@ -13,7 +13,7 @@ See 'man 2 mmap' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
     prot(int): prot
     flags(int): flags
     fd(int): fd

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/mprotect.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/mprotect.asm
@@ -13,7 +13,7 @@ See 'man 2 mprotect' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
     prot(int): prot
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/msync.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/msync.asm
@@ -13,7 +13,7 @@ See 'man 2 msync' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
     flags(int): flags
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/munlock.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/munlock.asm
@@ -13,7 +13,7 @@ See 'man 2 munlock' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/munmap.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/munmap.asm
@@ -13,7 +13,7 @@ See 'man 2 munmap' for more information.
 
 Arguments:
     addr(void*): addr
-    len(size_t): len
+    length(size_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/open.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/open.asm
@@ -14,7 +14,7 @@ See 'man 2 open' for more information.
 Arguments:
     file(char*): file
     oflag(int): oflag
-    vararg(int): vararg
+    mode(int): mode
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/pciconfig_read.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/pciconfig_read.asm
@@ -15,7 +15,7 @@ Arguments:
     bus(unsigned): bus
     dfn(unsigned): dfn
     off(unsigned): off
-    len(unsigned): len
+    length(unsigned): length
     buf(void*): buf
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/pciconfig_write.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/pciconfig_write.asm
@@ -15,7 +15,7 @@ Arguments:
     bus(unsigned): bus
     dfn(unsigned): dfn
     off(unsigned): off
-    len(unsigned): len
+    length(unsigned): length
     buf(void*): buf
 Returns:
     int

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/readlink.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/readlink.asm
@@ -14,7 +14,7 @@ See 'man 2 readlink' for more information.
 Arguments:
     path(char*): path
     buf(char*): buf
-    len(size_t): len
+    length(size_t): length
 Returns:
     ssize_t
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/readlinkat.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/readlinkat.asm
@@ -15,7 +15,7 @@ Arguments:
     fd(int): fd
     path(char*): path
     buf(char*): buf
-    len(size_t): len
+    length(size_t): length
 Returns:
     ssize_t
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/set_robust_list.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/set_robust_list.asm
@@ -13,7 +13,7 @@ See 'man 2 set_robust_list' for more information.
 
 Arguments:
     head(robust_list_head*): head
-    len(size_t): len
+    length(size_t): length
 Returns:
     long
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/setdomainname.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/setdomainname.asm
@@ -13,7 +13,7 @@ See 'man 2 setdomainname' for more information.
 
 Arguments:
     name(char*): name
-    len(size_t): len
+    length(size_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/sethostname.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/sethostname.asm
@@ -13,7 +13,7 @@ See 'man 2 sethostname' for more information.
 
 Arguments:
     name(char*): name
-    len(size_t): len
+    length(size_t): length
 Returns:
     int
 </%docstring>

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/splice.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/splice.asm
@@ -16,7 +16,7 @@ Arguments:
     offin(off64_t*): offin
     fdout(int): fdout
     offout(off64_t*): offout
-    len(size_t): len
+    length(size_t): length
     flags(unsigned): flags
 Returns:
     ssize_t

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/symlink.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/symlink.asm
@@ -12,7 +12,7 @@ Invokes the syscall symlink.
 See 'man 2 symlink' for more information.
 
 Arguments:
-    from(char*): from
+    from_(char*): from
     to(char*): to
 Returns:
     int
@@ -27,7 +27,7 @@ Returns:
     can_pushstr = ['from', 'to']
     can_pushstr_array = []
 
-    argument_names = ['from_', 'to']
+    argument_names = ['from', 'to']
     argument_values = [from_, to]
 
     # Load all of the arguments into their destination registers / stack slots.

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/symlinkat.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/symlinkat.asm
@@ -12,7 +12,7 @@ Invokes the syscall symlinkat.
 See 'man 2 symlinkat' for more information.
 
 Arguments:
-    from(char*): from
+    from_(char*): from
     tofd(int): tofd
     to(char*): to
 Returns:
@@ -28,7 +28,7 @@ Returns:
     can_pushstr = ['from', 'to']
     can_pushstr_array = []
 
-    argument_names = ['from_', 'tofd', 'to']
+    argument_names = ['from', 'tofd', 'to']
     argument_values = [from_, tofd, to]
 
     # Load all of the arguments into their destination registers / stack slots.

--- a/pwnlib/shellcraft/templates/common/linux/syscalls/tee.asm
+++ b/pwnlib/shellcraft/templates/common/linux/syscalls/tee.asm
@@ -14,7 +14,7 @@ See 'man 2 tee' for more information.
 Arguments:
     fdin(int): fdin
     fdout(int): fdout
-    len(size_t): len
+    length(size_t): length
     flags(unsigned): flags
 Returns:
     ssize_t


### PR DESCRIPTION
Just stick to the replaced names everywhere.
This actually only broke linkat(2) and symlinkat(2),
but it touches many len -> length renames as well
for the sake of consistency.
Fixes #1964