### PR TITLE
Fix typo in ssh trying to access log.Progress.error

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1474,7 +1474,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             self._download_raw(remote, local, p)
 
             if not self._verify_local_fingerprint(fingerprint):
-                p.error('Could not download file %r' % remote)
+                raise PwnlibException('Could not download file %r' % remote)
 
         return local
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1474,7 +1474,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             self._download_raw(remote, local, p)
 
             if not self._verify_local_fingerprint(fingerprint):
-                raise PwnlibException('Could not download file %r' % remote)
+                self.error('Could not download file %r', remote)
 
         return local
 


### PR DESCRIPTION
That function doesn't exist and .failure() is used everywhere else.

I feel like it should throw in `_download_raw` as well, since it would result in potentially returning a path to an invalid or non-existent file.