### PR TITLE
Process: Fix AttributeError when stdin, stdout, and stderr are redirected to files

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -348,28 +348,45 @@ class process(tube):
 
             p.success('pid %i' % self.pid)
 
+        stdin_assigned, stdout_assigned, stderr_assigned = False, False, False
+
         if self.pty is not None:
             if stdin is slave:
                 self.proc.stdin = os.fdopen(os.dup(master), 'r+b', 0)
-            elif isinstance(stdin, io.TextIOWrapper):
-                self.proc.stdin = os.fdopen(os.dup(stdin.fileno()), 'r+b', 0)
-            elif isinstance(stdin, int) and self.__is_valid_fd(stdin):
-                self.proc.stdin = os.fdopen(os.dup(stdin), 'r+b', 0)
+                stdin_assigned = True
             if stdout is slave:
                 self.proc.stdout = os.fdopen(os.dup(master), 'r+b', 0)
-            elif isinstance(stdout, io.TextIOWrapper):
-                self.proc.stdout = os.fdopen(os.dup(stdout.fileno()), 'r+b', 0)
-            elif isinstance(stdout, int) and self.__is_valid_fd(stdout):
-                self.proc.stdout = os.fdopen(os.dup(stdout), 'r+b', 0)
+                stdout_assigned = True
             if stderr is slave:
                 self.proc.stderr = os.fdopen(os.dup(master), 'r+b', 0)
-            elif isinstance(stderr, io.TextIOWrapper):
-                self.proc.stderr = os.fdopen(os.dup(stderr.fileno()), 'r+b', 0)
-            elif isinstance(stderr, int) and self.__is_valid_fd(stderr):
-                self.proc.stderr = os.fdopen(os.dup(stderr), 'r+b', 0)
+                stderr_assigned = True
 
             os.close(master)
             os.close(slave)
+
+        if not stdin_assigned:
+            if isinstance(stdin, io.TextIOWrapper):
+                self.proc.stdin = os.fdopen(os.dup(stdin.fileno()), 'r+b', 0)
+                stdin_assigned = True
+            elif isinstance(stdin, int) and self.__is_valid_fd(stdin):
+                self.proc.stdin = os.fdopen(os.dup(stdin), 'r+b', 0)
+                stdin_assigned = True
+
+        if not stdout_assigned:
+            if isinstance(stdout, io.TextIOWrapper):
+                self.proc.stdout = os.fdopen(os.dup(stdout.fileno()), 'r+b', 0)
+                stdout_assigned = True
+            elif isinstance(stdout, int) and self.__is_valid_fd(stdout):
+                self.proc.stdout = os.fdopen(os.dup(stdout), 'r+b', 0)
+                stdout_assigned = True
+
+        if not stderr_assigned:
+            if isinstance(stderr, io.TextIOWrapper):
+                self.proc.stderr = os.fdopen(os.dup(stderr.fileno()), 'r+b', 0)
+                stderr_assigned = True
+            elif isinstance(stderr, int) and self.__is_valid_fd(stderr):
+                self.proc.stderr = os.fdopen(os.dup(stderr), 'r+b', 0)
+                stderr_assigned = True
 
         # Set in non-blocking mode so that a call to call recv(1000) will
         # return as soon as a the first byte is available


### PR DESCRIPTION
This closes #2036.

This PR would allow users to redirect `stdin`, `stdout`, or/and `stderr` to files via 2 methods, even partially (i.e., the user can choose to redirect only `stdin`, only `stdout`, only `stderr`, or any combination of those 3):

1. By using Python's built-in `open()` function:

    ```python
    pwn.process("cat", stdin=open("some_file", "r"), stdout=open("some_other_file", "w"), stderr=open("yet_another_file", "w"))
    ```

2. By using the `os.open()` function:

    ```python
    pwn.process(["cat", "-"], stdin=os.open("some_file", os.O_RDWR), stdout=os.open("some_other_file", os.O_RDWR), stderr=os.open("yet_another_file", os.O_RDWR))
    ```

If the user passes in some raw integer(s) for `stdin`, `stdout`, or/and `stderr`, such as when they invoke `os.open()`, we only attempt to check whether they are valid file descriptors or not. Other than that, we trust the user that they know what they are doing.