### PR TITLE
Fix Python 2 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,20 @@ jobs:
         key: ${{ matrix.os }}-cache-pip
 
     - name: Set up Python ${{ matrix.python-version }}
+      if: matrix.python-version != '2.7'
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Set up Python 2.7
+      if: matrix.python-version == '2.7'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          python2.7 python2.7-dev python2-pip-whl
+        export PYTHONPATH=`echo /usr/share/python-wheels/pip-*py2*.whl`
+        sudo --preserve-env=PYTHONPATH python2.7 -m pip install --upgrade pip setuptools wheel
+        sudo ln -sf python2.7 /usr/bin/python
 
     - name: Verify tag against version
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -217,7 +217,7 @@ def unstrip_libc(filename):
         >>> libc = ELF(filename)
         >>> hex(libc.symbols.main_arena)
         '0x219c80'
-        >>> unstrip_libc(which('python'))
+        >>> unstrip_libc(which('python3'))
         False
         >>> filename = search_by_build_id('d1704d25fbbb72fa95d517b883131828c0883fe9', unstrip=True)
         >>> 'main_arena' in ELF(filename).symbols

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1151,10 +1151,10 @@ os.execve(exe, argv, env)
 
         Examples:
             >>> s =  ssh(host='example.pwnme')
-            >>> py = s.run('python -i')
+            >>> py = s.run('python3 -i')
             >>> _ = py.recvuntil(b'>>> ')
             >>> py.sendline(b'print(2+2)')
-            >>> py.sendline(b'exit')
+            >>> py.sendline(b'exit()')
             >>> print(repr(py.recvline()))
             b'4\n'
             >>> s.system('env | grep -a AAAA', env={'AAAA': b'\x90'}).recvall()


### PR DESCRIPTION
Python 2 was removed from the `setup-python` Action, so install it manually from Ubuntu's repositories like we do in the `base` Dockerfile.

Fixes #2209 