### PR TITLE
Fix stable Python 2 installation from a built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,8 @@ install_requires     = ['paramiko>=1.15.2',
                         'six>=1.12.0',
                         'rpyc',
                         'colored_traceback',
+                        'pathlib2; python_version < "3.4"',
 ]
-
-if platform.python_version_tuple()[0] == '2':
-    install_requires += ['pathlib2']
 
 # Check that the user has installed the Python development headers
 PythonH = os.path.join(get_python_inc(), 'Python.h')


### PR DESCRIPTION
The dynamic addition of the `pathlib2` dependency which was used previously wasn't included in the published wheel on pypi. The beta release works since #2179 is included there which does this already.

Refs #2119 

We'd need a 4.10.1 release to fix Python 2 support without requiring `python2.7 -m pip install pathlib2`. The Docker images pull from the respective branches on Github directly, so those installs won't be a problem once they are build again.