### PR TITLE
Fix incorrect disasm output

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -779,9 +779,9 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
            0:   60 00 00 00     nop
         >>> print(disasm(unhex('00000000'), arch='mips64'))
            0:   00000000        nop
-        >>> print(disasm(unhex('48b84141414141414100c3'), arch = 'amd64'))
+        >>> print(disasm(unhex('48b84141414141414100c3'), arch='amd64'))
            0:   48 b8 41 41 41 41 41 41 41 00   movabs rax, 0x41414141414141
-           a:   c3
+           a:   c3                      ret
     """
     result = ''
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -779,6 +779,9 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
            0:   60 00 00 00     nop
         >>> print(disasm(unhex('00000000'), arch='mips64'))
            0:   00000000        nop
+        >>> print(disasm(unhex('48b84141414141414100c3'), arch = 'amd64'))
+           0:   48 b8 41 41 41 41 41 41 41 00   movabs rax, 0x41414141414141
+           a:   c3
     """
     result = ''
 
@@ -790,7 +793,7 @@ def disasm(data, vma = 0, byte = True, offset = True, instructions = True):
 
     bfdarch = _bfdarch()
     bfdname = _bfdname()
-    objdump = _objdump() + ['-d', '--adjust-vma', str(vma), '-b', bfdname]
+    objdump = _objdump() + ['-w', '-d', '--adjust-vma', str(vma), '-b', bfdname]
     objcopy = _objcopy() + [
         '-I', 'binary',
         '-O', bfdname,


### PR DESCRIPTION
## Detail
By default, objdump attempts to keep lines under 80 columns by splitting the bytes for long instructions over two lines:
```
   0:	48 b8 41 41 41 41 41 	movabs rax,0x41414141414141
   7:	41 41 00 
   a:	55                   	push   rbp
   b:	90                   	nop
   c:	c3                   	ret  
```

In disasm.py the length of `str.splitlines(bytes)` will be longer than `splitlines(offsets)` or `splitlines(instrs)`, this leads to the bytes being out of sync with the offsets and instructions when zip is applied:
https://github.com/Gallopsled/pwntools/blob/1238fc359eb72313d3f82849b2effdb7063ab429/pwnlib/commandline/disasm.py#L85


Current behaviour:
```sh
 $ disasm 48b841414141414141005590c3 -c amd64
   0:    48 b8 41 41 41 41 41     movabs rax,  0x41414141414141
   a:    41 41 00  push   rbp
   b:    55                       nop
   c:    90                       ret
```
Note how the bytes are shifted and it looks like `0x90` is a `ret`!

Expected behaviour:
```sh
$ disasm 48b841414141414141005590c3 -c amd64
   0:    48 b8 41 41 41 41 41 41 41 00    movabs rax,  0x41414141414141
   a:    55                       push   rbp
   b:    90                       nop
   c:    c3                       ret   
```

## Fix
Add objdump's `--wide` option which will remove the extra newlines. I have also added a doctest to cover this.

## Alternative
An alternative approach could be to rewrite the disasm command to not make 3 separate calls to disasm, although this would require handling the highlight and formatting differently.
https://github.com/Gallopsled/pwntools/blob/1238fc359eb72313d3f82849b2effdb7063ab429/pwnlib/commandline/disasm.py#L80-L89