### PR TITLE
Fix typo and comment consistency

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1298,7 +1298,7 @@ class tube(Timeout, Logger):
         Should not be called directly. Sends data to the tube.
 
         Should return ``exceptions.EOFError``, if it is unable to send any
-        more, because of a close tube.
+        more, because of a closed tube.
         """
 
         raise EOFError('Not implemented')
@@ -1314,9 +1314,8 @@ class tube(Timeout, Logger):
 
     def timeout_change(self):
         """
-        Informs the raw layer of the tube that the timeout has changed.
+        Should not be called directly. Informs the raw layer of the tube that the timeout has changed.
 
-        Should not be called directly.
 
         Inherited from :class:`Timeout`.
         """


### PR DESCRIPTION
Fixed a typo in the docstring of `send_raw()` and changed the docstring of `timeout_change()` to match the format of the rest of the methods.