### PR TITLE
Support FinishBreakpoint for GDB API

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -665,6 +665,48 @@ class Breakpoint:
         # Handle stop() call from the server.
         return self.stop()
 
+class FinishBreakpoint:
+    """Mirror of ``gdb.FinishBreakpoint`` class.
+
+    See https://sourceware.org/gdb/onlinedocs/gdb/Finish-Breakpoints-in-Python.html
+    for more information.
+    """
+
+    def __init__(self, conn, *args, **kwargs):
+        """Do not create instances of this class directly.
+
+        Use ``pwnlib.gdb.Gdb.FinishBreakpoint`` instead.
+        """
+        # Creates a real finish breakpoint and connects it with this mirror
+        self.conn = conn
+        self.server_breakpoint = conn.root.set_finish_breakpoint(
+            self, hasattr(self, 'stop'), hasattr(self, 'out_of_scope'),
+            *args, **kwargs)
+
+    def __getattr__(self, item):
+        """Return attributes of the real breakpoint."""
+        if item in (
+                '____id_pack__',
+                '__name__',
+                '____conn__',
+                'stop',
+                'out_of_scope',
+        ):
+            # Ignore RPyC netref attributes.
+            # Also, if stop() or out_of_scope() are not defined, hasattr() call
+            # in our __init__() will bring us here. Don't contact the
+            # server in this case either.
+            raise AttributeError()
+        return getattr(self.server_breakpoint, item)
+
+    def exposed_stop(self):
+        # Handle stop() call from the server.
+        return self.stop()
+
+    def exposed_out_of_scope(self):
+        # Handle out_of_scope() call from the server.
+        return self.out_of_scope()
+
 class Gdb:
     """Mirror of ``gdb`` module.
 
@@ -682,8 +724,12 @@ class Gdb:
         class _Breakpoint(Breakpoint):
             def __init__(self, *args, **kwargs):
                 super().__init__(conn, *args, **kwargs)
+        class _FinishBreakpoint(FinishBreakpoint):
+            def __init__(self, *args, **kwargs):
+                super().__init__(conn, *args, **kwargs)
 
         self.Breakpoint = _Breakpoint
+        self.FinishBreakpoint = _FinishBreakpoint
         self.stopped = Event()
 
         def stop_handler(event):

--- a/pwnlib/gdb_api_bridge.py
+++ b/pwnlib/gdb_api_bridge.py
@@ -89,6 +89,18 @@ class GdbService(Service):
             return Breakpoint(*args, **kwargs)
         return gdb.Breakpoint(*args, **kwargs)
 
+    def exposed_set_finish_breakpoint(self, client, has_stop, has_out_of_scope, *args, **kwargs):
+        """Create a finish breakpoint and connect it with the client-side mirror."""
+        class FinishBreakpoint(gdb.FinishBreakpoint):
+            def stop(self):
+                if has_stop:
+                    return client.stop()
+                return True
+            def out_of_scope(self):
+                if has_out_of_scope:
+                    client.out_of_scope()
+        return FinishBreakpoint(*args, **kwargs)
+
     def exposed_quit(self):
         """Terminate GDB."""
         gdb.post_event(lambda: gdb.execute('quit'))

--- a/pwnlib/gdb_api_bridge.py
+++ b/pwnlib/gdb_api_bridge.py
@@ -92,12 +92,11 @@ class GdbService(Service):
     def exposed_set_finish_breakpoint(self, client, has_stop, has_out_of_scope, *args, **kwargs):
         """Create a finish breakpoint and connect it with the client-side mirror."""
         class FinishBreakpoint(gdb.FinishBreakpoint):
-            def stop(self):
-                if has_stop:
+            if has_stop:
+                def stop(self):
                     return client.stop()
-                return True
-            def out_of_scope(self):
-                if has_out_of_scope:
+            if has_out_of_scope:
+                def out_of_scope(self):
                     client.out_of_scope()
         return FinishBreakpoint(*args, **kwargs)
 


### PR DESCRIPTION
Support FinishBreakpoints: https://sourceware.org/gdb/onlinedocs/gdb/Finish-Breakpoints-in-Python.html

This feature can be tested by the following:
- `main.c`:
  ```c
  #include <stdio.h>
  #include <stdlib.h>
  
  int subroutine(int a) {
    printf("%d\n", a);
    if (a == 2)
      exit(0);
    return a;
  }
  
  int main() {
    int i;
    for (i = 0; i < 3; i++)
      subroutine(i);
    puts("done");
    return 0;
  }
  ```
- `main.py`:
  ```py
  from pwn import *
  
  io = gdb.debug('./a.out', api=True)
  
  class MyFinishBreakpoint(io.gdb.FinishBreakpoint):
      def stop(self):
          print('FinishBreakpoint Hit, return value:', self.return_value)
          return False
      def out_of_scope(self):
          print('FinishBreakpoint Out of Scope')
  
  class MyBreakpoint(io.gdb.Breakpoint):
      def stop(self):
          print('Breakpoint Hit')
          MyFinishBreakpoint()
          return False
  MyBreakpoint('subroutine')
  
  io.gdb.continue_nowait()
  print(io.recvall().decode())
  io.interactive()
  ```

and run:

```
$ gcc -g main.c
$ tmux
$ python3 main.py
Breakpoint Hit
FinishBreakpoint Hit, return value: 0
Breakpoint Hit
FinishBreakpoint Hit, return value: 1
Breakpoint Hit
FinishBreakpoint Out of Scope
0
1
2
```
