### PR TITLE
setresuid: generic implementation for all arches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.10.0 (`dev`)
 
+- [#2093][2093] setresuid() in shellcraft uses current euid by default
 
+[2093]: https://github.com/Gallopsled/pwntools/pull/2093
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/shellcraft/templates/aarch64/linux/setresuid.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/setresuid.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.aarch64 import mov, linux %>
+<%page args="ruid=None, euid=None, suid=None"/>
+<%docstring>
+Args: [ruid = geteuid(), euid = ruid, suid = ruid]
+    Sets real, effective and saved user ids to given values
+</%docstring>
+
+%if ruid is None:
+${linux.geteuid()}
+<% ruid = 'x0' %>
+%endif
+<%
+ if euid is None: euid = ruid
+ if suid is None: suid = ruid
+%>
+
+${linux.syscalls.setresuid(ruid, euid, suid)}

--- a/pwnlib/shellcraft/templates/amd64/linux/setresuid.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/setresuid.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.amd64 import mov, linux %>
+<%page args="ruid=None, euid=None, suid=None"/>
+<%docstring>
+Args: [ruid = geteuid(), euid = ruid, suid = ruid]
+    Sets real, effective and saved user ids to given values
+</%docstring>
+
+%if ruid is None:
+${linux.geteuid()}
+<% ruid = 'eax' %>
+%endif
+<%
+ if euid is None: euid = ruid
+ if suid is None: suid = ruid
+%>
+
+${linux.syscalls.setresuid(ruid, euid, suid)}

--- a/pwnlib/shellcraft/templates/arm/linux/setresuid.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/setresuid.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.arm import mov, linux %>
+<%page args="ruid=None, euid=None, suid=None"/>
+<%docstring>
+Args: [ruid = geteuid(), euid = ruid, suid = ruid]
+    Sets real, effective and saved user ids to given values
+</%docstring>
+
+%if ruid is None:
+${linux.geteuid()}
+<% ruid = 'r0' %>
+%endif
+<%
+ if euid is None: euid = ruid
+ if suid is None: suid = ruid
+%>
+
+${linux.syscalls.setresuid(ruid, euid, suid)}

--- a/pwnlib/shellcraft/templates/i386/linux/setresuid.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/setresuid.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.i386 import mov, linux %>
+<%page args="ruid=None, euid=None, suid=None"/>
+<%docstring>
+Args: [ruid = geteuid(), euid = ruid, suid = ruid]
+    Sets real, effective and saved user ids to given values
+</%docstring>
+
+%if ruid is None:
+${linux.geteuid()}
+<% ruid = 'eax' %>
+%endif
+<%
+ if euid is None: euid = ruid
+ if suid is None: suid = ruid
+%>
+
+${linux.syscalls.setresuid(ruid, euid, suid)}

--- a/pwnlib/shellcraft/templates/mips/linux/setresuid.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/setresuid.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.mips import mov, linux %>
+<%page args="ruid=None, euid=None, suid=None"/>
+<%docstring>
+Args: [ruid = geteuid(), euid = ruid, suid = ruid]
+    Sets real, effective and saved user ids to given values
+</%docstring>
+
+%if ruid is None:
+${linux.geteuid()}
+<% ruid = '$v0' %>
+%endif
+<%
+ if euid is None: euid = ruid
+ if suid is None: suid = ruid
+%>
+
+${linux.syscalls.setresuid(ruid, euid, suid)}

--- a/pwnlib/shellcraft/templates/thumb/linux/setresuid.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/setresuid.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import common %>
+<% from pwnlib.shellcraft.thumb import mov, linux %>
+<%page args="ruid=None, euid=None, suid=None"/>
+<%docstring>
+Args: [ruid = geteuid(), euid = ruid, suid = ruid]
+    Sets real, effective and saved user ids to given values
+</%docstring>
+
+%if ruid is None:
+${linux.geteuid()}
+<% ruid = 'r0' %>
+%endif
+<%
+ if euid is None: euid = ruid
+ if suid is None: suid = ruid
+%>
+
+${linux.syscalls.setresuid(ruid, euid, suid)}


### PR DESCRIPTION
Closes #1324

The real uid to set defaults to geteuid() and the remaining uids default to new real uid.
Supported usage includes:
- `asm(setresuid() + connect(...) + dupsh())`
- `asm(setresuid(0) + connect(...) + dupsh())`
- `asm(setresuid(5,6[,5]) + connect(...) + dupsh())`
- `asm(setresuid(1,2,3) + connect(...) + dupsh())`

Hope this proves useful.