### PR TITLE
Fix format string badbytes not working

### DIFF
--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -304,7 +304,7 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
             candidate = candidate.union(AtomWrite(candidate.end, 1, data[i + candidate.size]))
 
         sz = min([s for s in SPECIFIER if s >= candidate.size] + [float("inf")])
-        if i + sz > len(data):
+        if i + sz >= len(data):
             raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
         i += candidate.size
         candidate = candidate.union(AtomWrite(candidate.end, sz - candidate.size, 0, 0))

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -300,11 +300,11 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
     out = []
     while i < len(data):
         candidate = AtomWrite(address + i, 1, data[i])
-        while candidate.end < len(data) and any(x in badbytes for x in pack(candidate.end)):
+        while i + candidate.size < len(data) and any(x in badbytes for x in pack(candidate.end)):
             candidate = candidate.union(AtomWrite(candidate.end, 1, data[i + candidate.size]))
 
         sz = min([s for s in SPECIFIER if s >= candidate.size] + [float("inf")])
-        if candidate.start + sz > len(data):
+        if i + sz > len(data):
             raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
         i += candidate.size
         candidate = candidate.union(AtomWrite(candidate.end, sz - candidate.size, 0, 0))


### PR DESCRIPTION
Fix https://github.com/Gallopsled/pwntools/issues/1888

Fixed a bug in comparing relative and absolute offsets when dealing with bad bytes of fmtstr.make_atoms_simple