### PR TITLE
Replace `isSet` with `is_set` as the former is deprecated in 3.10+

### DIFF
--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -875,7 +875,7 @@ class tube(Timeout, Logger):
 
         go = threading.Event()
         def recv_thread():
-            while not go.isSet():
+            while not go.is_set():
                 try:
                     cur = self.recv(timeout = 0.05)
                     cur = cur.replace(self.newline, b'\n')
@@ -897,7 +897,7 @@ class tube(Timeout, Logger):
         try:
             os_linesep = os.linesep.encode()
             to_skip = b''
-            while not go.isSet():
+            while not go.is_set():
                 if term.term_mode:
                     data = term.readline.readline(prompt = prompt, float = True)
                     if data:


### PR DESCRIPTION
`threading.Event.isSet` is deprecated here: https://github.com/python/cpython/commit/9825bdfbd5c966abf1f1b7264992d722a94c9613

So using pwntools with Python 3.10+ will have this warning: `DeprecationWarning: isSet() is deprecated, use is_set() instead`