### PR TITLE
Force `ELF.path` to be of type string

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -225,7 +225,7 @@ class ELF(ELFFile):
         super(ELF,self).__init__(self.mmap)
 
         #: :class:`str`: Path to the file
-        self.path = os.path.abspath(path)
+        self.path = packing._need_text(os.path.abspath(path))
 
         #: :class:`str`: Architecture of the file (e.g. ``'i386'``, ``'arm'``).
         #:


### PR DESCRIPTION
This fixes #2166.

This PR forces the `path` class variable of the `ELF` class to be of type string, even if a byte string argument is supplied. This also makes the implementation consistent with the documentation, which states that `ELF.path` is of type `str`.

Signed-off-by: James Raphael Tiovalen <jamestiotio@gmail.com>