### PR TITLE
Reduce Pylint CI false positives

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,10 +28,10 @@ jobs:
         set -x
         pip install pylint
         pip install --upgrade -r requirements.txt
-        pylint --exit-zero --errors-only  pwnlib > current.txt
+        pylint --exit-zero --errors-only pwnlib -f parseable | cut -d ' ' -f2- > current.txt
         git fetch origin
         git checkout origin/"$GITHUB_BASE_REF"
-        pylint --exit-zero --errors-only  pwnlib > base.txt
+        pylint --exit-zero --errors-only pwnlib -f parseable | cut -d ' ' -f2- > base.txt
         if diff base.txt current.txt | grep '>'; then
           false
         fi


### PR DESCRIPTION
As noted in #2141, the CI detects new lint errors by diffing the output of `pylint` before and after a change - this means that if a file with existing errors is edited, the line numbers change and the CI fails.

This PR removes the line information from the diffed output, which should reduce these spurious failures.

Unfortunately, this does mean contributors will be required to lint locally to see the actual location of any newly introduced issues, so maybe this isn't the best approach.