### PR TITLE
Added arch and bits specific flag to asm call from elf wrapper

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1535,7 +1535,7 @@ class ELF(ELFFile):
         This modifies the ELF in-place.
         The resulting binary can be saved with :meth:`.ELF.save`
         """
-        binary = asm(assembly, vma=address)
+        binary = asm(assembly, vma=address, arch=self.arch, endian=self.endian, bits=self.bits)
         self.write(address, binary)
 
     def bss(self, offset=0):


### PR DESCRIPTION
In the ELF class, the `asm(...)` method wraps the `pwnlib.asm:asm` which defaults to 32 bits. I added bits, arch, and endianness to that call so that calls to the `ELF.asm(...)` method will use the flags that apply to the loaded ELF file.