### PR TITLE
Quote file and core path in generated GDB script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2011][2011] Fix tube's debug output of same byte compression
 - [#2023][2023] Support KDE Konsole in run_in_new_terminal function
 - [#2027][2027] Fix ELF.libc_start_main_return with glibc 2.34
+- [#2033][2033] Quote file and core path in generated GDB script
 
 [2011]: https://github.com/Gallopsled/pwntools/pull/2011
 [2023]: https://github.com/Gallopsled/pwntools/pull/2023
 [2027]: https://github.com/Gallopsled/pwntools/pull/2027
+[2033]: https://github.com/Gallopsled/pwntools/pull/2033
 
 ## 4.8.0 (`beta`)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -878,7 +878,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
             pre += 'set gnutarget ' + _bfdname() + '\n'
 
         if exe and context.os != 'baremetal':
-            pre += 'file %s\n' % exe
+            pre += 'file "%s"\n' % exe
 
     # let's see if we can find a pid to attach to
     pid = None
@@ -967,7 +967,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
 
         exe = exe or findexe()
     elif isinstance(target, elf.corefile.Corefile):
-        pre += 'target core %s\n' % target.path
+        pre += 'target core "%s"\n' % target.path
     else:
         log.error("don't know how to attach to target: %r", target)
 


### PR DESCRIPTION
Quote file and core path in automatically generated GDB scripts, so that debugging works correctly when the target path contains spaces.