### PR TITLE
Fix inconsistent comparison of sets in encode when using regular expression

### DIFF
--- a/pwnlib/encoders/encoder.py
+++ b/pwnlib/encoders/encoder.py
@@ -67,7 +67,7 @@ def encode(raw_bytes, avoid=None, expr=None, force=0, pcreg=''):
     if expr:
         for char in all_chars:
             if re.search(expr, char):
-                avoid.add(char)
+                avoid.add(ord(char))
 
     if not (force or avoid & set(raw_bytes)):
         return raw_bytes


### PR DESCRIPTION
In this code: 
```python
67    if expr:
68        for char in all_chars:
69            if re.search(expr, char):
70                avoid.add(char)
```
which make avoid something like `{'a', 'b'}`.

But `set()` of bytes would be `{some ints}`.

This will invalidate the following conditions because they can never intersect:
```python
79        if encoder.blacklist & avoid:
...
87        if avoid & set(v):
```