### PR TITLE
Add shellcraft.sleep template wrapping SYS_nanosleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,11 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.12.0 (`dev`)
 - [#2202][2202] Fix `remote` and `listen` in sagemath
 - [#2117][2117] Add -p (--prefix) and -s (--separator) arguments to `hex` command
+- [#2221][2221] Add shellcraft.sleep template wrapping SYS_nanosleep
 
 [2202]: https://github.com/Gallopsled/pwntools/pull/2202
 [2117]: https://github.com/Gallopsled/pwntools/pull/2117
+[2221]: https://github.com/Gallopsled/pwntools/pull/2221
 
 ## 4.11.0 (`beta`)
 

--- a/pwnlib/shellcraft/templates/aarch64/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/sleep.asm
@@ -1,0 +1,1 @@
+../../common/linux/sleep.asm

--- a/pwnlib/shellcraft/templates/amd64/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/sleep.asm
@@ -1,0 +1,1 @@
+../../common/linux/sleep.asm

--- a/pwnlib/shellcraft/templates/arm/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/arm/linux/sleep.asm
@@ -1,0 +1,1 @@
+../../common/linux/sleep.asm

--- a/pwnlib/shellcraft/templates/common/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/common/linux/sleep.asm
@@ -1,0 +1,28 @@
+<%
+  import pwnlib.abi
+  from pwnlib import shellcraft
+%>
+<%page args="seconds"/>
+<%docstring>
+Sleeps for the specified amount of seconds.
+
+Uses SYS_nanosleep under the hood.
+
+Args:
+  seconds (int,float): The time to sleep in seconds.
+</%docstring>
+<%
+  # struct timespec {
+  #     time_t  tv_sec;  /* Seconds */
+  #     long    tv_nsec; /* Nanoseconds */
+  # };
+  tv_sec = int(seconds)
+  tv_nsec = int((seconds % 1) * 1000000000)
+
+  abi = pwnlib.abi.ABI.syscall()
+  stack = abi.stack
+%>
+    /* sleep(${seconds}) */
+    ${shellcraft.push(tv_nsec)}
+    ${shellcraft.push(tv_sec)}
+    ${shellcraft.syscall('SYS_nanosleep', stack, 0)}

--- a/pwnlib/shellcraft/templates/common/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/common/linux/sleep.asm
@@ -25,4 +25,4 @@ Args:
     /* sleep(${seconds}) */
     ${shellcraft.push(tv_nsec)}
     ${shellcraft.push(tv_sec)}
-    ${shellcraft.syscall('SYS_nanosleep', stack, 0)}
+    ${shellcraft.nanosleep(stack, 0)}

--- a/pwnlib/shellcraft/templates/i386/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/sleep.asm
@@ -1,0 +1,1 @@
+../../common/linux/sleep.asm

--- a/pwnlib/shellcraft/templates/mips/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/mips/linux/sleep.asm
@@ -1,0 +1,1 @@
+../../common/linux/sleep.asm

--- a/pwnlib/shellcraft/templates/thumb/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/sleep.asm
@@ -1,0 +1,1 @@
+../../common/linux/sleep.asm


### PR DESCRIPTION
Accepts the time in seconds as a float argument and calls SYS_nanosleep.

This doesn't check for interrupts and doesn't retry with the remaining time. Do we want that?

Fixes #1428