### PR TITLE
gdb: fix #1493

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -568,7 +568,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, api=
     gdbserver.executable = exe
 
     # Find what port we need to connect to
-    if context.native or (context.os == 'android'):
+    if ssh or context.native or (context.os == 'android'):
         port = _gdbserver_port(gdbserver, ssh)
     else:
         port = qemu_port


### PR DESCRIPTION
Fix wrong branch taken when trying to debug non native arch via ssh
(resulting qemu_port being referenced without being set).

This is done by setting the condition in line 571 to be the same
as in line 534

Signed-off-by: Aviya Erenfeld <aviyae42@gmail.com>