### PR TITLE
Fixes for download_dir

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1565,8 +1565,8 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             local_tar = tempfile.NamedTemporaryFile(suffix='.tar.gz')
             self.download_file(remote_tar, local_tar.name)
             
-            #Delete temporary tarfile from remote host
-            if(self.sftp):
+            # Delete temporary tarfile from remote host
+            if self.sftp:
                 self.unlink(remote_tar)
             else:
                 self.system(b'rm ' + sh_string(remote_tar)).wait()

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1547,7 +1547,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         self.info("Downloading %r to %r" % (remote, local))
 
-        if(ignore_failed_read):
+        if ignore_failed_read:
             opts = b" --ignore-failed-read"
         else:
             opts = b""
@@ -1564,7 +1564,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
             local_tar = tempfile.NamedTemporaryFile(suffix='.tar.gz')
             self.download_file(remote_tar, local_tar.name)
-            
+
             # Delete temporary tarfile from remote host
             if self.sftp:
                 self.unlink(remote_tar)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1564,8 +1564,12 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
             local_tar = tempfile.NamedTemporaryFile(suffix='.tar.gz')
             self.download_file(remote_tar, local_tar.name)
-
-            self.system(b"rm "+remote_tar)
+            
+            #Delete temporary tarfile from remote host
+            if(self.sftp):
+                self.unlink(remote_tar)
+            else:
+                self.system(b'rm ' + sh_string(remote_tar)).wait()
             tar = tarfile.open(local_tar.name)
             tar.extractall(local)
 


### PR DESCRIPTION
- Fixes a bug of missing `.recvall().strip()` when `self.sftp == False`
- Adds option `ignore_failed_read` to ignore files in the folder that current user has no read access
- Deletes created temporary file after download
