### PR TITLE
Fix debugging and assembly for RISCV

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -185,6 +185,7 @@ def which_binutils(util, check_version=False):
         'mips64': ['mips'],
         'powerpc64': ['powerpc'],
         'sparc64': ['sparc'],
+        'riscv32': ['riscv32', 'riscv64'],
     }.get(arch, [])
 
     # If one of the candidate architectures matches the native
@@ -262,7 +263,11 @@ def _assembler():
         'powerpc64': [gas, '-m%s' % context.endianness, '-mppc%s' % context.bits],
 
         # ia64 only accepts -mbe or -mle
-        'ia64':    [gas, '-m%ce' % context.endianness[0]]
+        'ia64':    [gas, '-m%ce' % context.endianness[0]],
+
+        # riscv64-unknown-elf-as supports riscv32 as well as riscv64
+        'riscv32': [gas, '-march=rv32gc', '-mabi=ilp32'],
+        'riscv64': [gas, '-march=rv64gc', '-mabi=lp64'],
     }
 
     assembler = assemblers.get(context.arch, [gas])
@@ -362,7 +367,8 @@ def _bfdname():
         'msp430'  : 'elf32-msp430',
         'powerpc' : 'elf32-powerpc',
         'powerpc64' : 'elf64-powerpc',
-        'riscv'   : 'elf%d-%sriscv' % (context.bits, E),
+        'riscv32' : 'elf%d-%sriscv' % (context.bits, E),
+        'riscv64' : 'elf%d-%sriscv' % (context.bits, E),
         'vax'     : 'elf32-vax',
         's390'    : 'elf%d-s390' % context.bits,
         'sparc'   : 'elf32-sparc',
@@ -385,6 +391,8 @@ def _bfdarch():
         'powerpc64': 'powerpc',
         'sparc64':   'sparc',
         'thumb':     'arm',
+        'riscv32':   'riscv',
+        'riscv64':   'riscv',
     }
 
     if arch in convert:

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -185,7 +185,8 @@ def which_binutils(util, check_version=False):
         'mips64': ['mips'],
         'powerpc64': ['powerpc'],
         'sparc64': ['sparc'],
-        'riscv32': ['riscv32', 'riscv64'],
+        'riscv32': ['riscv32', 'riscv64', 'riscv'],
+        'riscv64': ['riscv32', 'riscv64', 'riscv'],
     }.get(arch, [])
 
     # If one of the candidate architectures matches the native

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -186,7 +186,7 @@ def which_binutils(util, check_version=False):
         'powerpc64': ['powerpc'],
         'sparc64': ['sparc'],
         'riscv32': ['riscv32', 'riscv64', 'riscv'],
-        'riscv64': ['riscv32', 'riscv64', 'riscv'],
+        'riscv64': ['riscv64', 'riscv32', 'riscv'],
     }.get(arch, [])
 
     # If one of the candidate architectures matches the native

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -599,7 +599,9 @@ def get_gdb_arch():
         'powerpc64': 'powerpc:common64',
         'mips64': 'mips:isa64',
         'thumb': 'arm',
-        'sparc64': 'sparc:v9'
+        'sparc64': 'sparc:v9',
+        'riscv32': 'riscv:rv32',
+        'riscv64': 'riscv:rv64',
     }.get(context.arch, context.arch)
 
 def binary():


### PR DESCRIPTION
It was broken when the riscv architecture was split into riscv32 and riscv64 internally in #2177.

Since there's only a `riscv64` binutils version packaged in ubuntu, which support riscv32 as well, this searches for the riscv64 toolchain too when riscv32 is selected.

Thus `apt install binutils-riscv64-unknown-elf` is enough to assemble/diassemble shellcode now.