### PR TITLE
shellcraft: consistently name dupio and optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.10.0 (`dev`)
 
+- [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 
+[2092]: https://github.com/Gallopsled/pwntools/pull/2092
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/shellcraft/templates/aarch64/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/dupio.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.aarch64 import mov,setregs %>
+<%page args="sock = 'x12'"/>
+<%docstring>
+Args: [sock (imm/reg) = x12]
+    Duplicates sock to stdin, stdout and stderr
+</%docstring>
+<%
+  looplabel = common.label("loop")
+%>
+    /* dup() file descriptor ${sock} into stdin/stdout/stderr */
+        ${setregs({'x8': 'SYS_dup3', 'x1': 2, 'x2': 0})}
+
+${looplabel}:
+        ${mov('x0', sock)}
+        svc #0
+        subs x1, x1, #1
+        bpl ${looplabel}

--- a/pwnlib/shellcraft/templates/aarch64/linux/dupsh.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/dupsh.asm
@@ -1,7 +1,7 @@
-<% from pwnlib.shellcraft.thumb import linux %>
-<%page args="sock = 'r6'"/>
+<% from pwnlib.shellcraft.aarch64 import linux %>
+<%page args="sock = 'x12'"/>
 <%docstring>
-Args: [sock (imm/reg) = r6]
+Args: [sock (imm/reg) = x12]
     Duplicates sock to stdin, stdout and stderr and spawns a shell.
 </%docstring>
 

--- a/pwnlib/shellcraft/templates/amd64/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/dupio.asm
@@ -5,23 +5,12 @@ Args: [sock (imm/reg) = rbp]
     Duplicates sock to stdin, stdout and stderr
 </%docstring>
 <%
-  dup       = common.label("dup")
   looplabel = common.label("loop")
-  after     = common.label("after")
 %>
 
     /* dup() file descriptor ${sock} into stdin/stdout/stderr */
-${dup}:
-    ${amd64.mov('rbp', sock)}
-
-    push 3
+    ${amd64.setregs({'rdi': sock, 'rsi': 2})}
 ${looplabel}:
-    pop rsi
+    ${amd64.linux.dup2('rdi', 'rsi')}
     dec rsi
-    js ${after}
-    push rsi
-
-    ${amd64.linux.syscall('SYS_dup2', 'rbp', 'rsi')}
-
-    jmp ${looplabel}
-${after}:
+    jns ${looplabel}

--- a/pwnlib/shellcraft/templates/amd64/linux/dupsh.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/dupsh.asm
@@ -7,6 +7,6 @@ Args: [sock (imm/reg) = rbp]
 </%docstring>
 
 
-${linux.dup(sock)}
+${linux.dupio(sock)}
 
 ${linux.sh()}

--- a/pwnlib/shellcraft/templates/arm/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/dupio.asm
@@ -1,0 +1,19 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.arm import mov %>
+<%page args="sock = 'r6'"/>
+<%docstring>
+Args: [sock (imm/reg) = r6]
+    Duplicates sock to stdin, stdout and stderr
+</%docstring>
+<%
+  looplabel = common.label("loop")
+%>
+    /* dup() file descriptor ${sock} into stdin/stdout/stderr */
+        ${mov('r1', 2)}
+        ${mov('r7', 'SYS_dup2')}
+
+${looplabel}:
+        ${mov('r0', sock)}
+        svc 0
+        subs r1, #1
+        bpl ${looplabel}

--- a/pwnlib/shellcraft/templates/arm/linux/dupsh.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/dupsh.asm
@@ -1,4 +1,4 @@
-<% from pwnlib.shellcraft.thumb import linux %>
+<% from pwnlib.shellcraft.arm import linux %>
 <%page args="sock = 'r6'"/>
 <%docstring>
 Args: [sock (imm/reg) = r6]

--- a/pwnlib/shellcraft/templates/i386/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/dupio.asm
@@ -1,5 +1,5 @@
 <% from pwnlib.shellcraft.i386.linux import dup2 %>
-<% from pwnlib.shellcraft.i386 import mov %>
+<% from pwnlib.shellcraft.i386 import setregs %>
 <% from pwnlib.shellcraft import common %>
 <%page args="sock = 'ebp'"/>
 <%docstring>
@@ -7,16 +7,12 @@ Args: [sock (imm/reg) = ebp]
     Duplicates sock to stdin, stdout and stderr
 </%docstring>
 <%
-  dup       = common.label("dup")
   looplabel = common.label("loop")
 %>
 
     /* dup() file descriptor ${sock} into stdin/stdout/stderr */
-${dup}:
-    ${mov('ebx', sock)}
-    ${mov('ecx', 3)}
+    ${setregs({'ebx': sock, 'ecx': 2})}
 ${looplabel}:
-    dec ecx
-
     ${dup2('ebx', 'ecx')}
-    jnz ${looplabel}
+    dec ecx
+    jns ${looplabel}

--- a/pwnlib/shellcraft/templates/mips/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/dupio.asm
@@ -7,12 +7,10 @@ Args: [sock (imm/reg) = s0]
     Duplicates sock to stdin, stdout and stderr
 </%docstring>
 <%
-   dup       = common.label("dup")
    looplabel = common.label("loop")
 %>
 
     /* dup() file descriptor ${sock} into stdin/stdout/stderr */
-${dup}:
     ${mov('$v0',2)}
 ${looplabel}:
     ${dup2(sock,'$v0')}

--- a/pwnlib/shellcraft/templates/thumb/linux/dupio.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/dupio.asm
@@ -6,11 +6,9 @@ Args: [sock (imm/reg) = r6]
     Duplicates sock to stdin, stdout and stderr
 </%docstring>
 <%
-  dup       = common.label("dup")
   looplabel = common.label("loop")
 %>
     /* dup() file descriptor ${sock} into stdin/stdout/stderr */
-${dup}:
         ${mov('r1', 2)}
         ${mov('r7', 'SYS_dup2')}
 


### PR DESCRIPTION
This is a major cleanup of shellcraft/*/linux/dup{,io}.asm making sure all the corresponding features are named the same.

This is hopefully the end of the saga of #1439, #1182 and such.