### PR TITLE
libc Search str 

### DIFF
--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1191,7 +1191,7 @@ class ELF(ELFFile):
             segments = self.executable_segments
         else:
             segments = self.segments
-
+        needle = packing._need_bytes(needle)
         for seg in segments:
             addr   = seg.header.p_vaddr
             memsz  = seg.header.p_memsz


### PR DESCRIPTION
libc can search str

```
└─$ cat exp.py&&python exp.py
from pwn import *
libc=ELF("./libc-2.23.so")
print(hex(next(libc.search('/bin/sh'))))

[*] '/mnt/hgfs/0/pwn/ing/buu/16/32/libc-2.23.so'
    Arch:     i386-32-little
    RELRO:    Partial RELRO
    Stack:    Canary found
    NX:       NX enabled
    PIE:      PIE enabled
0x15902b
            
```