### PR TITLE
Support non-bytes argument in `packing._need_text()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
+- [#2127][2127] Support non-bytes argument in `packing._need_text()`
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
+[2127]: https://github.com/Gallopsled/pwntools/pull/2127
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -441,7 +441,7 @@ def make_packer(word_size = None, sign = None, **kwargs):
 def make_unpacker(word_size = None, endianness = None, sign = None, **kwargs):
     """make_unpacker(word_size = None, endianness = None, sign = None,  **kwargs) -> str → number
 
-    Creates a unpacker by "freezing" the given arguments.
+    Creates an unpacker by "freezing" the given arguments.
 
     Semantically calling ``make_unpacker(w, e, s)(data)`` is equivalent to calling
     ``unpack(data, w, e, s)``. If word_size is one of 8, 16, 32 or 64, it is however
@@ -836,7 +836,7 @@ def dd(dst, src, count = 0, skip = 0, seek = 0, truncate = False):
     values from offset `seek` in `src` to offset `skip` in `dst`.  If `count` is
     0, all of ``src[seek:]`` is copied.
 
-    If `dst` is a mutable type it will be updated.  Otherwise a new instance of
+    If `dst` is a mutable type it will be updated.  Otherwise, a new instance of
     the same type will be created.  In either case the result is returned.
 
     `src` can be an iterable of characters or integers, a unicode string or a
@@ -1034,6 +1034,9 @@ def _need_bytes(s, level=1, min_wrong=0):
 def _need_text(s, level=1):
     if isinstance(s, (str, six.text_type)):
         return s   # already text
+
+    if not isinstance(s, (bytes, bytearray)):
+        return repr(s)
 
     encoding = context.encoding
     errors = 'strict'


### PR DESCRIPTION
Allow to pass everything to `_need_text` and be sure to get a string back. This allows to log any object without the need for a format string by calling `repr` on it.

```py
# before:
log.info('%r', 5)
# now
log.info(5)
```

(Also fixes some grammar mistakes noticed on the way.)

Fixes #2018