### PR TITLE
Clean up usages of getattr/__getattr__

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -384,6 +384,9 @@ class AdbDevice(Device):
             >>> adb.getprop(property) == device.getprop(property)
             True
         """
+        if name.startswith('_'):
+            raise AttributeError(name)
+
         with context.local(device=self):
             g = globals()
 
@@ -1513,7 +1516,7 @@ class Partitions(object):
         return iter(names)
 
     def __getattr__(self, attr):
-        if attr.startswith("_"):
+        if attr.startswith('_'):
             raise AttributeError(attr)
 
         for name in self:

--- a/pwnlib/adb/bootimg.py
+++ b/pwnlib/adb/bootimg.py
@@ -46,7 +46,7 @@ class BootImage(object):
         self.kernel = self.data[PAGE:PAGE+self.kernel_size]
 
     def __getattr__(self, name):
-        value = getattr(self.header, name, None)
-        if value is not None:
-            return value
-        return getattr(super(BootImage, self), name)
+        if name.startswith('_'):
+            raise AttributeError(name)
+
+        return getattr(self.header, name)

--- a/pwnlib/adb/bootloader.py
+++ b/pwnlib/adb/bootloader.py
@@ -114,10 +114,11 @@ class BootloaderImage(object):
         return '\n'.join(rv)
 
     def __getattr__(self, name):
-        value = getattr(self.header, name, None)
-        if value is not None:
-            return value
-        return getattr(super(BootImage, self), name)
+        if name.startswith('_'):
+            raise AttributeError(name)
+
+        return getattr(self.header, name)
+
 
 if __name__ == '__main__':
     # Easy sanity checking

--- a/pwnlib/args.py
+++ b/pwnlib/args.py
@@ -62,6 +62,8 @@ from pwnlib.context import context
 
 class PwnlibArgs(collections.defaultdict):
     def __getattr__(self, attr):
+        if attr.startswith('_'):
+            raise AttributeError(attr)
         return self[attr]
 
 args = PwnlibArgs(str)

--- a/pwnlib/data/useragents/download-useragents.py
+++ b/pwnlib/data/useragents/download-useragents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """Script for downloading lists of user agent strings."""
 from __future__ import division
 import os
@@ -43,7 +43,7 @@ with log.waitfor('Fetching from from http://www.user-agents.org') as l:
     l.success()
 
 with log.waitfor('Parsing list') as l:
-    for item in soup.__getattr__('user-agents'):
+    for item in getattr(soup, 'user-agents'):
         if item.name == 'user-agent':
             ua = item.select('string')[0].string.strip()
             try:

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1184,14 +1184,13 @@ class Corefile(ELF):
         pwnlib.gdb.attach(self, exe=self.exe.path)
 
     def __getattr__(self, attribute):
-        if self.prstatus:
-            if hasattr(self.prstatus, attribute):
-                return getattr(self.prstatus, attribute)
+        if attribute.startswith('_') or not self.prstatus:
+            raise AttributeError(attribute)
 
-            if hasattr(self.prstatus.pr_reg, attribute):
-                return getattr(self.prstatus.pr_reg, attribute)
+        if hasattr(self.prstatus, attribute):
+            return getattr(self.prstatus, attribute)
 
-        return super(Corefile, self).__getattribute__(attribute)
+        return getattr(self.prstatus.pr_reg, attribute)
 
     # Override routines which don't make sense for Corefiles
     def _populate_got(*a): pass

--- a/pwnlib/elf/datatypes.py
+++ b/pwnlib/elf/datatypes.py
@@ -604,7 +604,8 @@ class user_regs_struct_aarch64(ctypes.Structure):
     def __getattr__(self, name):
         if name.startswith('r'):
             name = 'x' + name[1:]
-            return getattr(name) & 0xffffffff
+            return getattr(self, name) & 0xffffffff
+        raise AttributeError(name)
 
 class elf_prstatus_i386(ctypes.Structure):
     _fields_ = generate_prstatus_common(32, user_regs_struct_i386)

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -167,8 +167,7 @@ class dotdict(dict):
 
         if subkeys:
             return dotdict(subkeys)
-
-        return getattr(super(dotdict, self), name)
+        raise AttributeError(name)
 
 class ELF(ELFFile):
     """Encapsulates information about an ELF file.

--- a/pwnlib/filepointer.py
+++ b/pwnlib/filepointer.py
@@ -176,13 +176,8 @@ class FileStructure(object):
     def __repr__(self):
         structure=[]
         for i in self.vars_:
-            structure.append(" %s: %s" % (i,hex(self.__getattr__(i))))
+            structure.append(" %s: %s" % (i,hex(getattr(self, i))))
         return "{"+ "\n".join(structure)+"}"
-
-    def __getattr__(self,item):
-        if item in FileStructure.__dict__ or item in self.vars_:
-            return object.__getattribute__(self,item)
-        log.error("Unknown variable %r" % item)
 
     def __len__(self):
         return len(bytes(self))
@@ -190,10 +185,10 @@ class FileStructure(object):
     def __bytes__(self):
         structure = b''
         for val in self.vars_:
-            if isinstance(self.__getattr__(val), bytes):
-                structure += self.__getattr__(val).ljust(context.bytes, b'\x00')
+            if isinstance(getattr(self, val), bytes):
+                structure += getattr(self, val).ljust(context.bytes, b'\x00')
             else:
-                structure += pack(self.__getattr__(val), self.length[val]*8)
+                structure += pack(getattr(self, val), self.length[val]*8)
         return structure
 
     def struntil(self,v):
@@ -218,10 +213,10 @@ class FileStructure(object):
             return b''
         structure = b''
         for val in self.vars_:
-            if isinstance(self.__getattr__(val), bytes):
-                structure += self.__getattr__(val).ljust(context.bytes, b'\x00')
+            if isinstance(getattr(self, val), bytes):
+                structure += getattr(self, val).ljust(context.bytes, b'\x00')
             else:
-                structure += pack(self.__getattr__(val), self.length[val]*8)
+                structure += pack(getattr(self, val), self.length[val]*8)
             if val == v:
                 break
         return structure[:-1]

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1274,7 +1274,7 @@ class ROP(object):
                 pass
 
             def __getattr__(self, k):
-                return self._fd.__getattribute__(k)
+                return getattr(self._fd, k)
 
         gadgets = {}
         for elf in self.elfs:

--- a/pwnlib/rop/srop.py
+++ b/pwnlib/rop/srop.py
@@ -391,7 +391,9 @@ class SigreturnFrame(dict):
             self.set_regvalue(attr, value)
 
     def __getattr__(self, attr):
-        return self[attr]
+        if attr in self:
+            return self[attr]
+        raise AttributeError(attr)
 
     def __bytes__(self):
         frame = b""

--- a/pwnlib/term/readline.py
+++ b/pwnlib/term/readline.py
@@ -486,7 +486,7 @@ def init():
         def readline(self, size = None):
             return readline(size)
         def __getattr__(self, k):
-            return self._fd.__getattribute__(k)
+            return getattr(self._fd, k)
     sys.stdin = Wrapper(sys.stdin)
 
     if six.PY2:

--- a/pwnlib/term/term.py
+++ b/pwnlib/term/term.py
@@ -139,7 +139,7 @@ def init():
         def write(self, s):
             output(s, frozen = True)
         def __getattr__(self, k):
-            return self._fd.__getattribute__(k)
+            return getattr(self._fd, k)
     if sys.stdout.isatty():
         sys.stdout = Wrapper(sys.stdout)
     if sys.stderr.isatty():

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -89,6 +89,9 @@ class Module(types.ModuleType):
         return functools.partial(f, self)
 
     def __getattr__(self, desc):
+        if desc.startswith('_'):
+            raise AttributeError(desc)
+
         try:
             ds = desc.replace('gray', 'bright_black').split('_')
             init = ''

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -159,15 +159,18 @@ class listen(sock):
         self.sock
         return self
 
-    def __getattr__(self, key):
-        if key == 'sock':
-            self._accepter.join(timeout = self.timeout)
-            if 'sock' in self.__dict__:
-                return self.sock
-            else:
-                return None
-        else:
-            return getattr(super(listen, self), key)
+    @property
+    def sock(self):
+        try:
+            return self.__dict__['sock']
+        except KeyError:
+            pass
+        self._accepter.join(timeout=self.timeout)
+        return self.__dict__.get('sock')
+
+    @sock.setter
+    def sock(self, s):
+        self.__dict__['sock'] = s
 
     def close(self):
         # since `close` is scheduled to run on exit we must check that we got

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -608,7 +608,7 @@ class process(tube):
         """Permit pass-through access to the underlying process object for
         fields like ``pid`` and ``stdin``.
         """
-        if hasattr(self.proc, attr):
+        if not attr.startswith('_') and hasattr(self.proc, attr):
             return getattr(self.proc, attr)
         raise AttributeError("'process' object has no attribute '%s'" % attr)
 

--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -72,8 +72,9 @@ class sock(tube):
                 raise
 
     def settimeout_raw(self, timeout):
-        if getattr(self, 'sock', None):
-            self.sock.settimeout(timeout)
+        sock = getattr(self, 'sock', None)
+        if sock:
+            sock.settimeout(timeout)
 
     def can_recv_raw(self, timeout):
         """
@@ -161,14 +162,15 @@ class sock(tube):
         return True
 
     def close(self):
-        if not getattr(self, 'sock', None):
+        sock = getattr(self, 'sock', None)
+        if not sock:
             return
 
         # Mark as closed in both directions
         self.closed['send'] = True
         self.closed['recv'] = True
 
-        self.sock.close()
+        sock.close()
         self.sock = None
         self._close_msg()
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -519,13 +519,19 @@ class ssh_listener(sock):
         _ = self.sock
         return self
 
-    def __getattr__(self, key):
-        if key == 'sock':
-            while self._accepter.is_alive():
-                self._accepter.join(timeout = 0.1)
-            return self.sock
-        else:
-            return getattr(super(ssh_listener, self), key)
+    @property
+    def sock(self):
+        try:
+            return self.__dict__['sock']
+        except KeyError:
+            pass
+        while self._accepter.is_alive():
+            self._accepter.join(timeout=0.1)
+        return self.__dict__.get('sock')
+
+    @sock.setter
+    def sock(self, s):
+        self.__dict__['sock'] = s
 
 
 class ssh(Timeout, Logger):


### PR DESCRIPTION
Proactively avoid messing up introspection (e.g. tab-completion in ipython, serialization etc.) by raising AttributeError early from most `__getattr__` functions on underscore-prefixed attributes; an example of what can still go wrong:

https://github.com/Gallopsled/pwntools/blob/da8bf2667d735a82ab539898e0cc1b36d40bc3d5/pwnlib/tubes/ssh.py#L1297-L1299