### PR TITLE
Make template respect args.EXE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
+- [#2111][2111] add args.EXE to pwn template to be able to override hard coded value
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
 - [#2125][2125] Allow tube.recvregex to return capture groups
-- [#2111][2111] add args.EXE to pwn template to be able to override hard coded value
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -44,7 +44,7 @@ from pwn import *
 # Set up pwntools for the correct architecture
 %endif
 %if ctx.binary:
-exe = context.binary = ELF(${binary_repr})
+exe = context.binary = ELF(args.EXE) or ELF(${binary_repr})
 <% binary_repr = 'exe.path' %>
 %else:
 context.update(arch='i386')
@@ -58,7 +58,7 @@ exe = ${binary_repr}
 # for all created processes...
 # ./exploit.py DEBUG NOASLR
 %if host or port or user:
-# ./exploit.py GDB HOST=example.com PORT=4141
+# ./exploit.py GDB HOST=example.com PORT=4141 EXE=/tmp/executable
 %endif
 %endif
 %if host:

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -44,7 +44,7 @@ from pwn import *
 # Set up pwntools for the correct architecture
 %endif
 %if ctx.binary:
-exe = context.binary = ELF(args.EXE) or ELF(${binary_repr})
+exe = context.binary = ELF(args.EXE) if args.EXE else ELF(${binary_repr})
 <% binary_repr = 'exe.path' %>
 %else:
 context.update(arch='i386')

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -44,7 +44,7 @@ from pwn import *
 # Set up pwntools for the correct architecture
 %endif
 %if ctx.binary:
-exe = context.binary = ELF(args.EXE) if args.EXE else ELF(${binary_repr})
+exe = context.binary = ELF(args.EXE or ${binary_repr})
 <% binary_repr = 'exe.path' %>
 %else:
 context.update(arch='i386')


### PR DESCRIPTION
I think it would be convenient to be able to execute a script using an executable with another name and/or location than specified at template generation. `args.EXE` may be used as path for ELF file loading, only using the preconfigured value hard coded in the template at generation time when no argument is supplied.