### PR TITLE
Fix Python 2 editable user install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,14 @@ for filename in glob.glob('pwnlib/commandline/*'):
 
 compat = {}
 if sys.version_info < (3, 4):
+    import site
+
     import toml
     project = toml.load('pyproject.toml')['project']
     compat['install_requires'] = project['dependencies']
     compat['name'] = project['name']
-    if '--user' in sys.argv:
-        sys.argv.remove('--user')
+    # https://github.com/pypa/pip/issues/7953
+    site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 
 # Check that the user has installed the Python development headers


### PR DESCRIPTION
This appears to be fixed in setuptools 62, but Python 2 is stuck at version 44. Use a workaround which overrides the disabled user installs temporarily. https://github.com/pypa/pip/issues/7953#issuecomment-645133255

This fixes our develop Dockerfile too!