### PR TITLE
make pwn cyclic -l work with entry larger than 4 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.10.0 (`dev`)
 
+- [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 
+[2062]: https://github.com/Gallopsled/pwntools/pull/2062
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -72,6 +72,7 @@ def main(args):
 
         try:
             pat = int(pat, 0)
+            pat = pack(pat, 'all')
         except ValueError:
             pass
         pat = flat(pat, bytes=args.length)

--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -70,10 +70,10 @@ def main(args):
         if six.PY3:
             pat = bytes(pat, encoding='utf-8')
 
-        if pat[:2] == b'0x':
-            pat = bytes.fromhex(pat[2::].decode())
-            pat = pat[::-1]
-
+        try:
+            pat = int(pat, 0)
+        except ValueError:
+            pass
         pat = flat(pat, bytes=args.length)
 
         if len(pat) < subsize:

--- a/pwnlib/commandline/cyclic.py
+++ b/pwnlib/commandline/cyclic.py
@@ -70,15 +70,17 @@ def main(args):
         if six.PY3:
             pat = bytes(pat, encoding='utf-8')
 
-        try:
-            pat = int(pat, 0)
-        except ValueError:
-            pass
+        if pat[:2] == b'0x':
+            pat = bytes.fromhex(pat[2::].decode())
+            pat = pat[::-1]
+
         pat = flat(pat, bytes=args.length)
 
-        if len(pat) != subsize:
-            log.critical('Subpattern must be %d bytes' % subsize)
+        if len(pat) < subsize:
+            log.critical('Subpattern must be at least %d bytes' % subsize)
             sys.exit(1)
+        else:
+            pat = pat[:subsize]
 
         if not all(c in alphabet for c in pat):
             log.critical('Pattern contains characters not present in the alphabet')


### PR DESCRIPTION
Hello,
This is my first pull request to an open-source project 🎉️

This commit make the command `pwn cyclic -l` capable of handling larger inputs such as :

```
pwn cyclic -l 0x6161616c6161616b      
40

pwn cyclic -l kaaalaaamaaanaaa        
40
```

At the moment, `pwn cyclic -l` only handle entries of 4 bytes (or more precisely `-n` bytes).

I didn't manage to run the test suite using the docker image. But I have tested the changes on x86, x64, armv5 and mipsel architectures.