### PR TITLE
Fix env command not found in gdb.debug

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -303,7 +303,7 @@ def _gdbserver_args(pid=None, path=None, args=None, which=None, env=None):
                 env_args.append(b'%s=%s' % (key, env.pop(key)))
             else:
                 env_args.append(b'%s=%s' % (key, env[key]))
-        gdbserver_args += ['--wrapper', 'env', '-i'] + env_args + ['--']
+        gdbserver_args += ['--wrapper', which('env'), '-i'] + env_args + ['--']
 
     gdbserver_args += ['localhost:0']
     gdbserver_args += args


### PR DESCRIPTION
This fixes the "env: command not found" error that I was getting when using `gdb.debug`.

## Testing

N/A

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
