### PR TITLE
Update libcdb debuginfod default URL to federating server

### DIFF
--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -25,7 +25,7 @@ from pwnlib.util.web import wget
 log = getLogger(__name__)
 
 HASHES = ['build_id', 'sha1', 'sha256', 'md5']
-DEBUGINFOD_SERVERS = ['https://debuginfod.systemtap.org/']
+DEBUGINFOD_SERVERS = ['https://debuginfod.elfutils.org/']
 
 # https://gitlab.com/libcdb/libcdb wasn't updated after 2019,
 # but still is a massive database of older libc binaries.

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -27,6 +27,10 @@ log = getLogger(__name__)
 HASHES = ['build_id', 'sha1', 'sha256', 'md5']
 DEBUGINFOD_SERVERS = ['https://debuginfod.elfutils.org/']
 
+if 'DEBUGINFOD_URLS' in os.environ:
+    urls = os.environ['DEBUGINFOD_URLS'].split(' ')
+    DEBUGINFOD_SERVERS = urls + DEBUGINFOD_SERVERS
+
 # https://gitlab.com/libcdb/libcdb wasn't updated after 2019,
 # but still is a massive database of older libc binaries.
 def provider_libcdb(hex_encoded_id, hash_type):
@@ -227,6 +231,8 @@ def unstrip_libc(filename):
     if not libc.buildid:
         log.warn_once('Given libc does not have a buildid. Cannot look for debuginfo to unstrip.')
         return False
+
+    log.debug('Trying debuginfod servers: %r', DEBUGINFOD_SERVERS)
 
     for server_url in DEBUGINFOD_SERVERS:
         libc_dbg = _search_debuginfo_by_hash(server_url, enhex(libc.buildid))


### PR DESCRIPTION
elfutils.org offers a federating proxy server which forwards the requests to all other debuginfod servers of the different linux distributions.

https://sourceware.org/elfutils/Debuginfod.html

Use that instead by default to increase our success rate of finding debuginfo while unstripping libc binaries and potentially include new servers automatically once the distro sets one up. (ubuntu is [on its way](https://blog.sergiodj.net/2022/08/14/debuginfod-is-coming-to-ubuntu.html))

The `DEBUGINFOD_URLS` environment variable is what you use for your normal debuginfod setup to tell it where to look for debug symbols.

Parse it as well and prepend it to the list of servers to try to allow for dynamic adjusting of the target servers.