### PR TITLE
Fix asm() instruction consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,12 +70,13 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
 - [#2125][2125] Allow tube.recvregex to return capture groups
-- Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
+- [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
 [2125]: https://github.com/Gallopsled/pwntools/pull/2125
+[2144]: https://github.com/Gallopsled/pwntools/pull/2144
 
 ## 4.9.0 (`beta`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
 - [#2125][2125] Allow tube.recvregex to return capture groups
+- Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -305,20 +305,23 @@ def _arch_header():
     prefix  = ['.section .shellcode,"awx"',
                 '.global _start',
                 '.global __start',
-                '.p2align 2',
                 '_start:',
                 '__start:']
     headers = {
-        'i386'  :  ['.intel_syntax noprefix'],
-        'amd64' :  ['.intel_syntax noprefix'],
+        'i386'  :  ['.intel_syntax noprefix', '.p2align 0'],
+        'amd64' :  ['.intel_syntax noprefix', '.p2align 0'],
         'arm'   : ['.syntax unified',
                    '.arch armv7-a',
-                   '.arm'],
+                   '.arm',
+                   '.p2align 2'],
         'thumb' : ['.syntax unified',
                    '.arch armv7-a',
-                   '.thumb'],
+                   '.thumb',
+                   '.p2align 0'
+                   ],
         'mips'  : ['.set mips2',
                    '.set noreorder',
+                   '.p2align 2'
                    ],
     }
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -317,7 +317,7 @@ def _arch_header():
         'thumb' : ['.syntax unified',
                    '.arch armv7-a',
                    '.thumb',
-                   '.p2align 0'
+                   '.p2align 1'
                    ],
         'mips'  : ['.set mips2',
                    '.set noreorder',


### PR DESCRIPTION
# Fix asm() instruction consistency

### Expected Behaviour

When using either `asm()` with the `vma` parameter or the `ELF.asm()` function with an instruction like `nop` I expect it to write 1 byte `0x90` at the specified position.

### Actual behaviour

Depending on the memory address specified (either as `vma` or as first parameter of `ELF.asm()`) it will add padding `nop` bytes before the instruction. More specifically, if the address is not a multiple of 4 (`address % 4 != 0`) it will add `4 - (address % 4)` padding bytes making it sometimes hard to patch instructions smaller than 4 bytes.

### Example Script

Running this script will quickly demonstrate the effect
```py
from pwn import *

for i in range(17):
    print(f"{i}", asm("INT 3", vma=i))
```

#### Output before changes
```
0 b'\xcc'
1 b'f\x90\x90\xcc'
2 b'f\x90\xcc'
3 b'\x90\xcc'
4 b'\xcc'
5 b'f\x90\x90\xcc'
6 b'f\x90\xcc'
7 b'\x90\xcc'
8 b'\xcc'
9 b'f\x90\x90\xcc'
10 b'f\x90\xcc'
11 b'\x90\xcc'
12 b'\xcc'
13 b'f\x90\x90\xcc'
14 b'f\x90\xcc'
15 b'\x90\xcc'
16 b'\xcc'
```

#### Output after changes
```
0 b'\xcc'
1 b'\xcc'
2 b'\xcc'
3 b'\xcc'
4 b'\xcc'
5 b'\xcc'
6 b'\xcc'
7 b'\xcc'
8 b'\xcc'
9 b'\xcc'
10 b'\xcc'
11 b'\xcc'
12 b'\xcc'
13 b'\xcc'
14 b'\xcc'
15 b'\xcc'
16 b'\xcc'
```

## Testing

I was not able to start the whole test suite but I tried testing at least the `asm` part which doesn't start on only one architecture (it isn't failing, I'm missing some dependency).  
The Docker image also seems to fail to build at the `apt update` step.  
`E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`

This, therefore, might require at least someone who can run all the tests to test them again

_(First time contributing to a project, I hope I did this right, I apologize if I made a mistake either choosing the wrong target branch or in the rest of the pull request)_