### PR TITLE
Fix ssh.process not setting ssh_process.cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,10 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.10.1 (`stable`)
 
 - [#2214][2214] Fix bug at ssh.py:`download` and `download_file` with relative paths
+- [#2241][2241] Fix ssh.process not setting ssh_process.cwd attribute
 
 [2214]: https://github.com/Gallopsled/pwntools/pull/2214
+[2241]: https://github.com/Gallopsled/pwntools/pull/2241
 
 ## 4.10.0
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -57,7 +57,7 @@ class ssh_channel(sock):
     #: Command specified for the constructor
     process = None
 
-    def __init__(self, parent, process = None, tty = False, wd = None, env = None, raw = True, *args, **kwargs):
+    def __init__(self, parent, process = None, tty = False, cwd = None, env = None, raw = True, *args, **kwargs):
         super(ssh_channel, self).__init__(*args, **kwargs)
 
         # keep the parent from being garbage collected in some cases
@@ -68,9 +68,9 @@ class ssh_channel(sock):
         self.tty  = tty
         self.env  = env
         self.process = process
-        self.cwd  = wd or '.'
-        if isinstance(wd, six.text_type):
-            wd = packing._need_bytes(wd, 2, 0x80)
+        self.cwd  = cwd or '.'
+        if isinstance(cwd, six.text_type):
+            cwd = packing._need_bytes(cwd, 2, 0x80)
 
         env = env or {}
         msg = 'Opening new channel: %r' % (process or 'shell')
@@ -80,8 +80,8 @@ class ssh_channel(sock):
         if isinstance(process, six.text_type):
             process = packing._need_bytes(process, 2, 0x80)
 
-        if process and wd:
-            process = b'cd ' + sh_string(wd) + b' >/dev/null 2>&1; ' + process
+        if process and cwd:
+            process = b'cd ' + sh_string(cwd) + b' >/dev/null 2>&1; ' + process
 
         if process and env:
             for name, value in env.items():
@@ -841,8 +841,11 @@ class ssh(Timeout, Logger):
             >>> sh = s.process(executable='/bin/sh')
             >>> str(sh.pid).encode() in s.pidof('sh') # doctest: +SKIP
             True
-            >>> s.process(['pwd'], cwd='/tmp').recvall()
+            >>> io = s.process(['pwd'], cwd='/tmp')
+            >>> io.recvall()
             b'/tmp\n'
+            >>> io.cwd
+            '/tmp'
             >>> p = s.process(['python','-c','import os; os.write(1, os.read(2, 1024))'], stderr=0)
             >>> p.send(b'hello')
             >>> p.recv()
@@ -1068,7 +1071,7 @@ os.execve(exe, argv, env)
 
             script = 'echo PWNTOOLS; for py in python3 python2.7 python2 python; do test -x "$(which $py 2>&1)" && echo $py && exec $py -c %s check; done; echo 2' % sh_string(script)
             with context.quiet:
-                python = ssh_process(self, script, tty=True, raw=True, level=self.level, timeout=timeout)
+                python = ssh_process(self, script, tty=True, cwd=cwd, raw=True, level=self.level, timeout=timeout)
 
             try:
                 python.recvline_contains(b'PWNTOOLS')        # Magic flag so that any sh/bash initialization errors are swallowed
@@ -1151,7 +1154,7 @@ os.execve(exe, argv, env)
 
         Examples:
             >>> s =  ssh(host='example.pwnme')
-            >>> py = s.run('python3 -i')
+            >>> py = s.system('python3 -i')
             >>> _ = py.recvuntil(b'>>> ')
             >>> py.sendline(b'print(2+2)')
             >>> py.sendline(b'exit()')
@@ -1159,6 +1162,11 @@ os.execve(exe, argv, env)
             b'4\n'
             >>> s.system('env | grep -a AAAA', env={'AAAA': b'\x90'}).recvall()
             b'AAAA=\x90\n'
+            >>> io = s.system('pwd', wd='/tmp')
+            >>> io.recvall()
+            b'/tmp\n'
+            >>> io.cwd
+            '/tmp'
         """
 
         if wd is None:
@@ -1844,6 +1852,13 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             >>> _=s.set_working_directory(symlink=symlink)
             >>> assert b'foo' in s.ls().split(), s.ls().split()
             >>> assert homedir != s.pwd()
+
+            >>> _=s.set_working_directory()
+            >>> io = s.system('pwd')
+            >>> io.recvallS().strip() == io.cwd
+            True
+            >>> io.cwd == s.cwd
+            True
         """
         status = 0
 


### PR DESCRIPTION
The cwd wasn't passed to the ssh_process created in ssh.process, so the ssh_process.cwd attribute was never set. The process is running in the correct working directory though, but the `cwd` attribute didn't reflect it.

This passes the cwd along now.
```
s = ssh(..)
io = s.process("pwd", cwd="/tmp")
io.cwd # was ".", is now "/tmp"
io.recvall() # b"/tmp\n"
```
 
Fixes #1479