### PR TITLE
ci: leverage stock Android SDK present on GHA

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,14 +33,13 @@ jobs:
           qemu-user-static \
           binutils-aarch64-linux-gnu \
           binutils-arm-linux-gnueabihf \
-          libc6-dbg \
-          openjdk-8-jre-headless
+          libc6-dbg
 
     - name: Install Android AVD
       run: |
-        USER=travis source travis/setup_avd.sh
+        source travis/setup_avd_fast.sh
         sed -i 's/skip_android = True/skip_android = False/' docs/source/conf.py
-        set | egrep '^(ANDROID|PATH)' >.android.env
+        set | grep ^PATH >.android.env
 
     - name: Install dependencies
       run: |

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -1370,8 +1370,12 @@ def compile(source):
     ndk_build = misc.which('ndk-build')
     if not ndk_build:
         # Ensure that we can find the NDK.
-        ndk = os.environ.get('NDK', None)
-        if ndk is None:
+        for envvar in ('NDK', 'ANDROID_NDK', 'ANDROID_NDK_ROOT',
+                       'ANDROID_NDK_HOME', 'ANDROID_NDK_LATEST_HOME'):
+            ndk = os.environ.get(envvar)
+            if ndk is not None:
+                break
+        else:
             log.error('$NDK must be set to the Android NDK directory')
         ndk_build = os.path.join(ndk, 'ndk-build')
 

--- a/travis/setup_avd_fast.sh
+++ b/travis/setup_avd_fast.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -ex
+
+# Grab prerequisites
+# Valid ABIs:
+# - armeabi-v7a
+# - arm64-v8a
+# - x86
+# - x86_64
+ANDROID_ABI='armeabi-v7a'
+ANDROIDV=android-24
+
+# Create our emulator Android Virtual Device (AVD)
+# --snapshot flag is deprecated, see bitrise-steplib/steps-create-android-emulator#18
+export PATH=$PATH:"$ANDROID_HOME"/cmdline-tools/latest/bin:"$ANDROID_HOME"/platform-tools
+yes | sdkmanager --sdk_root="$ANDROID_HOME" --install "system-images;$ANDROIDV;default;$ANDROID_ABI"
+yes | sdkmanager --sdk_root="$ANDROID_HOME" --licenses
+echo no | avdmanager --silent create avd --name android-$ANDROID_ABI --force --package "system-images;$ANDROIDV;default;$ANDROID_ABI"
+
+"$ANDROID_HOME"/emulator/emulator -avd android-$ANDROID_ABI -no-window -no-boot-anim -read-only -no-audio -no-window -no-snapshot &
+adb wait-for-device
+adb shell id
+adb shell getprop


### PR DESCRIPTION
I did not know that before, but GHA runners apparently already have Android SDK [preinstalled](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#android) (although without system images...).  We can install less packages and download less data, saving approx. 60-90 seconds (50% of setup time, ≈20% of total workflow time) on the Android tests.

Feedback is appreciated.