### PR TITLE
Fix `make_elf` on systems with GNU ld 2.39+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#1981][1981] Fix `cyclic_find()` to make it work with large int values
 - [#2123][2123] Fix ROP without a writeable cache directory
 - [#2124][2124] Fix `tube.recvpred()` timout argument
+- [#2141][2141] Fix `make_elf` on systems with GNU ld 2.39+
 
 [1922]: https://github.com/Gallopsled/pwntools/pull/1922
 [1828]: https://github.com/Gallopsled/pwntools/pull/1828
@@ -103,6 +104,7 @@ The table below shows which release corresponds to each branch, and what date th
 [1981]: https://github.com/Gallopsled/pwntools/pull/1981
 [2123]: https://github.com/Gallopsled/pwntools/pull/2123
 [2124]: https://github.com/Gallopsled/pwntools/pull/2124
+[2141]: https://github.com/Gallopsled/pwntools/pull/2141
 
 ## 4.7.1
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -276,6 +276,16 @@ def _linker():
         'i386': ['-m', 'elf_i386'],
     }.get(context.arch, [])
 
+    try:
+        # Test if this argument is recognised
+        # If so, we should add it to the commandline so we don't throw spurious errors later on
+        # https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=ld/NEWS;hb=refs/heads/binutils-2_39-branch
+        proc = subprocess.run(ld + ["--no-warn-rwx-segments", "--help"], capture_output=True)
+        if proc.returncode == 0:
+            arguments.append("--no-warn-rwx-segments")
+    except Exception as e:
+        pass
+
     return ld + bfd + [E] + arguments
 
 def _objcopy():


### PR DESCRIPTION
Fixes #2140

GNU ld 2.39 introduces a new warning which is always invoked by `ELF.from_bytes` and similar functions.

This PR detects affected versions of `ld` and adds an argument which ignores the warning.