### PR TITLE
modified options in make_elf to disable newer GNU linker warnings

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -595,7 +595,7 @@ def make_elf(data,
 
         _run(assembler + ['-o', step2, step1])
 
-        linker_options = ['-z', 'execstack']
+        linker_options = ['-z', 'execstack', '--no-warn-rwx-segments', '--no-warn-execstack']
         if vma is not None:
             linker_options += ['--section-start=.shellcode=%#x' % vma,
                                '--entry=%#x' % vma]


### PR DESCRIPTION
# linker options

the stable/dev repositories of asm/make_elf throw when building ELFs due to an error with a newly implemented GNU linker warning that warns about LOAD segment with RWX permissions. Adding the ``--no-warn-rwx-segments`` and  ``--no-warn-execstack`` linker options remediates this issue 

See [kernel.org mailing list](https://lore.kernel.org/all/CACPK8Xe4hEB3wkRc4W2dNQ+ChonsKtWGCVPpoOFdjdfpbK88Mg@mail.gmail.com/T/) for explanation of these new gnu linker warnings

# error replication

```py
>>> from pwn import *
>>> p = run_assembly('push 0xbad')
[ERROR] There was an error running ['/usr/bin/x86_64-linux-gnu-ld', '--oformat=elf32-i386', '-EL', '-m', 'elf_i386', '-z', 'execstack', '-o', '/tmp/pwn-asm-phbp53vv/step3', '/tmp/pwn-asm-phbp53vv/step2', '--section-start=.shellcode=0x10000000', '--entry=0x10000000', '-z', 'max-page-size=4096', '-z', 'common-page-size=4096']:
    It had this on stdout:
    /usr/bin/x86_64-linux-gnu-ld: warning: /tmp/pwn-asm-phbp53vv/step3 has a LOAD segment with RWX permissions
    
[ERROR] An error occurred while assembling:
       1: .section .shellcode,"awx"
       2: .global _start
       3: .global __start
       4: .p2align 2
       5: _start:
       6: __start:
       7: .intel_syntax noprefix
       8: push 0xbad
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/dist-packages/pwnlib/asm.py", line 710, in asm
        _run(linker + ldflags)
      File "/usr/local/lib/python3.10/dist-packages/pwnlib/asm.py", line 404, in _run
        log.error(msg, *args)
      File "/usr/local/lib/python3.10/dist-packages/pwnlib/log.py", line 424, in error
        raise PwnlibException(message % args)
    pwnlib.exception.PwnlibException: There was an error running ['/usr/bin/x86_64-linux-gnu-ld', '--oformat=elf32-i386', '-EL', '-m', 'elf_i386', '-z', 'execstack', '-o', '/tmp/pwn-asm-phbp53vv/step3', '/tmp/pwn-asm-phbp53vv/step2', '--section-start=.shellcode=0x10000000', '--entry=0x10000000', '-z', 'max-page-size=4096', '-z', 'common-page-size=4096']:
    It had this on stdout:
    /usr/bin/x86_64-linux-gnu-ld: warning: /tmp/pwn-asm-phbp53vv/step3 has a LOAD segment with RWX permissions
    
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/context/__init__.py", line 1577, in setter
    return function(*a, **kw)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/runner.py", line 34, in run_assembly
    return ELF.from_assembly(assembly).process()
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/context/__init__.py", line 1577, in setter
    return function(*a, **kw)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/elf/elf.py", line 402, in from_assembly
    return ELF(make_elf_from_assembly(assembly, *a, **kw))
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/context/__init__.py", line 1577, in setter
    return function(*a, **kw)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/asm.py", line 524, in make_elf_from_assembly
    result = asm(assembly, vma = vma, shared = shared, extract = False, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/context/__init__.py", line 1577, in setter
    return function(*a, **kw)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/asm.py", line 733, in asm
    log.exception("An error occurred while assembling:\n%s" % lines)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/asm.py", line 710, in asm
    _run(linker + ldflags)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/asm.py", line 404, in _run
    log.error(msg, *args)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/log.py", line 424, in error
    raise PwnlibException(message % args)
pwnlib.exception.PwnlibException: There was an error running ['/usr/bin/x86_64-linux-gnu-ld', '--oformat=elf32-i386', '-EL', '-m', 'elf_i386', '-z', 'execstack', '-o', '/tmp/pwn-asm-phbp53vv/step3', '/tmp/pwn-asm-phbp53vv/step2', '--section-start=.shellcode=0x10000000', '--entry=0x10000000', '-z', 'max-page-size=4096', '-z', 'common-page-size=4096']:
It had this on stdout:
/usr/bin/x86_64-linux-gnu-ld: warning: /tmp/pwn-asm-phbp53vv/step3 has a LOAD segment with RWX permissions
```