### PR TITLE
Fix failing libcdb.unstrip_libc tests

### DIFF
--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -208,20 +208,18 @@ def unstrip_libc(filename):
         :const:`True` if binary was unstripped, :const:`False` otherwise.
 
     Examples:
-        >>> filename = search_by_build_id('2d1c5e0b85cb06ff47fa6fa088ec22cb6e06074e', unstrip=False)
+        >>> filename = search_by_build_id('69389d485a9793dbe873f0ea2c93e02efaa9aa3d', unstrip=False)
         >>> libc = ELF(filename)
-        >>> hex(libc.symbols.read)
-        '0xe56c0'
         >>> 'main_arena' in libc.symbols
         False
         >>> unstrip_libc(filename)
         True
         >>> libc = ELF(filename)
         >>> hex(libc.symbols.main_arena)
-        '0x1d57a0'
+        '0x219c80'
         >>> unstrip_libc(which('python'))
         False
-        >>> filename = search_by_build_id('06a8004be6e10c4aeabbe0db74423ace392a2d6b', unstrip=True)
+        >>> filename = search_by_build_id('d1704d25fbbb72fa95d517b883131828c0883fe9', unstrip=True)
         >>> 'main_arena' in ELF(filename).symbols
         True
     """

--- a/pwnlib/util/web.py
+++ b/pwnlib/util/web.py
@@ -25,7 +25,7 @@ def wget(url, save=None, timeout=5, **kwargs):
 
     Example:
 
-      >>> url    = 'https://httpbin.org/robots.txt'
+      >>> url    = 'https://httpbingo.org/robots.txt'
       >>> result = wget(url, timeout=60)
       >>> result
       b'User-agent: *\nDisallow: /deny\n'


### PR DESCRIPTION
The old debugsymbols seem to have been pruned. Update hashes to recent Ubuntu 22.04 libcs. (Ubuntu [has it's own](https://lists.ubuntu.com/archives/ubuntu-devel-announce/2022-September/001320.html) debuginfod server now btw!)

I'm not sure of a more sustainable test. Just use the host libc and assume you don't run the tests on an ancient system? But that would make them undeteministic. But I think there are other tests already which use host binaries?