### PR TITLE
Add the 'raw' option to SSH shell initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,11 +68,13 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2023][2023] Support KDE Konsole in run_in_new_terminal function
 - [#2027][2027] Fix ELF.libc_start_main_return with glibc 2.34
 - [#2035][2035] Change Buffer's parent class to object
+- [#2037][2037] Allow SSH tunnel to be treated like a TCP socket (with 'raw=True')
 
 [2011]: https://github.com/Gallopsled/pwntools/pull/2011
 [2023]: https://github.com/Gallopsled/pwntools/pull/2023
 [2027]: https://github.com/Gallopsled/pwntools/pull/2027
 [2035]: https://github.com/Gallopsled/pwntools/pull/2035
+[2037]: https://github.com/Gallopsled/pwntools/pull/2037
 
 ## 4.8.0 (`beta`)
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -552,8 +552,8 @@ class ssh(Timeout, Logger):
     _cwd = '.'
 
     def __init__(self, user=None, host=None, port=22, password=None, key=None,
-                 keyfile=None, proxy_command=None, proxy_sock=None,
-                 level=None, cache=True, ssh_agent=False, ignore_config=False, *a, **kw):
+                 keyfile=None, proxy_command=None, proxy_sock=None, level=None,
+                 cache=True, ssh_agent=False, ignore_config=False, raw=False, *a, **kw):
         """Creates a new ssh connection.
 
         Arguments:
@@ -570,6 +570,7 @@ class ssh(Timeout, Logger):
             cache: Cache downloaded files (by hash/size/timestamp)
             ssh_agent: If :const:`True`, enable usage of keys via ssh-agent
             ignore_config: If :const:`True`, disable usage of ~/.ssh/config and ~/.ssh/authorized_keys
+            raw: If :const:`True`, assume a non-standard shell and don't probe the environment
 
         NOTE: The proxy_command and proxy_sock arguments is only available if a
         fairly new version of paramiko is used.
@@ -666,6 +667,9 @@ class ssh(Timeout, Logger):
             self.transport.use_compression(True)
 
             h.success()
+
+        if self.raw:
+            return
 
         self._tried_sftp = False
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -601,6 +601,7 @@ class ssh(Timeout, Logger):
         self.keyfile         = keyfile
         self._cachedir       = os.path.join(tempfile.gettempdir(), 'pwntools-ssh-cache')
         self.cache           = cache
+        self.raw             = raw
 
         # Deferred attributes
         self._platform_info = {}


### PR DESCRIPTION
This permits the use of the SSH shell as an arbitrary TCP tunnel by bypassing the startup environmental checks.