### PR TITLE
Fix bug at ssh.py:get() with relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,13 @@ The table below shows which release corresponds to each branch, and what date th
 [2186]: https://github.com/Gallopsled/pwntools/pull/2186
 [2129]: https://github.com/Gallopsled/pwntools/pull/2129
 
-## 4.10.0 (`stable`)
+## 4.10.1 (`stable`)
+
+- [#2214][2214] Fix bug at ssh.py:`download` and `download_file` with relative paths
+
+[2214]: https://github.com/Gallopsled/pwntools/pull/2214
+
+## 4.10.0
 
 In memoriam — [Zach Riggle][zach] — long time contributor and maintainer of Pwntools.
 
@@ -93,14 +99,12 @@ In memoriam — [Zach Riggle][zach] — long time contributor and maintainer of 
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
 - [#2125][2125] Allow tube.recvregex to return capture groups
 - [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
-- [#2214][2214] Fix bug at ssh.py:download and download_file with relative paths by removing broken `os.path.join()`
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
 [2125]: https://github.com/Gallopsled/pwntools/pull/2125
 [2144]: https://github.com/Gallopsled/pwntools/pull/2144
-[2214]: https://github.com/Gallopsled/pwntools/pull/2214
 [zach]: https://github.com/zachriggle
 
 ## 4.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,12 +93,14 @@ In memoriam — [Zach Riggle][zach] — long time contributor and maintainer of 
 - [#2093][2093] setresuid() in shellcraft uses current euid by default
 - [#2125][2125] Allow tube.recvregex to return capture groups
 - [#2144][2144] Removes `p2align 2` `asm()` headers from `x86-32`, `x86-64` and `mips` architectures to avoid inconsistent instruction length when patching binaries
+- [#2214][2214] Fix bug at ssh.py:download and download_file with relative paths by removing broken `os.path.join()`
 
 [2062]: https://github.com/Gallopsled/pwntools/pull/2062
 [2092]: https://github.com/Gallopsled/pwntools/pull/2092
 [2093]: https://github.com/Gallopsled/pwntools/pull/2093
 [2125]: https://github.com/Gallopsled/pwntools/pull/2125
 [2144]: https://github.com/Gallopsled/pwntools/pull/2144
+[2214]: https://github.com/Gallopsled/pwntools/pull/2214
 [zach]: https://github.com/zachriggle
 
 ## 4.9.0

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1509,7 +1509,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         calling the function twice has little overhead.
 
         Arguments:
-            remote(str): The remote filename to download
+            remote(str/bytes): The remote filename to download
             local(str): The local filename to save it to. Default is to infer it from the remote filename.
         """
 
@@ -1517,8 +1517,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         if not local:
             local = os.path.basename(os.path.normpath(remote))
 
-        if os.path.basename(remote) == remote:
-            remote = os.path.join(self.cwd, remote)
+        if not os.path.isabs(remote):
+            # Make sure cwd and remote are bytes before joining 
+            remote = packing._encode(remote)
+            remote = os.path.join(packing._encode(self.cwd), remote)
 
         with self.progress('Downloading %r to %r' % (remote, local)) as p:
             local_tmp = self._download_to_cache(remote, p)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1517,11 +1517,11 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
             ...         cache=False)
-            >>> s.set_working_directory(wd='/tmp')
-            >>> s.download_file('foobar', 'barfoo')
+            >>> _ = s.set_working_directory(wd='/tmp')
+            >>> _ = s.download_file('foobar', 'barfoo')
             >>> with open('barfoo','r') as f:
             ...     print(f.read())
-            b'Hello, world'
+            Hello, world
         """
 
 
@@ -1706,11 +1706,11 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
             ...         cache=False)
-            >>> s.set_working_directory('/tmp')
-            >>> s.download('foobar', 'barfoo')
+            >>> _ = s.set_working_directory('/tmp')
+            >>> _ = s.download('foobar', 'barfoo')
             >>> with open('barfoo','r') as f:
             ...     print(f.read())
-            b'Hello, world'
+            Hello, world
         """
         file_or_directory = packing._encode(file_or_directory)
         with self.system(b'test -d ' + sh_string(file_or_directory)) as io:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1511,16 +1511,21 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         Arguments:
             remote(str/bytes): The remote filename to download
             local(str): The local filename to save it to. Default is to infer it from the remote filename.
+        
+        Examples:
+            >>> with open('foobar','w+') as f:
+            ...     _ = f.write('Hello, world')
+            >>> s =  ssh(host='example.pwnme',
+            ...         cache=False)
+            >>> s.download_file('foobar', 'barfoo')
+            >>> with open('barfoo','r') as f:
+            ...     print(f.read())
+            b'Hello, world'
         """
 
 
         if not local:
             local = os.path.basename(os.path.normpath(remote))
-
-        if not os.path.isabs(remote):
-            # Make sure cwd and remote are bytes before joining 
-            remote = packing._encode(remote)
-            remote = os.path.join(packing._encode(self.cwd), remote)
 
         with self.progress('Downloading %r to %r' % (remote, local)) as p:
             local_tmp = self._download_to_cache(remote, p)
@@ -1693,6 +1698,17 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             file_or_directory(str): Path to the file or directory to download.
             local(str): Local path to store the data.
                 By default, uses the current directory.
+        
+
+        Examples:
+            >>> with open('foobar','w+') as f:
+            ...     _ = f.write('Hello, world')
+            >>> s =  ssh(host='example.pwnme',
+            ...         cache=False)
+            >>> s.download('foobar', 'barfoo')
+            >>> with open('barfoo','r') as f:
+            ...     print(f.read())
+            b'Hello, world'
         """
         file_or_directory = packing._encode(file_or_directory)
         with self.system(b'test -d ' + sh_string(file_or_directory)) as io:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1513,10 +1513,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             local(str): The local filename to save it to. Default is to infer it from the remote filename.
         
         Examples:
-            >>> with open('foobar','w+') as f:
+            >>> with open('/tmp/foobar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
-            ...         cache=False)
+            ...         cache=False, wd='/tmp')
             >>> s.download_file('foobar', 'barfoo')
             >>> with open('barfoo','r') as f:
             ...     print(f.read())
@@ -1701,10 +1701,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         
 
         Examples:
-            >>> with open('foobar','w+') as f:
+            >>> with open('/tmp/foobar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
-            ...         cache=False)
+            ...         cache=False, wd='/tmp')
             >>> s.download('foobar', 'barfoo')
             >>> with open('barfoo','r') as f:
             ...     print(f.read())

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1516,7 +1516,8 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             >>> with open('/tmp/foobar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
-            ...         cache=False, wd='/tmp')
+            ...         cache=False)
+            >>> s.set_working_directory(wd='/tmp')
             >>> s.download_file('foobar', 'barfoo')
             >>> with open('barfoo','r') as f:
             ...     print(f.read())
@@ -1704,7 +1705,8 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             >>> with open('/tmp/foobar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
-            ...         cache=False, wd='/tmp')
+            ...         cache=False)
+            >>> s.set_working_directory('/tmp')
             >>> s.download('foobar', 'barfoo')
             >>> with open('barfoo','r') as f:
             ...     print(f.read())


### PR DESCRIPTION
This fixes a bug in `ssh.py` that previously prevented downloading a file from a relative path.

Previously the following snippet resulted in an error:
```py
s = ssh("exploitme.example.com")
s.get("somefile")
```
`TypeError:** Can't mix strings and bytes in path components`


Since the `get` function casts the remote variable to bytes, but the `self.cwd` is always `str`, this function failed no matter whether `bytes` or `str` was provided.


This fixes the bug in `ssh.py:download_file` by casting both parts of the join to `bytes` 