### PR TITLE
Fix CI after Groovy Gorilla went away for libc unstrip test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,7 @@ jobs:
         [ "$GITHUB_TAG" = "$vsetup" ]
 
     - name: Install Linux dependencies
-      # Install newer elfutils version from groovy due to regression in 0.176 available in focal.
       run: |
-        if lsb_release -c | grep focal; then
-          echo 'APT::Default-Release "focal";' | sudo tee /etc/apt/apt.conf.d/99elfutils > /dev/null
-          sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/groovy.list
-          sudo sed -i 's/focal/groovy/g' /etc/apt/sources.list.d/groovy.list
-          echo -e 'Package: elfutils libdw1 libelf1 libasm1\nPin: release n=groovy\nPin-Priority: 1001' | sudo tee /etc/apt/preferences.d/elfutils.pref > /dev/null
-        fi
-
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
           ash bash-static dash ksh mksh zsh \
@@ -67,8 +59,32 @@ jobs:
           binutils-s390x-linux-gnu \
           binutils-sparc64-linux-gnu \
           gcc-multilib \
-          libc6-dbg \
-          elfutils
+          libc6-dbg
+      
+    - name: Cache for elfutils
+      uses: actions/cache@v1
+      id: cache-elfutils
+      with:
+        path: ~/.cache/elfutils
+        key: ${{ matrix.os }}-cache-elfutils
+    
+    # Install newer elfutils version due to regression in 0.176 available in focal.
+    - name: Install newer elfutils
+      env:
+        ELFUTILS_VERSION: 0.181
+      run: |
+        if [[ ! -d ~/.cache/elfutils/elfutils-${ELFUTILS_VERSION} ]]
+        then
+          wget -O /tmp/elfutils-${ELFUTILS_VERSION}.tar.bz2 https://sourceware.org/elfutils/ftp/${ELFUTILS_VERSION}/elfutils-${ELFUTILS_VERSION}.tar.bz2
+          mkdir -p ~/.cache/elfutils && cd ~/.cache/elfutils
+          tar -xf /tmp/elfutils-${ELFUTILS_VERSION}.tar.bz2
+          cd elfutils-${ELFUTILS_VERSION}
+          LDFLAGS=-Wl,-rpath=/usr/local/lib,--enable-new-dtags ./configure --disable-libdebuginfod --disable-debuginfod && make && sudo make install
+        else
+          cd ~/.cache/elfutils/elfutils-${ELFUTILS_VERSION}
+          sudo make install
+        fi
+        eu-unstrip --version
 
     - name: Install RPyC for GDB
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
+        pip install --upgrade wheel
         pip install --upgrade flake8 appdirs
         python setup.py egg_info
         pip install --upgrade --editable .

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -242,7 +242,7 @@ def unstrip_libc(filename):
     p.close()
 
     if output:
-        log.error('Failed to unstrip libc binary: %s', output)
+        log.error('Failed to unstrip libc binary: %r', output)
         return False
 
     return True


### PR DESCRIPTION
Build elfutils 0.181 from source since we can't use builds from a newer ubuntu version anymore in CI.

The elfutils version 0.176 packaged with ubuntu 20.04 focal fails to unstrip recent libc builds, so the previous workaround was to grab the newer elfutils package from ubuntu 20.10. Ubuntu 20.10 reached its end-of-life a while ago and the package repository was removed. So build a newer elfutils version 0.181 from source now to fix the `libcdb.libc_unstrip` doctests in CI.
0.181 was the version packaged with ubuntu groovy, so any newer version should be fine too.

ref #1828 