### PR TITLE
Fix ELF.from_assembly linker error

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -705,6 +705,9 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
             # across architectures.
             ldflags += ['-z', 'max-page-size=4096',
                         '-z', 'common-page-size=4096']
+            
+            #Mute linker warning: LOAD segment with RWX permissions
+            ldflags += ['--no-warn-rwx-segment']
 
             _run(linker + ldflags)
 


### PR DESCRIPTION
# Bug fix
 
 Mute linker warning : LOAD segment with RWX permissions. 
This addition comes from a pwnlib exception throw when I was trying to create an ELF file from assembly.

`pwn.context.arch = 'aarch64'`
`pwn.context.bits = 64`
`pwn.ELF.from_assembly(shellcraft.sh())`


`raise PwnlibException(message % args)
    pwnlib.exception.PwnlibException: There was an error running ['/usr/bin/aarch64-linux-gnu-ld', '--oformat=elf64-littleaarch64', '-EL', '-z', 'execstack', '-o', '/tmp/pwn-asm-gpd86fa_/step3', '/tmp/pwn-asm-gpd86fa_/step2', '--section-start=.shellcode=0x10000000', '--entry=0x10000000', '-z', 'max-page-size=4096', '-z', 'common-page-size=4096']:
    It had this on stdout:
    /usr/bin/aarch64-linux-gnu-ld: warning: /tmp/pwn-asm-gpd86fa_/step3 has a LOAD segment with RWX permissions`
