### PR TITLE
Fix BytesWarning in ssh.interactive()

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1766,7 +1766,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         if self.cwd != '.':
             cmd = 'cd ' + sh_string(self.cwd)
-            s.sendline(cmd)
+            s.sendline(packing._need_bytes(cmd, 2, 0x80))
 
         s.interactive()
         s.close()


### PR DESCRIPTION
When the current working directory was changed, `interactive()` changes into that directory using `cd X` which wasn't encoded.
I don't know if `interactive()` can be tested in CI :/