### PR TITLE
Fix `remote` and `listen` in sagemath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 4.12.0 (`dev`)
+- [#2202][2202] Fix `remote` and `listen` in sagemath
 
-
+[2202]: https://github.com/Gallopsled/pwntools/pull/2202
 
 ## 4.11.0 (`beta`)
 

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -80,6 +80,9 @@ class listen(sock):
                  fam='any', typ='tcp', *args, **kwargs):
         super(listen, self).__init__(*args, **kwargs)
 
+        # convert port to string for sagemath support
+        port = str(port)
+
         fam = self._get_family(fam)
         typ = self._get_type(typ)
 

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -61,7 +61,8 @@ class remote(sock):
                  *args, **kwargs):
         super(remote, self).__init__(*args, **kwargs)
 
-        self.rport  = port
+        # convert port to string for sagemath support
+        self.rport  = str(port)
         self.rhost  = host
 
         if sock:


### PR DESCRIPTION
sage's Integer doesn't seem to inherit from python's base int.

```
----> 1 listen(Integer(1337))
OSError: Int or String expected
```

Fixes #2201