### PR TITLE
Allow tube.recvregex to return capture groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
+- [#2125][2125] Allow tube.recvregex to return capture groups
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
+[2125]: https://github.com/Gallopsled/pwntools/pull/2125
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -633,17 +633,30 @@ class tube(Timeout, Logger):
                                   keepends=keepends,
                                   timeout=timeout)
 
-    def recvregex(self, regex, exact=False, timeout=default):
-        """recvregex(regex, exact=False, timeout=default) -> bytes
+    def recvregex(self, regex, exact=False, timeout=default, capture=False):
+        r"""recvregex(regex, exact=False, timeout=default, capture=False) -> bytes
 
         Wrapper around :func:`recvpred`, which will return when a regex
         matches the string in the buffer.
+
+        Returns all received data up until the regex matched. If `capture` is
+        set to True, a :class:`re.Match` object is returned instead.
 
         By default :func:`re.RegexObject.search` is used, but if `exact` is
         set to True, then :func:`re.RegexObject.match` will be used instead.
 
         If the request is not satisfied before ``timeout`` seconds pass,
         all data is buffered and an empty string (``''``) is returned.
+
+        Examples:
+
+            >>> t = tube()
+            >>> t.recv_raw = lambda n: b'The lucky number is 1337 as always\nBla blubb blargh\n'
+            >>> m = t.recvregex(br'number is ([0-9]+) as always\n', capture=True)
+            >>> m.group(1)
+            b'1337'
+            >>> t.recvregex(br'Bla .* blargh\n')
+            b'Bla blubb blargh\n'
         """
 
         if isinstance(regex, (bytes, bytearray, six.text_type)):
@@ -655,7 +668,10 @@ class tube(Timeout, Logger):
         else:
             pred = regex.search
 
-        return self.recvpred(pred, timeout = timeout)
+        if capture:
+            return pred(self.recvpred(pred, timeout = timeout))
+        else:
+            return self.recvpred(pred, timeout = timeout)
 
     def recvline_regex(self, regex, exact=False, keepends=False, timeout=default):
         """recvline_regex(regex, exact=False, keepends=False, timeout=default) -> bytes


### PR DESCRIPTION
When wanting to extract a value from the received data, one had to receive up until the value and the value itself in two steps without carving the data out of a large blob like this:

```python
io.recvuntil(b'The address is: ')
address = int(io.recvline(), 16)
```

or use a regex twice:

```python
pattern = re.compile(rb'The address is: (0x[0-9a-fA-F]+)')
data = io.recvregex(pattern)
address = int(pattern.search(data).group(1), 16)
```

This patch allows to pass `capture=True` to `tube.recvregex()` to return a `re.Match` object instead of the raw bytes.

```python
addr = int(io.recvregex(rb'The address is: (0x[0-9a-fA-F]+)', capture=True).group(1), 16)
```

This allows for slicker data extraction!

Fixes #1962
