### PR TITLE
Fix ROP without a writeable cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,13 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1828][1828] libcdb: Load debug info and unstrip libc binary
 - [#1939][1939] Fix error in validating log levels
 - [#1981][1981] Fix `cyclic_find()` to make it work with large int values
+- [#2123][2123] Fix ROP without a writeable cache directory
 
 [1922]: https://github.com/Gallopsled/pwntools/pull/1922
 [1828]: https://github.com/Gallopsled/pwntools/pull/1828
 [1939]: https://github.com/Gallopsled/pwntools/pull/1939
 [1981]: https://github.com/Gallopsled/pwntools/pull/1981
+[2123]: https://github.com/Gallopsled/pwntools/pull/2123
 
 ## 4.7.1
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1189,6 +1189,9 @@ class ROP(object):
 
     def __get_cachefile_name(self, files):
         """Given an ELF or list of ELF objects, return a cache file for the set of files"""
+        if context.cache_dir is None:
+            return None
+
         cachedir = os.path.join(context.cache_dir, 'rop-cache')
         if not os.path.exists(cachedir):
             os.mkdir(cachedir)
@@ -1205,12 +1208,14 @@ class ROP(object):
     @staticmethod
     def clear_cache():
         """Clears the ROP gadget cache"""
+        if context.cache_dir is None:
+            return
         cachedir = os.path.join(context.cache_dir, 'rop-cache')
         shutil.rmtree(cachedir)
 
     def __cache_load(self, elf):
         filename = self.__get_cachefile_name(elf)
-        if not os.path.exists(filename):
+        if filename is None or not os.path.exists(filename):
             return None
         gadgets = eval(open(filename).read())
         gadgets = {k - elf.load_addr + elf.address:v for k, v in gadgets.items()}
@@ -1218,8 +1223,11 @@ class ROP(object):
         return gadgets
 
     def __cache_save(self, elf, data):
+        filename = self.__get_cachefile_name(elf)
+        if filename is None:
+            return
         data = {k + elf.load_addr - elf.address:v for k, v in data.items()}
-        open(self.__get_cachefile_name(elf), 'w+').write(repr(data))
+        open(filename, 'w+').write(repr(data))
 
     def __load(self):
         """Load all ROP gadgets for the selected ELF files"""


### PR DESCRIPTION
`context.cache_dir` can be None, but the ROP class assumed it would always be a valid path and crash. Disable rop-cache if we can't save it.

Fixes #2072
