### PR TITLE
Support adding lists in `ROP.raw()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
+- [#2128][2128] Support adding lists in `ROP.raw()`
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
+[2128]: https://github.com/Gallopsled/pwntools/pull/2128
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1169,7 +1169,7 @@ class ROP(object):
 
     def _flatten(self, initial_list):
         # Flatten out any nested lists.
-        flattened_list = list()
+        flattened_list = []
         for data in initial_list:
             if isinstance(data, (list, tuple)):
                 flattened_list.extend(self._flatten(data))


### PR DESCRIPTION
Allow to add multiple raw entries to a rop chain using an array instead of multiple calls to `raw()`.

```py
rop = ROP('/bin/ls')
# before
rop.raw(1)
rop.raw(2)
rop.raw(rop.ret)

# after
rop.raw([1, 2, rop.ret])
```

Fixes #2017