### PR TITLE
fix tube's debug output of same byte compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.9.0 (`dev`)
 
+- [#2011][2011] Fix tube's debug output of same byte compression
 
+[2011]: https://github.com/Gallopsled/pwntools/pull/2011
 
 ## 4.8.0 (`beta`)
 

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -99,6 +99,7 @@ import os
 import random
 import re
 import six
+import string
 import sys
 import threading
 import time
@@ -401,6 +402,24 @@ class Logger(object):
 
         self.info(pwnlib.util.fiddling.hexdump(message, *args, **kwargs))
 
+    def maybe_hexdump(self, message, *args, **kwargs):
+        """maybe_hexdump(self, message, *args, **kwargs)
+
+        Logs a message. Repeated single byte is compressed, and unprintable
+        message is hexdumped.
+
+        Arguments:
+            level(int): Alternate log level at which to set the message.
+                        Defaults to :const:`logging.INFO`.
+        """
+        if len(set(message)) == 1 and len(message) > 1:
+            self.indented('%r * %#x' % (message[:1], len(message)), *args, **kwargs)
+        elif len(message) == 1 or all(c in string.printable.encode() for c in message):
+            for line in message.splitlines(True):
+                self.indented(repr(line), *args, **kwargs)
+        else:
+            import pwnlib.util.fiddling
+            self.indented(pwnlib.util.fiddling.hexdump(message), *args, **kwargs)
 
     def warning(self, message, *args, **kwargs):
         """warning(message, *args, **kwargs)

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -405,12 +405,8 @@ class Logger(object):
     def maybe_hexdump(self, message, *args, **kwargs):
         """maybe_hexdump(self, message, *args, **kwargs)
 
-        Logs a message. Repeated single byte is compressed, and unprintable
-        message is hexdumped.
-
-        Arguments:
-            level(int): Alternate log level at which to set the message.
-                        Defaults to :const:`logging.INFO`.
+        Logs a message using indented. Repeated single byte is compressed, and
+        unprintable message is hexdumped.
         """
         if len(set(message)) == 1 and len(message) > 1:
             self.indented('%r * %#x' % (message[:1], len(message)), *args, **kwargs)

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -157,7 +157,7 @@ class tube(Timeout, Logger):
             self.debug('Received %#x bytes:' % len(data))
 
             if len(set(data)) == 1 and len(data) > 1:
-                self.indented('%r * %#x' % (data[0], len(data)), level = logging.DEBUG)
+                self.indented('%r * %#x' % (data[:1], len(data)), level = logging.DEBUG)
             elif all(c in string.printable.encode() for c in data):
                 for line in data.splitlines(True):
                     self.indented(repr(line), level = logging.DEBUG)
@@ -767,8 +767,8 @@ class tube(Timeout, Logger):
 
         if self.isEnabledFor(logging.DEBUG):
             self.debug('Sent %#x bytes:' % len(data))
-            if len(set(data)) == 1:
-                self.indented('%r * %#x' % (data[0], len(data)))
+            if len(set(data)) == 1 and len(data) > 1:
+                self.indented('%r * %#x' % (data[:1], len(data)))
             elif all(c in string.printable.encode() for c in data):
                 for line in data.splitlines(True):
                     self.indented(repr(line), level = logging.DEBUG)

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -19,7 +19,6 @@ from pwnlib.context import context
 from pwnlib.log import Logger
 from pwnlib.timeout import Timeout
 from pwnlib.tubes.buffer import Buffer
-from pwnlib.util import fiddling
 from pwnlib.util import misc
 from pwnlib.util import packing
 
@@ -155,15 +154,7 @@ class tube(Timeout, Logger):
 
         if data and self.isEnabledFor(logging.DEBUG):
             self.debug('Received %#x bytes:' % len(data))
-
-            if len(set(data)) == 1 and len(data) > 1:
-                self.indented('%r * %#x' % (data[:1], len(data)), level = logging.DEBUG)
-            elif all(c in string.printable.encode() for c in data):
-                for line in data.splitlines(True):
-                    self.indented(repr(line), level = logging.DEBUG)
-            else:
-                self.indented(fiddling.hexdump(data), level = logging.DEBUG)
-
+            self.maybe_hexdump(data, level=logging.DEBUG)
         if data:
             self.buffer.add(data)
 
@@ -767,13 +758,8 @@ class tube(Timeout, Logger):
 
         if self.isEnabledFor(logging.DEBUG):
             self.debug('Sent %#x bytes:' % len(data))
-            if len(set(data)) == 1 and len(data) > 1:
-                self.indented('%r * %#x' % (data[:1], len(data)))
-            elif all(c in string.printable.encode() for c in data):
-                for line in data.splitlines(True):
-                    self.indented(repr(line), level = logging.DEBUG)
-            else:
-                self.indented(fiddling.hexdump(data), level = logging.DEBUG)
+            self.maybe_hexdump(data, level=logging.DEBUG)
+
         self.send_raw(data)
 
     def sendline(self, line=b''):


### PR DESCRIPTION
The tube will compress same byte in debug output, however it prints `data[0]`, which is int.
And `send` still prints `* 0x1`, while `recv` omits it.

```python
from pwn import *
context.log_level = 'debug'

t = tube()
t.recv_raw = lambda n: b'a'
t.recv()
t.recv_raw = lambda n: b'a' * 4
t.recv()
t.send_raw = lambda x: None
t.send(b'a')
t.send(b'aaaa')
```

before pr:
```
[DEBUG] Received 0x1 bytes:
    b'a'
[DEBUG] Received 0x4 bytes:
    97 * 0x4
[DEBUG] Sent 0x1 bytes:
    97 * 0x1
[DEBUG] Sent 0x4 bytes:
    97 * 0x4
```
after pr:
```
[DEBUG] Received 0x1 bytes:
    b'a'
[DEBUG] Received 0x4 bytes:
    b'a' * 0x4
[DEBUG] Sent 0x1 bytes:
    b'a'
[DEBUG] Sent 0x4 bytes:
    b'a' * 0x4
```