### PR TITLE
Use a more reliable way to split the KDE konsole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2023][2023] Support KDE Konsole in run_in_new_terminal function
 
 [2011]: https://github.com/Gallopsled/pwntools/pull/2011
+[2023]: https://github.com/Gallopsled/pwntools/pull/2023
 
 ## 4.8.0 (`beta`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.9.0 (`dev`)
 
 - [#2011][2011] Fix tube's debug output of same byte compression
+- [#2023][2023] Support KDE Konsole in run_in_new_terminal function
 
 [2011]: https://github.com/Gallopsled/pwntools/pull/2011
 


### PR DESCRIPTION
A more stable way to split KDE Konsole than in #2023.
Problems can start only after detaching the tab of KDE Konsole (the `$WINDOWID` environment variable remains in the  detached tab), but otherwise the code works well.