### PR TITLE
py2: fix long hex in shellcraft etc.

### DIFF
--- a/pwnlib/filepointer.py
+++ b/pwnlib/filepointer.py
@@ -176,7 +176,7 @@ class FileStructure(object):
     def __repr__(self):
         structure=[]
         for i in self.vars_:
-            structure.append(" %s: %s" % (i,hex(getattr(self, i))))
+            structure.append(" %s: %#x" % (i, getattr(self, i)))
         return "{"+ "\n".join(structure)+"}"
 
     def __len__(self):

--- a/pwnlib/shellcraft/__init__.py
+++ b/pwnlib/shellcraft/__init__.py
@@ -153,9 +153,9 @@ class module(ModuleType):
             if comment: return '%s /* %s */' % (n,self.pretty(int(n)))
             else:       return '%s (%s)'     % (n,self.pretty(int(n)))
         elif abs(n) < 10:
-            return str(n)
+            return '%d' % n
         else:
-            return hex(n)
+            return '%#x' % n
 
     def okay(self, s, *a, **kw):
         if isinstance(s, six.integer_types):

--- a/pwnlib/shellcraft/templates/amd64/linux/migrate_stack.asm
+++ b/pwnlib/shellcraft/templates/amd64/linux/migrate_stack.asm
@@ -5,4 +5,4 @@
     ${amd64.linux.mmap_rwx(size)}
     ${amd64.mov('rsp', 'rax')}
 
-    add rsp, ${hex((size * 3 // 4) & ~7)}
+    add rsp, ${'%#x' % ((size * 3 // 4) & ~7)}

--- a/pwnlib/shellcraft/templates/i386/mov.asm
+++ b/pwnlib/shellcraft/templates/i386/mov.asm
@@ -190,8 +190,8 @@ else:
     % else:
         <%
         a,b = fiddling.xor_pair(srcp, avoid = '\x00\n')
-        a = hex(packing.unpack(a, dest.size))
-        b = hex(packing.unpack(b, dest.size))
+        a = '%#x' % packing.unpack(a, dest.size)
+        b = '%#x' % packing.unpack(b, dest.size)
         %>\
         mov ${dest}, ${a}
         xor ${dest}, ${a} ^ ${pretty(src)}

--- a/pwnlib/shellcraft/templates/i386/stackhunter.asm
+++ b/pwnlib/shellcraft/templates/i386/stackhunter.asm
@@ -25,13 +25,13 @@ Example:
 <% stackhunter = common.label("stackhunter") %>
 %if (cookie & 0xffffff) == 0xfceb58:
 ${stackhunter}:
-    cmp eax, ${hex(cookie)}
+    cmp eax, ${'%#x' % cookie}
     jne ${stackhunter}+1
     jmp esp
 %else:
 ${stackhunter}:
     pop eax
-    cmp eax, ${hex(cookie)}
+    cmp eax, ${'%#x' % cookie}
     jne ${stackhunter}
     jmp esp
 %endif

--- a/pwnlib/shellcraft/templates/mips/mov.asm
+++ b/pwnlib/shellcraft/templates/mips/mov.asm
@@ -130,8 +130,8 @@ if src_reg == 0:
 % else:
 <%
 a,b = fiddling.xor_pair(srcp, avoid = '\x00\n')
-a = hex(packing.unpack(a, 32))
-b = hex(packing.unpack(b, 32))
+a = '%#x' % packing.unpack(a, 32)
+b = '%#x' % packing.unpack(b, 32)
 %>
     li ${tmp_reg}, ${a} ^ ${pretty(src)}
     li ${dst}, ${a}


### PR DESCRIPTION
Followup to #1571 

Fixes #518
Fixes #801
Regression introduced in 4b196c7d96398d8b28dda5b34226b6ce1148f341
And now it should be possible to close #2229 too, and get rid of all of that warning.