### PR TITLE
Resolved issue #1411 abt serial-tube misbehaving.

### DIFF
--- a/pwnlib/tubes/serialtube.py
+++ b/pwnlib/tubes/serialtube.py
@@ -19,13 +19,6 @@ class serialtube(tube.tube):
             convert_newlines = True,
             bytesize = 8, parity='N', stopbits=1, xonxoff = False,
             rtscts = False, dsrdtr = False, *a, **kw):
-        """
-        Initializes a serial tube
-
-        If some parameter is invalid and triggers a serial.SerialException
-        during initialization, the function propagates this error with a call 
-        to self.exception().
-        """
         super(serialtube, self).__init__(*a, **kw)
 
         if port is None:
@@ -60,15 +53,6 @@ class serialtube(tube.tube):
 
     # Implementation of the methods required for tube
     def recv_raw(self, numb):
-        """
-        Method that receives `numb` bytes from a serial tube
-
-        Arguments: 
-            numb(int): number of bytes to read from the connection
-        
-        Returns:
-            data received from the connection or None
-        """
         if not self.conn:
             raise EOFError
 
@@ -96,25 +80,9 @@ class serialtube(tube.tube):
         self.conn.flush()
 
     def settimeout_raw(self, timeout):
-        """
-        Method to set the timeout of a serial tube.
-
-        Currently unimplemented
-        """
         pass
 
     def can_recv_raw(self, timeout):
-        """
-        Method to indicate if a serial tube is waiting
-        and can receive data. 
-
-        Arguments:
-            timeout: a duration in number of seconds
-        
-        Returns:
-            A boolean to indicate if the current serial tube can receive
-            data
-        """
         with self.countdown(timeout):
             while self.conn and self.countdown_active():
                 if self.conn.inWaiting():
@@ -126,21 +94,11 @@ class serialtube(tube.tube):
         return self.conn is not None
 
     def close(self):
-        """
-        Method that attempts to close a serial tube if it has an open
-        connection
-        """
         if self.conn:
             self.conn.close()
             self.conn = None
 
     def fileno(self):
-        """
-        Method that returns the fileno of the serial connection
-
-        Returns:
-            An integer representing the fileno
-        """
         if not self.connected():
             self.error("A closed serialtube does not have a file number")
 

--- a/pwnlib/tubes/serialtube.py
+++ b/pwnlib/tubes/serialtube.py
@@ -19,6 +19,13 @@ class serialtube(tube.tube):
             convert_newlines = True,
             bytesize = 8, parity='N', stopbits=1, xonxoff = False,
             rtscts = False, dsrdtr = False, *a, **kw):
+        """
+        Initializes a serial tube
+
+        If some parameter is invalid and triggers a serial.SerialException
+        during initialization, the function propagates this error with a call 
+        to self.exception().
+        """
         super(serialtube, self).__init__(*a, **kw)
 
         if port is None:
@@ -28,22 +35,40 @@ class serialtube(tube.tube):
                 port = '/dev/ttyUSB0'
 
         self.convert_newlines = convert_newlines
-        self.conn = serial.Serial(
-            port = port,
-            baudrate = baudrate,
-            bytesize = bytesize,
-            parity = parity,
-            stopbits = stopbits,
-            timeout = 0,
-            xonxoff = xonxoff,
-            rtscts = rtscts,
-            writeTimeout = None,
-            dsrdtr = dsrdtr,
-            interCharTimeout = 0
-        )
+        # serial.Serial might throw an exception, which must be handled
+        # and propagated accordingly using self.exception
+        try:
+            self.conn = serial.Serial(
+                port = port,
+                baudrate = baudrate,
+                bytesize = bytesize,
+                parity = parity,
+                stopbits = stopbits,
+                timeout = 0,
+                xonxoff = xonxoff,
+                rtscts = rtscts,
+                writeTimeout = None,
+                dsrdtr = dsrdtr,
+                interCharTimeout = 0
+            )
+        except serial.SerialException:
+            # self.conn is set to None to avoid an AttributeError when
+            # initialization fails, but the program still tries closing
+            # the serial tube anyway
+            self.conn = None
+            self.exception("Could not open a serial tube on port %s", port)
 
     # Implementation of the methods required for tube
     def recv_raw(self, numb):
+        """
+        Method that receives `numb` bytes from a serial tube
+
+        Arguments: 
+            numb(int): number of bytes to read from the connection
+        
+        Returns:
+            data received from the connection or None
+        """
         if not self.conn:
             raise EOFError
 
@@ -71,9 +96,25 @@ class serialtube(tube.tube):
         self.conn.flush()
 
     def settimeout_raw(self, timeout):
+        """
+        Method to set the timeout of a serial tube.
+
+        Currently unimplemented
+        """
         pass
 
     def can_recv_raw(self, timeout):
+        """
+        Method to indicate if a serial tube is waiting
+        and can receive data. 
+
+        Arguments:
+            timeout: a duration in number of seconds
+        
+        Returns:
+            A boolean to indicate if the current serial tube can receive
+            data
+        """
         with self.countdown(timeout):
             while self.conn and self.countdown_active():
                 if self.conn.inWaiting():
@@ -85,11 +126,21 @@ class serialtube(tube.tube):
         return self.conn is not None
 
     def close(self):
+        """
+        Method that attempts to close a serial tube if it has an open
+        connection
+        """
         if self.conn:
             self.conn.close()
             self.conn = None
 
     def fileno(self):
+        """
+        Method that returns the fileno of the serial connection
+
+        Returns:
+            An integer representing the fileno
+        """
         if not self.connected():
             self.error("A closed serialtube does not have a file number")
 


### PR DESCRIPTION
Resolved the Issue #1411 with serial-tube misbehaving by raising an inappropriate exception. The call to serial.Serial is now wrapped in a try-except block that calls self.exception() upon failing to create the connection. In the except branch, it also sets self.conn to None to avoid an AttributeError with self.close() later on. Also added some documentation for some of the functions in serialtube.py