### PR TITLE
Detect Windows Terminal and split gdb into new pane

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -343,6 +343,11 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
                 terminal    = 'cmd.exe'
                 args        = ['/c', 'start']
                 distro_name = os.getenv('WSL_DISTRO_NAME')
+
+                # Split pane in Windows Terminal
+                if 'WT_SESSION' in os.environ and which('wt.exe'):
+                    args.extend(['wt.exe', '-w', '0', 'split-pane', '-d', '.'])
+
                 if distro_name:
                     args.extend(['wsl.exe', '-d', distro_name, 'bash', '-c'])
                 else:


### PR DESCRIPTION
[Split the terminal window](https://docs.microsoft.com/en-gb/windows/terminal/command-line-arguments?tabs=windows#options-and-commands) similar to tmux debugging experience when we're running in Windows Terminal instead of the plain old console host.