### PR TITLE
Add Docker publish workflow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ vars.DOCKER_REPOSITORY }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./extra/docker/stable
+          file: ./extra/docker/stable/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

This PR adds a GitHub action to build and publish docker images to DockerHub, solving #2187. For this to work, a repo admin needs to set up two secrets: DOCKER_USERNAME, DOCKER_PASSWORD as well as a variable DOCKER_REPOSITORY. The latter should be set to "pwntools/pwntools".

The action uses the extra/docker/stable Dockerfile to build the image so there is an implicit assumption here that the release tag points to the tip of the stable branch at the time of release. If this cannot be assumed a more sophisticated solution is probably required.

This introduces no new code to pwntools itself. I have tested the GitHub action on a separate repo and it seems to work fine.

