### PR TITLE
Update Sphinx in order to fix jinja2 deprecated dependency.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       run:  PWNLIB_NOTERM=1 python -bb -c 'from pwn import *; print(pwnlib.term.term_mode)'
 
     - name: Install documentation dependencies
-      run:  pip install -r docs/requirements.txt
+      run: pip install -r docs/requirements.txt
 
     - name: Manually install non-broken Unicorn
       run:  pip install unicorn==1.0.2rc3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,8 @@ pypandoc
 pyserial>=2.7
 requests>=2.5.1
 ropgadget>=5.3
-sphinx<3.4
+sphinx==1.8.6; python_version < '3.0.0'
+sphinx==4.5.0; python_version >= '3.0.0'
 sphinx_rtd_theme
 sphinxcontrib-napoleon
 sphinxcontrib-autoprogram<=0.1.5


### PR DESCRIPTION
# Pwntools Pull Request

Fix the error `ImportError: cannot import name 'environmentfilter' from 'jinja2'` on sphinx on the travis cicd.

## Testing

## Target Branch

## Changelog
