### PR TITLE
add pwnlib/gdb.py gdb_binary_file() function

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -172,6 +172,7 @@ from pwnlib.util import packing
 from pwnlib.util import proc
 
 log = getLogger(__name__)
+GDB_BIN_BINARY = ""
 
 @LocalContext
 def debug_assembly(asm, gdbscript=None, vma=None, api=False):
@@ -604,6 +605,11 @@ def get_gdb_arch():
         'riscv64': 'riscv:rv64',
     }.get(context.arch, context.arch)
 
+def gdb_binary_file(gdb_bin):
+    global GDB_BIN_BINARY
+    GDB_BIN_BINARY = gdb_bin
+
+
 def binary():
     """binary() -> str
 
@@ -615,6 +621,10 @@ def binary():
         >>> gdb.binary() # doctest: +SKIP
         '/usr/bin/gdb'
     """
+    if(GDB_BIN_BINARY != ""):
+        gdb = misc.which(GDB_BIN_BINARY)
+        return gdb
+
     gdb = misc.which('pwntools-gdb') or misc.which('gdb')
 
     if not context.native:


### PR DESCRIPTION
# Pwntools Pull Request

Hello, I'am not a python developer, but I made a change that is super useful to me, I have added a function inside pwnlib/gdb.py and a new global, now I can change the GDB installation I will use with pwntools (this is useful to me because I have more than one GDB installation with different plugins)

![image](https://github.com/Gallopsled/pwntools/assets/57950943/f0f685c3-ec0b-4c84-bc48-f119643c586c)


## Example
We can use the function in this way

```python
from pwn import *

gdb.gdb_binary_file("/usr/bin/gdb-gef")
print(gdb.binary())

```

```python
from pwn import *

gdb.gdb_binary_file("gdb-peda")
print(gdb.binary())
```
![image](https://github.com/Gallopsled/pwntools/assets/57950943/4e766576-afd8-4668-b5e3-a76082009799)

