### PR TITLE
Filepointer fix

### DIFF
--- a/pwnlib/filepointer.py
+++ b/pwnlib/filepointer.py
@@ -193,7 +193,8 @@ class FileStructure(object):
             if isinstance(self.__getattr__(val), bytes):
                 structure += self.__getattr__(val).ljust(context.bytes, b'\x00')
             else:
-                structure += pack(self.__getattr__(val), self.length[val]*8)
+                if self.length[val] > 0:
+                    structure += pack(self.__getattr__(val), self.length[val]*8)
         return structure
 
     def struntil(self,v):


### PR DESCRIPTION
# Pwntools Pull Request
When using FileStructer() to make a FSOP exploitation under context.arch="i386",
you'll get `bits must > 0` error while packing payload.
```
>>> context.clear(arch='i386', bits=32
>>> f = FileStructure()
>>> bytes(f)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/filepointer.py", line 196, in __bytes__
    structure += pack(self.__getattr__(val), self.length[val]*8)
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/util/packing.py", line 111, in pack
    with context.local(**kwargs):
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/context/__init__.py", line 528, in __enter__
    self.update(**{k:v for k,v in kwargs.items() if v is not None})
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/context/__init__.py", line 489, in update
    setattr(self,k,v)
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/context/__init__.py", line 1469, in word_size
    self.bits = value
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/context/__init__.py", line 173, in fset
    self._tls[name] = validator(self, val)
  File "/usr/local/lib/python3.6/dist-packages/pwnlib/context/__init__.py", line 835, in bits
    raise AttributeError("bits must be > 0 (%r)" % bits)
AttributeError: bits must be > 0 (0)
```
so see [FileStructure fails to pack into bytes #2029](https://github.com/Gallopsled/pwntools/issues/2029)

Under the scenario of context.arch="i386", 
The error caused by the variables[20][size] = 0  (name='unknown1') pass to pack().

In `pwnlib/filepointer.py`
``` python
variables={
    0:{name:'flags',size:length},
    1:{name:'_IO_read_ptr',size:length},
    ...
    19:{name:'_shortbuf',size:1},
    20:{name:'unknown1',size:-4},  # <=====
    21:{name:'_lock',size:length},
    ...
}
@python_2_bytes_compatible
class FileStructure(object):
  def __init__(self, null=0):
        self.vars_ = [variables[i]['name'] for i in sorted(variables.keys())]
        self.setdefault(null)
        self.length = update_var(context.bytes)  #<=context.bytes=4
         
  def update_var(l):
      var={}
      for i in variables:
          var[variables[i]['name']]=variables[i]['size']
      for i in var:
          if var[i]<=0:
              var[i]+=l    # <== key:'unknown1' size = 0
      ...
  # while packing bytes
  def __bytes__(self):
      structure = b''
      for val in self.vars_:
          if isinstance(self.__getattr__(val), bytes):
              structure += self.__getattr__(val).ljust(context.bytes, b'\x00')
          else:
              structure += pack(self.__getattr__(val), self.length[val]*8) # <== key:'unknown1' size = 0 raise error
      return structure
```
## Changelog
Change:  pwnlib/filepointer.py #line 196
```python
def __bytes__(self):
    structure = b''
    for val in self.vars_:
        if isinstance(self.__getattr__(val), bytes):
            structure += self.__getattr__(val).ljust(context.bytes, b'\x00')
        else:
            if self.length[val]>0: #<=== pack() needs context bits must > 0  
                structure += pack(self.__getattr__(val), self.length[val]*8)
    return structure
```
Only add one line code to see if the bits pass to pack() is greater than  0.
