### PR TITLE
Correct a return type in Docstring

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -216,7 +216,7 @@ class tube(Timeout, Logger):
         return data
 
     def recvn(self, numb, timeout = default):
-        """recvn(numb, timeout = default) -> str
+        """recvn(numb, timeout = default) -> bytes
 
         Receives exactly `n` bytes.
 


### PR DESCRIPTION
The return type of fuction-recvn() seems to be incorrect.

In its docstring, return type is str.

![image](https://user-images.githubusercontent.com/30044929/163673528-bf2859e9-b604-4718-958d-1f1776f6f693.png)
![image](https://user-images.githubusercontent.com/30044929/163673533-c6f5104c-3a73-41bb-9520-21e65c445df6.png)
