### PR TITLE
Don't change log level for Corefile._parse_stack()

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -530,7 +530,6 @@ class Corefile(ELF):
         >>> io = elf.process()
         >>> io.wait(2)
         >>> core = io.corefile
-        [!] End of the stack is corrupted, skipping stack parsing (got: 41414141)
         >>> core.argc, core.argv, core.env
         (0, [], {})
         >>> core.stack.data.endswith(b'AAAA')

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -666,7 +666,7 @@ class Corefile(ELF):
                     log.warn('Could not find the stack!')
                     self.stack = None
 
-            with context.local(bytes=self.bytes, log_level='warn'):
+            with context.local(bytes=self.bytes):
                 try:
                     self._parse_stack()
                 except ValueError:


### PR DESCRIPTION
If we don't want to see the log, don't print it. There are no spammy debug logs anymore.

Fixes #1666