### PR TITLE
Fix boundary judgment error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
+- [#2116][2116] fix format string badbytes not working
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
+[2116]: https://github.com/Gallopsled/pwntools/pull/2116
 
 ## 4.9.0 (`beta`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,10 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
-- [#2116][2116] fix format string badbytes not working
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
-[2116]: https://github.com/Gallopsled/pwntools/pull/2116
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -288,6 +288,20 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
 
     >>> pwnlib.fmtstr.make_atoms_simple(0x0, b"abc", set())
     [AtomWrite(start=0, size=1, integer=0x61, mask=0xff), AtomWrite(start=1, size=1, integer=0x62, mask=0xff), AtomWrite(start=2, size=1, integer=0x63, mask=0xff)]
+    >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xf0')
+    [AtomWrite(start=3735928559, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=3735928561, size=1, integer=0x63, mask=0xff)]    >>> pwnlib.fmtstr.make_atoms_simple(0x1010, b'a'*0x10, b'\x10')
+    >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xef')
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 297, in make_atoms_simple
+        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 308, in make_atoms_simple
+    RuntimeError: impossible to avoid a bad byte in starting address deadbeef
+    >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'a'*0x10, b'\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7')
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 316, in make_atoms_simple
+        raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
+    RuntimeError: impossible to avoid badbytes starting after offset 0 (address deadbeef)
     """
     data = bytearray(data)
     if not badbytes:

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -290,20 +290,20 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
     
     If there are bad bytes, it will try to bypass by skipping addresses containing bad bytes, otherwise a
     RuntimeError will be raised:
-        >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xf0')
-        [AtomWrite(start=3735928559, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=3735928561, size=1, integer=0x63, mask=0xff)]    >>> pwnlib.fmtstr.make_atoms_simple(0x1010, b'a'*0x10, b'\x10')
-        >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xef')
+        >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'abc', b'\x62')
+        [AtomWrite(start=97, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=99, size=1, integer=0x63, mask=0xff)]
+        >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'abc', b'\x61')
         Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
-        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 297, in make_atoms_simple
-            File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 308, in make_atoms_simple
-        RuntimeError: impossible to avoid a bad byte in starting address deadbeef
-        >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'a'*0x10, b'\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7')
+        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 313, in make_atoms_simple
+            raise RuntimeError("impossible to avoid a bad byte in starting address %x" % address)
+        RuntimeError: impossible to avoid a bad byte in starting address 61
+        >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'a'*0x10, b'\x62\x63\x64\x65\x66\x67\x68\x69')
         Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
-        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 316, in make_atoms_simple
+        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 324, in make_atoms_simple
             raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
-        RuntimeError: impossible to avoid badbytes starting after offset 0 (address deadbeef)
+        RuntimeError: impossible to avoid badbytes starting after offset 0 (address 61)
     """
     data = bytearray(data)
     if not badbytes:

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -285,23 +285,25 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
 
     This function is simple and does not try to minimize the number of atoms. For example, if there are no
     bad bytes, it simply returns one atom for each byte:
-
-    >>> pwnlib.fmtstr.make_atoms_simple(0x0, b"abc", set())
-    [AtomWrite(start=0, size=1, integer=0x61, mask=0xff), AtomWrite(start=1, size=1, integer=0x62, mask=0xff), AtomWrite(start=2, size=1, integer=0x63, mask=0xff)]
-    >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xf0')
-    [AtomWrite(start=3735928559, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=3735928561, size=1, integer=0x63, mask=0xff)]    >>> pwnlib.fmtstr.make_atoms_simple(0x1010, b'a'*0x10, b'\x10')
-    >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xef')
-    Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 297, in make_atoms_simple
-        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 308, in make_atoms_simple
-    RuntimeError: impossible to avoid a bad byte in starting address deadbeef
-    >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'a'*0x10, b'\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7')
-    Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 316, in make_atoms_simple
-        raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
-    RuntimeError: impossible to avoid badbytes starting after offset 0 (address deadbeef)
+        >>> pwnlib.fmtstr.make_atoms_simple(0x0, b"abc", set())
+        [AtomWrite(start=0, size=1, integer=0x61, mask=0xff), AtomWrite(start=1, size=1, integer=0x62, mask=0xff), AtomWrite(start=2, size=1, integer=0x63, mask=0xff)]
+    
+    If there are bad bytes, it will try to bypass by skipping addresses containing bad bytes, otherwise a
+    RuntimeError will be raised:
+        >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xf0')
+        [AtomWrite(start=3735928559, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=3735928561, size=1, integer=0x63, mask=0xff)]    >>> pwnlib.fmtstr.make_atoms_simple(0x1010, b'a'*0x10, b'\x10')
+        >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'abc', b'\xef')
+        Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 297, in make_atoms_simple
+            File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 308, in make_atoms_simple
+        RuntimeError: impossible to avoid a bad byte in starting address deadbeef
+        >>> pwnlib.fmtstr.make_atoms_simple(0xdeadbeef, b'a'*0x10, b'\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7')
+        Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 316, in make_atoms_simple
+            raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
+        RuntimeError: impossible to avoid badbytes starting after offset 0 (address deadbeef)
     """
     data = bytearray(data)
     if not badbytes:

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -300,11 +300,11 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
     out = []
     while i < len(data):
         candidate = AtomWrite(address + i, 1, data[i])
-        while i + candidate.size < len(data) and any(x in badbytes for x in pack(candidate.end)):
+        while candidate.end < len(data) and any(x in badbytes for x in pack(candidate.end)):
             candidate = candidate.union(AtomWrite(candidate.end, 1, data[i + candidate.size]))
 
         sz = min([s for s in SPECIFIER if s >= candidate.size] + [float("inf")])
-        if i + sz >= len(data):
+        if candidate.start + sz > len(data):
             raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
         i += candidate.size
         candidate = candidate.union(AtomWrite(candidate.end, sz - candidate.size, 0, 0))

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -304,7 +304,7 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
             candidate = candidate.union(AtomWrite(candidate.end, 1, data[i + candidate.size]))
 
         sz = min([s for s in SPECIFIER if s >= candidate.size] + [float("inf")])
-        if i + sz >= len(data):
+        if i + sz > len(data):
             raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
         i += candidate.size
         candidate = candidate.union(AtomWrite(candidate.end, sz - candidate.size, 0, 0))

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -300,7 +300,7 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
     out = []
     while i < len(data):
         candidate = AtomWrite(address + i, 1, data[i])
-        while candidate.end < len(data) and any(x in badbytes for x in pack(candidate.end)):
+        while i + candidate.size < len(data) and any(x in badbytes for x in pack(candidate.end)):
             candidate = candidate.union(AtomWrite(candidate.end, 1, data[i + candidate.size]))
 
         sz = min([s for s in SPECIFIER if s >= candidate.size] + [float("inf")])

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -292,18 +292,8 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
     RuntimeError will be raised:
         >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'abc', b'\x62')
         [AtomWrite(start=97, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=99, size=1, integer=0x63, mask=0xff)]
-        >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'abc', b'\x61')
-        Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 313, in make_atoms_simple
-            raise RuntimeError("impossible to avoid a bad byte in starting address %x" % address)
-        RuntimeError: impossible to avoid a bad byte in starting address 61
-        >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'a'*0x10, b'\x62\x63\x64\x65\x66\x67\x68\x69')
-        Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-        File "/home/pwwwn/code/pwntools/pwnlib/fmtstr.py", line 324, in make_atoms_simple
-            raise RuntimeError("impossible to avoid badbytes starting after offset %d (address %x)" % (i, i + address))
-        RuntimeError: impossible to avoid badbytes starting after offset 0 (address 61)
+        >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'a'*0x10, b'\x62\x63\x64\x65\x66\x67\x68')
+        [AtomWrite(start=97, size=8, integer=0x6161616161616161, mask=0xffffffffffffffff), AtomWrite(start=105, size=1, integer=0x61, mask=0xff), AtomWrite(start=106, size=1, integer=0x61, mask=0xff), AtomWrite(start=107, size=1, integer=0x61, mask=0xff), AtomWrite(start=108, size=1, integer=0x61, mask=0xff), AtomWrite(start=109, size=1, integer=0x61, mask=0xff), AtomWrite(start=110, size=1, integer=0x61, mask=0xff), AtomWrite(start=111, size=1, integer=0x61, mask=0xff), AtomWrite(start=112, size=1, integer=0x61, mask=0xff)]
     """
     data = bytearray(data)
     if not badbytes:


### PR DESCRIPTION
Reverts Gallopsled/pwntools#2113
I realized that I made a mistake in judging whether it was out of bounds. After testing, I found out that I shouldn't have to add the equals sign, which made the format string with badbytes not work again.