### PR TITLE
shellcraft: more explicit sleep.asm docstring

### DIFF
--- a/pwnlib/shellcraft/templates/common/linux/sleep.asm
+++ b/pwnlib/shellcraft/templates/common/linux/sleep.asm
@@ -7,6 +7,7 @@
 Sleeps for the specified amount of seconds.
 
 Uses SYS_nanosleep under the hood.
+Doesn't check for interrupts and doesn't retry with the remaining time.
 
 Args:
   seconds (int,float): The time to sleep in seconds.


### PR DESCRIPTION
This commit adds information that the sleep shellcraft function does not check if it returned as part of an interrupt and it does not retry the syscall if this occured.
