### PR TITLE
Cast int target pid to str in ssh-gdb context

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -915,7 +915,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
             cmd = ['sshpass', '-p', shell.password] + cmd
         if shell.keyfile:
             cmd += ['-i', shell.keyfile]
-        cmd += ['gdb', '-q', target.executable, target.pid, '-x', tmpfile]
+        cmd += ['gdb', '-q', target.executable, str(target.pid), '-x', tmpfile]
 
         misc.run_in_new_terminal(cmd)
         return


### PR DESCRIPTION
# Pwntools Pull Request

Currently files like are generated:
```python
import os

os.execve(
    "/usr/bin/ssh",
    [
        "ssh",
        "-C",
        "-t",
        "-p",
        "22",
        "-l",
        "0x3c3e",
        "host",
        "gdb",
        "-q",
        "/usr/bin/bash",
        6913, # int here, instead of str
        "-x",
        b"/tmp/tmp.JqkTMT5Sxw",
    ],
    os.environ,
)
```

If I use code below:
```python
from pwn import *

context.arch = "amd64"
context.terminal = "/Applications/iTerm.app/Contents/MacOS/iTerm2"

ssh_session = ssh(host="host", user="0x3c3e")

p = ssh_session.process(["bash"])
# p.pid = str(p.pid) that line fixes it
gdb.attach(p)

p.interactive()
```

Results in:
`TypeError: expected str, bytes or os.PathLike object, not int`