### PR TITLE
Fmtstr no dollar payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 | Version          | Branch   | Release Date           |
 | ---------------- | -------- | ---------------------- |
+| [4.12.0](#4110)  | `dev`    |
 | [4.11.0](#4110)  | `dev`    |
 | [4.10.0](#4100)  | `beta`   |
 | [4.9.0](#490)    | `stable` | Dec 29, 2022
@@ -64,6 +65,10 @@ The table below shows which release corresponds to each branch, and what date th
 | [3.0.1](#301)    |          | Aug 20, 2016
 | [3.0.0](#300)    |          | Aug 20, 2016
 | [2.2.0](#220)    |          | Jan 5, 2015
+
+## 4.12.0 (`dev`)
+
+- [#2185][2185] make fmtstr able to create payload without $ notation 
 
 ## 4.11.0 (`dev`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The table below shows which release corresponds to each branch, and what date th
 
 | Version          | Branch   | Release Date           |
 | ---------------- | -------- | ---------------------- |
-| [4.12.0](#4120)  | `dev`    |
 | [4.11.0](#4110)  | `dev`    |
 | [4.10.0](#4100)  | `beta`   |
 | [4.9.0](#490)    | `stable` | Dec 29, 2022
@@ -66,12 +65,9 @@ The table below shows which release corresponds to each branch, and what date th
 | [3.0.0](#300)    |          | Aug 20, 2016
 | [2.2.0](#220)    |          | Jan 5, 2015
 
-## 4.12.0 (`dev`)
-
-- [#2185][2185] make fmtstr able to create payload without $ notation 
-
 ## 4.11.0 (`dev`)
 
+- [#2185][2185] make fmtstr module able to create payload without $ notation 
 - [#2062][2062] make pwn cyclic -l work with entry larger than 4 bytes
 - [#2092][2092] shellcraft: dup() is now called dupio() consistently across all supported arches
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
@@ -80,6 +76,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
 - [#2177][2177] Support for RISC-V 64-bit architecture
 
+[2185]: https://github.com/Gallopsled/pwntools/pull/2185
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 | Version          | Branch   | Release Date           |
 | ---------------- | -------- | ---------------------- |
-| [4.12.0](#4110)  | `dev`    |
+| [4.12.0](#4120)  | `dev`    |
 | [4.11.0](#4110)  | `dev`    |
 | [4.10.0](#4100)  | `beta`   |
 | [4.9.0](#490)    | `stable` | Dec 29, 2022

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -285,7 +285,7 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
 
     This function is simple and does not try to minimize the number of atoms. For example, if there are no
     bad bytes, it simply returns one atom for each byte:
-         >>> pwnlib.fmtstr.make_atoms_simple(0x0, b"abc", set())
+        >>> pwnlib.fmtstr.make_atoms_simple(0x0, b"abc", set())
         [AtomWrite(start=0, size=1, integer=0x61, mask=0xff), AtomWrite(start=1, size=1, integer=0x62, mask=0xff), AtomWrite(start=2, size=1, integer=0x63, mask=0xff)]
     
     If there are bad bytes, it will try to bypass by skipping addresses containing bad bytes, otherwise a
@@ -306,7 +306,7 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
     out = []
     while i < len(data):
         candidate = AtomWrite(address + i, 1, data[i])
-        while i + candidate.end < len(data) and any(x in badbytes for x in pack(candidate.end)):
+        while i + candidate.size < len(data) and any(x in badbytes for x in pack(candidate.end)):
             candidate = candidate.union(AtomWrite(candidate.end, 1, data[i + candidate.size]))
 
         sz = min([s for s in SPECIFIER if s >= candidate.size] + [float("inf")])
@@ -829,7 +829,7 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         no_dollars(boolean) : flag to generete the payload with or w/o $ notation 
     Returns:
         The payload in order to do needed writes
-     Examples:
+    Examples:
         >>> context.clear(arch = 'amd64')
         >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')
         b'%322419390c%4$llnaaaabaa\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -848,7 +848,6 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         b'%1c%3$na\x00\x00\x00\x00'
         >>> fmtstr_payload(1, {0x0: b"\xff\xff\x04\x11\x00\x00\x00\x00"}, write_size='short')
         b'%327679c%7$lln%18c%8$hhn\x00\x00\x00\x00\x03\x00\x00\x00'
-
     """
     sz = WRITE_SIZE[write_size]
     szmax = WRITE_SIZE[write_size_max]
@@ -857,7 +856,6 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
     fmt = b""
     for _ in range(1000000):
         data_offset = (offset_bytes + len(fmt)) // context.bytes
-        fmt = fmt + cyclic((-len(fmt)-offset_bytes) % context.bytes)
 
         # if no dollar is set, call the payload with the parameter no dollar set
         if no_dollars:

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -852,9 +852,15 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='byte')
         b'%19c%12$hhn%36c%13$hhn%131c%14$hhn%4c%15$hhn\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00'
         >>> fmtstr_payload(1, {0x0: 0x00000001}, write_size='byte')
-        b'%1c%3$na\x00\x00\x00\x00'
+        b'c%3$naaa\x00\x00\x00\x00'
         >>> fmtstr_payload(1, {0x0: b"\xff\xff\x04\x11\x00\x00\x00\x00"}, write_size='short')
         b'%327679c%7$lln%18c%8$hhn\x00\x00\x00\x00\x03\x00\x00\x00'
+        >>> fmtstr_payload(10, {0x404048 : 0xbadc0ffe, 0x40403c : 0xdeadbeef}, no_dollars=True)
+        b'%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%125c%hhn%17c%hhn%32c%hhn%17c%hhn%203c%hhn%34c%hhn%3618c%hnacccc>@@\x00cccc=@@\x00cccc?@@\x00cccc<@@\x00ccccK@@\x00ccccJ@@\x00ccccH@@\x00'
+        >>> fmtstr_payload(6, {0x404048 : 0xbadbad00}, no_dollars=True)
+        b'%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%229c%hhn%173c%hhn%13c%hhn%33c%hhnccccH@@\x00ccccI@@\x00ccccK@@\x00ccccJ@@\x00'
+        >>> fmtstr_payload(6, {0x4040 : 0xbadbad00, 0x4060: 0xbadbad02}, no_dollars=True)
+        b'%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%212c%hhn%173c%hhn%13c%hhn%33c%hhn%39c%hhn%171c%hhn%13c%hhn%33c%hhnacccc@@\x00\x00ccccA@\x00\x00ccccC@\x00\x00ccccB@\x00\x00cccc`@\x00\x00cccca@\x00\x00ccccc@\x00\x00ccccb@\x00\x00'
     """
     sz = WRITE_SIZE[write_size]
     szmax = WRITE_SIZE[write_size_max]

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -717,40 +717,41 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
         # perform write
         if padding:
             fmt += "%" + str(padding) + "c"
-            ''' 
-            [ @murph12F was here ]
 
-            the data += pack(0) is used to keey the arguments aligned when a %c is performed, so it wont use the actual address to write at
-            examplea stack and payload:
+            if no_dollars:
+                data += pack(0)
+                ''' 
+                [ @murph12F was here ]
+
+                the data += pack(0) is used to keey the arguments aligned when a %c is performed, so it wont use the actual address to write at
+                examplea stack and payload:
+                    
+                    fmtsr = %44c%hhn%66c%hhn
+
+                    ---------
+                    | addr2 |
+                    ---------
+                    | 0x000 |   
+                    ---------
+                    | addr1 |
+                    ---------
+                    | 0x000 | <-- (rsp)
+                    ---------
                 
-                fmtsr = %44c%hhn%66c%hhn
+                    in this case the the first %44c will use the current arugument used pointed by rsp ( 0 ), and increment  rsp
 
-                ---------
-                | addr2 |
-                ---------
-                | 0x000 |   
-                ---------
-                | addr1 |
-                ---------
-                | 0x000 | <-- (rsp)
-                ---------
-            
-                in this case the the first %44c will use the current arugument used pointed by rsp ( 0 ), and increment  rsp
+                    ---------
+                    | addr2 |
+                    ---------
+                    | 0X000 |   
+                    ---------
+                    | addr1 | <-- (rsp)
+                    ---------
+                    | 0x000 | 
+                    ---------
 
-                ---------
-                | addr2 |
-                ---------
-                | 0X000 |   
-                ---------
-                | addr1 | <-- (rsp)
-                ---------
-                | 0x000 | 
-                ---------
-
-                now it will perform the %hhn, and it will correctly use the addr1 argument
-                ...
-            '''
-            data += pack(0)
+                    now it will perform the %hhn, and it will correctly use the addr1 argument
+                '''
             
         if no_dollars:
             fmt += "%" +  SPECIFIER[atom.size]

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -688,7 +688,7 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
         atoms(list): list of atoms to execute
         numbwritten(int): number of byte already written by the printf function
         countersize(int): size in bytes of the format string counter (usually 4)
-        no_dollars(boolean) : flag to generete the payload with or w/o $ notation 
+        no_dollars(bool) : flag to generete the payload with or w/o $ notation 
 
     Examples:
         >>> pwnlib.fmtstr.make_payload_dollar(1, [pwnlib.fmtstr.AtomWrite(0x0, 0x1, 0xff)])
@@ -827,7 +827,7 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         write_size(str): must be ``byte``, ``short`` or ``int``. Tells if you want to write byte by byte, short by short or int by int (hhn, hn or n)
         overflows(int): how many extra overflows (at size sz) to tolerate to reduce the length of the format string
         strategy(str): either 'fast' or 'small' ('small' is default, 'fast' can be used if there are many writes)
-        no_dollars(boolean) : flag to generete the payload with or w/o $ notation 
+        no_dollars(bool) : flag to generete the payload with or w/o $ notation 
     Returns:
         The payload in order to do needed writes
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -715,7 +715,12 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
             log.warn("padding is negative, this will not work on glibc")
 
         # perform write
-        if padding:
+        # if the padding is less than 3, it is more convenient to write it : [ len("cc") < len("%2c") ] , this could help save some bytes, if it is 3 it will take the same amout of bytes
+        # we also add ( context.bytes * no_dollars ) because , "%nccccccccc%n...ptr1ptr2" is more convenient than %"n%8c%n...ptr1ccccccccptr2"
+        if padding < 4 + context.bytes * no_dollars:
+                fmt += "c" * padding
+                ## if do not padded with %{n}c  do not need to add something in data to use as argument, since  we are not using a printf argument
+        else: 
             fmt += "%" + str(padding) + "c"
 
             if no_dollars:
@@ -723,7 +728,7 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
                 ''' 
                 [ @murph12F was here ]
 
-                the data += pack(0) is used to keey the arguments aligned when a %c is performed, so it wont use the actual address to write at
+                the data += b'c' * context.bytes , is used to keey the arguments aligned when a %c is performed, so it wont use the actual address to write at
                 examplea stack and payload:
                     
                     fmtsr = %44c%hhn%66c%hhn

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -858,14 +858,7 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
     fmt = b""
     for _ in range(1000000):
         data_offset = (offset_bytes + len(fmt)) // context.bytes
-
-        # if no dollar is set, call the payload with the parameter no dollar set
-        if no_dollars:
-            fmt, data = make_payload_dollar(offset + data_offset, all_atoms, numbwritten=numbwritten, no_dollars=True)
-
-        else:
-            fmt, data = make_payload_dollar(offset + data_offset, all_atoms, numbwritten=numbwritten)
-
+        fmt, data = make_payload_dollar(offset + data_offset, all_atoms, numbwritten=numbwritten, no_dollars=no_dollars)
         fmt = fmt + cyclic((-len(fmt)-offset_bytes) % context.bytes)
 
         if len(fmt) + offset_bytes == data_offset * context.bytes:

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -700,8 +700,8 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
     counter = numbwritten
 
     if no_dollars:
-        # since we cant dynamically offset, we have to increment manually the parameter index, use %c, so the numeber of bytes written is predictable
-        fmt += "%c" * ( data_offset - 1)
+        # since we can't dynamically offset, we have to increment manually the parameter index, use %c, so the number of bytes written is predictable
+        fmt += "%c" * (data_offset - 1)
         # every %c write a byte, so we need to keep track of that to have the right pad
         counter += data_offset - 1
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -707,7 +707,7 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
 
     for idx, atom in enumerate(atoms):
         # set format string counter to correct value
-        padding = atom.compute_padding(counter) 
+        padding = atom.compute_padding(counter)
         counter = (counter + padding) % (1 << (countersize * 8))
         if countersize == 32 and counter > 2147483600:
             log.warn("number of written bytes in format string close to 1 << 31. this will likely not work on glibc")
@@ -829,6 +829,7 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         no_dollars(boolean) : flag to generete the payload with or w/o $ notation 
     Returns:
         The payload in order to do needed writes
+
     Examples:
         >>> context.clear(arch = 'amd64')
         >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')
@@ -864,8 +865,7 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         else:
             fmt, data = make_payload_dollar(offset + data_offset, all_atoms, numbwritten=numbwritten)
 
-        #pad fmt to context.bytes
-        fmt = fmt + ((-len(fmt)  % context.bytes )* b" ")
+        fmt = fmt + cyclic((-len(fmt)-offset_bytes) % context.bytes)
 
         if len(fmt) + offset_bytes == data_offset * context.bytes:
             break

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -719,7 +719,7 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
             fmt += "%" + str(padding) + "c"
 
             if no_dollars:
-                data += pack(0)
+                data += b'c' * context.bytes
                 ''' 
                 [ @murph12F was here ]
 


### PR DESCRIPTION
# No $ notation support for Fmtstr module 
Added a new feature in the fmtstr module, the fmtstr_payload(...) function now supports generating payload without using the $ notation.
This can be accomplished with the new flag in the fmstr_payload function parameters ``no_dollars``. 

> Every line of code added has effect only if the ``no_dollar`` parameter is set, if is not set the module remain unchanged. 

___
##  Function signature  
### Before
```py
def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_max='long', overflows=16, strategy="small", badbytes=frozenset(), offset_bytes=0 ) -> str  
```
### After
```py
def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_max='long', overflows=16, strategy="small", badbytes=frozenset(), offset_bytes=0, no_dollars=False)  -> str  
```

## Example: 
```py
[ins] In [5]: from pwn import *

[ins] In [6]: context.clear( arch='amd64')

[ins] In [7]: fmtstr_payload(7,{ 0xdeadbeef : 0xc00ffe }  , no_dollars=True)
Out[7]: b'%c%c%c%c%c%c%c%c%c%c%c%c%4082c%lln%194c%hhnaaaab\x00\x00\x00\x00\x00\x00\x00\x00\xef\xbe\xad\xde\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf1\xbe\xad\xde\x00\x00\x00\x00'
```


