### PR TITLE
Mention need for `listen.wait_for_connection()` in docs

### DIFF
--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -13,7 +13,8 @@ log = getLogger(__name__)
 
 class listen(sock):
     r"""Creates an TCP or UDP-socket to receive data on. It supports
-    both IPv4 and IPv6.
+    both IPv4 and IPv6. You need to call :meth:`wait_for_connection`
+    before using the listen socket.
 
     The returned object supports all the methods from
     :class:`pwnlib.tubes.sock` and :class:`pwnlib.tubes.tube`.
@@ -46,6 +47,7 @@ class listen(sock):
         >>> # and it works with ipv6 by defaut, too!
         >>> l = listen()
         >>> r = remote('::1', l.lport)
+        >>> _ = l.wait_for_connection()
         >>> r.sendline(b'Bye-bye')
         >>> l.recvline()
         b'Bye-bye\n'


### PR DESCRIPTION
You have to call `listen.wait_for_connection()` before using the listen socket or you face raceconditions with the thread accepting the client connection. Mention that fact more explicitly in the docs instead of just in the example code. The IPv6 example was even missing said call.

Fixes #2100
