### PR TITLE
Fix PwntoolsLexer number matching

### DIFF
--- a/pwnlib/lexer.py
+++ b/pwnlib/lexer.py
@@ -38,7 +38,7 @@ class PwntoolsLexer(RegexLexer):
     string = r'"(\\"|[^"])*"'
     char = r'[\w$.@-]'
     identifier = r'(?:[a-zA-Z$_]' + char + r'*|\.' + char + '+|or)'
-    number = r'(?:0[xX][a-zA-Z0-9]+|\d+)'
+    number = r'(?:-?0[xX][a-zA-Z0-9]+|\d+)'
     memory = r'(?:[\]\[])'
     bad = r'(?:\(bad\))'
 


### PR DESCRIPTION
This commit fixes a small bug with PwntoolsLexer where it matched negative numbers incorrectly in Arm assembly.

See https://github.com/pwndbg/pwndbg/pull/1367 for more information.