### PR TITLE
clean ioerror

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -696,7 +696,6 @@ class process(tube):
             raise EOFError
 
         try:
-            breakpoint()
             self.proc.stdin.write(data)
             self.proc.stdin.flush()
         except IOError:
@@ -747,10 +746,8 @@ class process(tube):
                 try:
                     fd.close()
                 except IOError as e:
-                    if e.errno == errno.EPIPE:
-                        pass
-                    else:
-                        print(e)
+                    if e.errno != errno.EPIPE:
+                        raise
 
         if not self._stop_noticed:
             try:

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -696,6 +696,7 @@ class process(tube):
             raise EOFError
 
         try:
+            breakpoint()
             self.proc.stdin.write(data)
             self.proc.stdin.flush()
         except IOError:
@@ -745,8 +746,11 @@ class process(tube):
             if fd is not None:
                 try:
                     fd.close()
-                except IOError:
-                    pass
+                except IOError as e:
+                    if e.errno == errno.EPIPE:
+                        pass
+                    else:
+                        print(e)
 
         if not self._stop_noticed:
             try:

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -740,10 +740,13 @@ class process(tube):
         # First check if we are already dead
         self.poll()
 
-        #close file descriptors
+        # close file descriptors
         for fd in [self.proc.stdin, self.proc.stdout, self.proc.stderr]:
             if fd is not None:
-                fd.close()
+                try:
+                    fd.close()
+                except IOError:
+                    pass
 
         if not self._stop_noticed:
             try:


### PR DESCRIPTION
suppresses #1936
rather difficult to get to the root of the issue due to the atexit which prevents me from debugging it.
by right, fd.close() should not throw an error even if fd is already closed which makes it a mystery why there is an IOError.

> Flush and close this stream. This method has no effect if the file is already closed. Once the file is closed, any operation on the file (e.g. reading or writing) will raise a [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError).
> As a convenience, it is allowed to call this method more than once; only the first call, however, will have an effect.

however I feel that this is a minor issue, and it is sufficient to simply catch this exception and move on with the code.
hence this pr will catch and suppress error messages in the case of a broken pipe.