### PR TITLE
Fix highlight of unaligned nullbyte in disasm command

### DIFF
--- a/pwnlib/commandline/disasm.py
+++ b/pwnlib/commandline/disasm.py
@@ -82,9 +82,9 @@ def main(args):
         instrs  = disasm(dat, vma=safeeval.const(args.address), byte=False, offset=False)
         # instrs  = highlight(instrs, PwntoolsLexer(), TerminalFormatter())
 
+        highlight_bytes = lambda t: ''.join(map(lambda x: x.replace('00', text.red('00')).replace('0a', text.red('0a')), group(2, t)))
         for o,b,i in zip(*map(str.splitlines, (offsets, bytes, instrs))):
-            b = b.replace('00', text.red('00'))
-            b = b.replace('0a', text.red('0a'))
+            b = ' '.join(highlight_bytes(bb) for bb in b.split(' '))
             i = highlight(i.strip(), PwntoolsLexer(), TerminalFormatter()).strip()
             i = i.replace(',',', ')
 


### PR DESCRIPTION
"1001" would highlight the "00" even though it's not a null byte in the input. Group the bytes correctly to look for real null bytes and newlines, ignoring accidental matches of adjacent bytes.

![grafik](https://user-images.githubusercontent.com/1635147/233793683-8142a24d-d66b-4a21-9cf7-067a02ace024.png)
