### PR TITLE
Handle `context.newline` correctly in `tube.interactive()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,6 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2125][2125] Allow tube.recvregex to return capture groups
 - [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
 
-
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,13 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
 - [#2125][2125] Allow tube.recvregex to return capture groups
+- [#2129][2129] Handle `context.newline` correctly when typing in `tube.interactive()`
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
 [2125]: https://github.com/Gallopsled/pwntools/pull/2125
+[2129]: https://github.com/Gallopsled/pwntools/pull/2129
 
 ## 4.9.0 (`beta`)
 

--- a/pwnlib/term/readline.py
+++ b/pwnlib/term/readline.py
@@ -404,7 +404,7 @@ def readline(_size=-1, prompt='', float=True, priority=10):
                     buffer = (buffer_left + buffer_right)
                     if buffer:
                         history.insert(0, buffer)
-                    return force_to_bytes(buffer) + b'\n'
+                    return force_to_bytes(buffer)
             except KeyboardInterrupt:
                 control_c()
     finally:

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -886,7 +886,7 @@ class tube(Timeout, Logger):
                 if term.term_mode:
                     data = term.readline.readline(prompt=prompt, float=True)
                     if data:
-                        data = data.replace(b'\n', self.newline)
+                        data += self.newline
                 else:
                     stdin = getattr(sys.stdin, 'buffer', sys.stdin)
                     data = stdin.read(1)

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -883,6 +883,7 @@ class tube(Timeout, Logger):
                 os_linesep = os.linesep.encode()
                 if term.term_mode:
                     data = term.readline.readline(prompt = prompt, float = True)
+                    data = data.replace(os_linesep, self.newline)
                 else:
                     stdin = getattr(sys.stdin, 'buffer', sys.stdin)
                     data = b''
@@ -892,9 +893,9 @@ class tube(Timeout, Logger):
                             if not new_byte:
                                 break
                             data += new_byte
+                        data = data.replace(os_linesep, self.newline)
                     else:
                         data = stdin.read(1)
-                data = data.replace(os_linesep, self.newline)
 
                 if data:
                     try:

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -899,7 +899,7 @@ class tube(Timeout, Logger):
             to_skip = b''
             while not go.isSet():
                 if term.term_mode:
-                    data = term.readline.readline(prompt=prompt, float=True)
+                    data = term.readline.readline(prompt = prompt, float = True)
                     if data:
                         data += self.newline
                 else:


### PR DESCRIPTION
The `context.newline` or `self.newline` variable isn't obeyed when typing in interactive mode. It is used when sending and receiving lines through `tube.sendline` though, causing a mismatch.

The receiving end of the `tube.interactive()` already has handling of newlines, but the sending side does not.

Example:
```python
from pwn import *
io = process('cat')
io.newline = b'\r\n'
io.sendline(b'auto')
io.interactive()
```

```
$ python testinteractive.py DEBUG
[x] Starting local process '/usr/bin/cat' argv=[b'cat']
[+] Starting local process '/usr/bin/cat' argv=[b'cat'] : pid 19060
[DEBUG] Sent 0x6 bytes:
    b'auto\r\n'
[*] Switching to interactive mode
[DEBUG] Received 0x6 bytes:
    b'auto\r\n'
auto
$ test
[DEBUG] Sent 0x5 bytes:
    b'test\n'
[DEBUG] Received 0x5 bytes:
    b'test\n'
test
```

The expected outcome would be to send `b'test\r\n'`.

The same problem arises in non-term mode (`PWNLIB_NOTERM=1`), where stdin is read in binary mode causing the OS line seperators to come through. Correctly replacing them with the `context.newline` setting allows to use the interactive input on windows hosts as well, without constantly sending `\r\n`.