### PR TITLE
Fix tube.recvpred() timout argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,12 +95,14 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1939][1939] Fix error in validating log levels
 - [#1981][1981] Fix `cyclic_find()` to make it work with large int values
 - [#2123][2123] Fix ROP without a writeable cache directory
+- [#2124][2124] Fix `tube.recvpred()` timout argument
 
 [1922]: https://github.com/Gallopsled/pwntools/pull/1922
 [1828]: https://github.com/Gallopsled/pwntools/pull/1828
 [1939]: https://github.com/Gallopsled/pwntools/pull/1939
 [1981]: https://github.com/Gallopsled/pwntools/pull/1981
 [2123]: https://github.com/Gallopsled/pwntools/pull/2123
+[2124]: https://github.com/Gallopsled/pwntools/pull/2124
 
 ## 4.7.1
 

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -204,14 +204,29 @@ class tube(Timeout, Logger):
         Returns:
             A bytes object containing bytes received from the socket,
             or ``''`` if a timeout occurred while waiting.
+
+        Examples:
+
+            >>> t = tube()
+            >>> t.recv_raw = lambda n: b'abbbaccc'
+            >>> pred = lambda p: p.count(b'a') == 2
+            >>> t.recvpred(pred)
+            b'abbba'
+            >>> pred = lambda p: p.count(b'd') > 0
+            >>> t.recvpred(pred, timeout=0.05)
+            b''
         """
 
         data = b''
 
         with self.countdown(timeout):
             while not pred(data):
+                if not self.countdown_active():
+                    self.unrecv(data)
+                    return b''
+
                 try:
-                    res = self.recv(1)
+                    res = self.recv(1, timeout=timeout)
                 except Exception:
                     self.unrecv(data)
                     return b''


### PR DESCRIPTION
The `timeout` argument wasn't implemented correctly causing the function to hang instead of timing out.