### PR TITLE
Add -p (--prefix) and -s (--separator) arguments to `hex` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,11 @@ jobs:
         pwn disasm --color ff3424c3ebfe
         pwn asm -f hex nop
 
+        pwn hex ABCD
+        pwn hex ABCD --separator ' '
+        pwn hex ABCD --prefix '\x'
+        pwn hex ABCD -p '0x' -s ' '
+
         pwn hex abcd
         pwn unhex 4141 4141
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 4.12.0 (`dev`)
+- [#2117][2117] Add -p (--prefix) and -s (--separator) arguments to `hex` command
 
-
+[2117]: https://github.com/Gallopsled/pwntools/pull/2117
 
 ## 4.11.0 (`beta`)
 

--- a/pwnlib/commandline/hex.py
+++ b/pwnlib/commandline/hex.py
@@ -34,7 +34,7 @@ parser.add_argument(
 )
 
 def format_hex(hex_string, prefix, separator):
-    return separator.join([f"{prefix}{x}" for x in group(2, hex_string)])
+    return separator.join(["%s%s" % (prefix, x) for x in group(2, hex_string)])
 
 def main(args):
     if not args.data:

--- a/pwnlib/commandline/hex.py
+++ b/pwnlib/commandline/hex.py
@@ -7,6 +7,7 @@ import sys
 
 from pwnlib.commandline import common
 from pwnlib.util.fiddling import enhex
+from pwnlib.util.lists import group
 
 parser = common.parser_commands.add_parser(
     'hex',
@@ -32,10 +33,8 @@ parser.add_argument(
     help = 'Add a separator between each byte',
 )
 
-def format_hex(s, prefix, separator):
-    n = 2
-    parts = [s[i:i+n] for i in range(0, len(s), n)]
-    return separator.join([f"{prefix}{x}" for x in parts])
+def format_hex(hex_string, prefix, separator):
+    return separator.join([f"{prefix}{x}" for x in group(2, hex_string)])
 
 def main(args):
     if not args.data:

--- a/pwnlib/commandline/hex.py
+++ b/pwnlib/commandline/hex.py
@@ -16,14 +16,40 @@ parser = common.parser_commands.add_parser(
 parser.add_argument('data', nargs='*',
     help='Data to convert into hex')
 
+parser.add_argument(
+    '-p', '--prefix',
+    metavar = 'prefix',
+    type = str,
+    default = '',
+    help = 'Insert a prefix before each byte',
+)
+
+parser.add_argument(
+    '-s', '--separator',
+    metavar = 'separator',
+    type = str,
+    default = '',
+    help = 'Add a separator between each byte',
+)
+
+def format_hex(s, prefix, separator):
+    n = 2
+    parts = [s[i:i+n] for i in range(0, len(s), n)]
+    return separator.join([f"{prefix}{x}" for x in parts])
+
 def main(args):
     if not args.data:
-        print(enhex(getattr(sys.stdin, 'buffer', sys.stdin).read()))
+        encoded = enhex(getattr(sys.stdin, 'buffer', sys.stdin).read())
     else:
         data = ' '.join(args.data)
         if not hasattr(data, 'decode'):
             data = data.encode('utf-8', 'surrogateescape')
-        print(enhex(data))
+        encoded = enhex(data)
+
+    if args.prefix or args.separator:
+        encoded = format_hex(encoded, args.prefix, args.separator)
+
+    print(encoded)
 
 if __name__ == '__main__':
     common.main(__file__)

--- a/pwnlib/commandline/hex.py
+++ b/pwnlib/commandline/hex.py
@@ -34,7 +34,7 @@ parser.add_argument(
 )
 
 def format_hex(hex_string, prefix, separator):
-    return separator.join(["%s%s" % (prefix, x) for x in group(2, hex_string)])
+    return separator.join([prefix + x for x in group(2, hex_string)])
 
 def main(args):
     if not args.data:


### PR DESCRIPTION
# Add formats for hex
Add `-p` (`--prefix`) and `-s` (`--separator`) arguments for adding a prefix and/or a separator to the output of the hex command.

```bash
$ pwn hex ABCD
41424344
$ pwn hex ABCD --separator ' '
41 42 43 44
$ pwn hex ABCD --prefix '\x'
\x41\x42\x43\x44
$ pwn hex ABCD -p '0x' -s ' '
0x41 0x42 0x43 0x44
```

Relates to #2071.
