### PR TITLE
Determine elf arch by e_machine and bits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       run: pip install -r docs/requirements.txt
 
     - name: Manually install non-broken Unicorn
-      run:  pip install unicorn==1.0.2rc3
+      run:  pip install unicorn==2.0.0rc7
 
     - name: Disable yama ptrace_scope
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2103][2103] Add search for libc binary by leaked function addresses `libcdb.search_by_symbol_offsets()`
 - [#2125][2125] Allow tube.recvregex to return capture groups
 - [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
-- [#2177][2177] Determine elf arch by e_machine and bits
+- [#2177][2177] Support for RISC-V 64-bit architecture
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2103][2103] Add search for libc binary by leaked function addresses `libcdb.search_by_symbol_offsets()`
 - [#2125][2125] Allow tube.recvregex to return capture groups
 - [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
+- [#2177][2177] Determine elf arch by e_machine and bits
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
@@ -80,6 +81,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2103]: https://github.com/Gallopsled/pwntools/pull/2103
 [2125]: https://github.com/Gallopsled/pwntools/pull/2125
 [2144]: https://github.com/Gallopsled/pwntools/pull/2144
+[2177]: https://github.com/Gallopsled/pwntools/pull/2177
 
 ## 4.10.0 (`beta`)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -404,7 +404,8 @@ class ContextType(object):
         'msp430':    little_16,
         'powerpc':   big_32,
         'powerpc64': big_64,
-        'riscv':     little_32,
+        'riscv32':   little_32,
+        'riscv64':   little_64,
         's390':      big_32,
         'sparc':     big_32,
         'sparc64':   big_64,
@@ -775,7 +776,9 @@ class ContextType(object):
                      ('i686', 'i386'),
                      ('armv7l', 'arm'),
                      ('armeabi', 'arm'),
-                     ('arm64', 'aarch64')]
+                     ('arm64', 'aarch64'),
+                     ('rv32', 'riscv32'),
+                     ('rv64', 'riscv64')]
         for k, v in transform:
             if arch.startswith(k):
                 arch = v
@@ -1447,7 +1450,7 @@ class ContextType(object):
         from pwnlib.tubes.ssh import ssh
 
         if not isinstance(shell, ssh):
-            raise AttributeError("context.ssh_session must be an ssh tube") 
+            raise AttributeError("context.ssh_session must be an ssh tube")
 
         return shell
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -472,7 +472,7 @@ class ELF(ELFFile):
             ('EM_SPARCV9', 64): 'sparc64',
             ('EM_IA_64', 64): 'ia64',
             ('EM_RISCV', 32): 'riscv32',
-            ('EM_RISCV', 64): 'riscv64'
+            ('EM_RISCV', 64): 'riscv64',
         }.get((self['e_machine'], self.bits), self['e_machine'])
 
     @property

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -64,8 +64,11 @@ def prepare_unicorn_and_context(elf, got, address, data):
         'arm': U.UC_ARCH_ARM,
         'i386': U.UC_ARCH_X86,
         'mips': U.UC_ARCH_MIPS,
+        'mips64': U.UC_ARCH_MIPS,
         # 'powerpc': U.UC_ARCH_PPC, <-- Not actually supported
         'thumb': U.UC_ARCH_ARM,
+        'riscv32': U.UC_ARCH_RISCV,
+        'riscv64': U.UC_ARCH_RISCV
     }.get(elf.arch, None)
 
     if arch is None:

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -68,7 +68,7 @@ def prepare_unicorn_and_context(elf, got, address, data):
         # 'powerpc': U.UC_ARCH_PPC, <-- Not actually supported
         'thumb': U.UC_ARCH_ARM,
         'riscv32': U.UC_ARCH_RISCV,
-        'riscv64': U.UC_ARCH_RISCV
+        'riscv64': U.UC_ARCH_RISCV,
     }.get(elf.arch, None)
 
     if arch is None:


### PR DESCRIPTION
# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

In context module, riscv32 and riscv64 need to be assigned arch separately.
In elf module, riscv32 and riscv64 share the same e_machine, EM_RISCV, and we used e_machine to determine arch directly, which does not work for RISC-V (and MIPS).
Change to determining elf arch by e_machine and bits.

Separate 32/64 for riscv and mips.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
