### PR TITLE
Fix pushing docker images on manual workflow run

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,15 +10,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            pwntools/pwntools
-          tags: |
-            type=ref,event=branch
-
       # Required for subdirectories in Git context
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -43,8 +34,7 @@ jobs:
         with:
           context: "{{defaultContext}}:extra/docker/stable"
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: pwntools/pwntools:stable
 
       - name: Build and push beta image
         uses: docker/build-push-action@v4
@@ -52,8 +42,7 @@ jobs:
         with:
           context: "{{defaultContext}}:extra/docker/beta"
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: pwntools/pwntools:beta
 
       - name: Build and push dev image
         uses: docker/build-push-action@v4
@@ -61,8 +50,9 @@ jobs:
         with:
           context: "{{defaultContext}}:extra/docker/dev"
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            pwntools/pwntools:dev
+            pwntools/pwntools:latest
 
       - name: Build and push ci image
         uses: docker/build-push-action@v4
@@ -71,4 +61,3 @@ jobs:
           context: "{{defaultContext}}:travis/docker"
           push: true
           tags: pwntools/pwntools:ci
-          labels: ${{ steps.meta.outputs.labels }}

--- a/extra/docker/base/Dockerfile
+++ b/extra/docker/base/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         python3 \
         python3-pip \
         python3-dev \
+        python-is-python3 \
         qemu-user-static \
         binutils-arm-linux-gnueabihf \
         binutils-aarch64-linux-gnu \
@@ -34,6 +35,7 @@ RUN apt-get update \
         binutils-powerpc-linux-gnu \
         binutils-powerpc64-linux-gnu \
         binutils-sparc64-linux-gnu \
+        binutils-riscv64-linux-gnu \
         tmux \
         patchelf \
     && locale-gen en_US.UTF-8 \

--- a/extra/docker/develop/Dockerfile
+++ b/extra/docker/develop/Dockerfile
@@ -34,7 +34,7 @@ RUN python2.7 -m pip install -U ipython ipdb \
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ="UTC"
 RUN sudo apt-get update && sudo -E apt-get install -y \
-  tzdata \
+	tzdata \
 	ash \
 	bash \
 	bash-static \

--- a/travis/docker/Dockerfile
+++ b/travis/docker/Dockerfile
@@ -5,8 +5,8 @@ ENV HISTFILE=/home/pwntools/.history
 
 # Uninstall existing versions of pwntools
 USER root
-RUN python -m pip uninstall -q -y pwntools \
- && python3 -m pip uninstall -q -y pwntools
+RUN python2.7 -m pip uninstall -q -y pwntools \
+    && python3 -m pip uninstall -q -y pwntools
 
 # Switch back to the pwntools user from here forward
 USER pwntools
@@ -18,20 +18,23 @@ ENV PATH="/home/pwntools/.local/bin:${PATH}"
 
 # Install Pwntools to the home directory, make it an editable install
 RUN git clone https://github.com/Gallopsled/pwntools \
- && python  -m pip install --upgrade --editable pwntools \
+ && python2.7 -m pip install --upgrade --editable pwntools \
  && python3 -m pip install --upgrade --editable pwntools \
  && PWNLIB_NOTERM=1 pwn version
 
 # Requirements for running the tests
-RUN python  -m pip install --upgrade --requirement pwntools/docs/requirements.txt \
- && python3 -m pip install --upgrade --requirement pwntools/docs/requirements.txt
+RUN python2.7 -m pip install --upgrade --requirement pwntools/docs/requirements.txt \
+    && python3 -m pip install --upgrade --requirement pwntools/docs/requirements.txt
 
 # Python niceties for debugging
-RUN python  -m pip install -U ipython ipdb \
- && python3 -m pip install -U ipython ipdb
+RUN python2.7 -m pip install -U ipython ipdb \
+    && python3 -m pip install -U ipython ipdb
 
 # Dependencies from .travis.yml addons -> apt -> packages
-RUN sudo apt-get update && sudo apt-get install -y \
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ="UTC"
+RUN sudo apt-get update && sudo -E apt-get install -y \
+	tzdata \
 	ash \
 	bash \
 	bash-static \
@@ -41,7 +44,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	dash \
 	gcc \
 	gcc-multilib \
-	gdb \ 
+	gdb \
 	ksh \
 	lib32stdc++6 \
 	libc6-dev-i386 \
@@ -51,12 +54,9 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	socat \
 	sshpass \
 	vim \
-	zsh
-
+	zsh \
 # Misc useful things when developing
-RUN sudo apt-get install -y  \
 	curl \
-	ipython \
 	ipython3 \
 	lsb-release \
 	ssh \
@@ -64,7 +64,7 @@ RUN sudo apt-get install -y  \
 	wget
 
 # Use zsh by default
-RUN sudo chsh -s /bin/zsh pwntools
+RUN sudo -E chsh -s /bin/zsh pwntools
 
 # Get and install prezto
 RUN git clone --recursive https://github.com/sorin-ionescu/prezto.git .zprezto
@@ -84,9 +84,10 @@ ADD ipython_config.py  /home/pwntools/.ipython/profile_default
 
 # Do not require password for sudo
 RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/travis
+
 # Some additional debugging tools that are useful
-RUN python  -m pip install ipdb
-RUN python3 -m pip install ipdb
+RUN python2.7 -m pip install ipdb && \
+    python3 -m pip install ipdb
 
 # Install debugging utilities
 USER root
@@ -94,14 +95,14 @@ RUN apt-get -y install gdb gdbserver tmux gdb-multiarch
 
 # Set up binfmt-misc mappings inside the VM
 USER root
-RUN mkdir /etc/qemu-binfmt
-RUN ln -sf /usr/lib/arm-linux-gnueabihf /etc/qemu-binfmt/arm
-RUN ln -sf /usr/lib/aarch64-linux-gnu   /etc/qemu-binfmt/aarch64
-RUN ln -sf /usr/lib/mips-linux-gnu      /etc/qemu-binfmt/mips
-RUN ln -sf /usr/lib/mipsel-linux-gnu    /etc/qemu-binfmt/mipsel
-RUN ln -sf /usr/lib/powerpc-linux-gnu   /etc/qemu-binfmt/powerpc
-RUN ln -sf /usr/lib/powerpc-linux-gnu64 /etc/qemu-binfmt/powerpc64
-RUN ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64
+RUN mkdir /etc/qemu-binfmt && \
+    ln -sf /usr/lib/arm-linux-gnueabihf /etc/qemu-binfmt/arm && \
+    ln -sf /usr/lib/aarch64-linux-gnu   /etc/qemu-binfmt/aarch64 && \
+    ln -sf /usr/lib/mips-linux-gnu      /etc/qemu-binfmt/mips && \
+    ln -sf /usr/lib/mipsel-linux-gnu    /etc/qemu-binfmt/mipsel && \
+    ln -sf /usr/lib/powerpc-linux-gnu   /etc/qemu-binfmt/powerpc && \
+    ln -sf /usr/lib/powerpc-linux-gnu64 /etc/qemu-binfmt/powerpc64 && \
+    ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64
 
 # Create the Travis user
 USER root
@@ -110,9 +111,9 @@ RUN echo "travis ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/travis
 
 # Set up SSH stuff so we can SSH into localhost
 USER pwntools
-RUN ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
-RUN cp ~/.ssh/id_rsa.pub /tmp
-RUN echo \
+RUN ssh-keygen -t rsa -f ~/.ssh/id_rsa -N '' && \
+    cp ~/.ssh/id_rsa.pub /tmp && \
+    echo \
 "Host *\n\
     User travis\n\
     HostName 127.0.0.1\n\
@@ -120,22 +121,19 @@ RUN echo \
 
 # Set up authorized_keys so we can login as travis with no creds
 USER travis
-RUN mkdir -m 0700 ~/.ssh
-RUN echo 'from="127.0.0.1"' $(cat /tmp/id_rsa.pub) > ~/.ssh/authorized_keys
+RUN mkdir -m 0700 ~/.ssh && \
+    echo 'from="127.0.0.1"' $(cat /tmp/id_rsa.pub) > ~/.ssh/authorized_keys
 
 # Add the doctest entrypoint to /usr/bin so we don't have to supply the full path
 USER root
-ADD doctest2 /usr/bin
-ADD doctest3 /usr/bin
+ADD doctest2 doctest3 /usr/bin
 
 # Switch back to pwntools to actually run the image
 USER pwntools
 WORKDIR /home/pwntools
 
 # Copy in the Doctest script
-COPY doctest2 /home/pwntools
-COPY doctest3 /home/pwntools
-COPY tmux.sh /home/pwntools
+COPY doctest2 doctest3 tmux.sh /home/pwntools
 
 # Do everything in UTF-8 mode!
 ENV LANG=C.UTF-8

--- a/travis/docker/Dockerfile
+++ b/travis/docker/Dockerfile
@@ -102,7 +102,8 @@ RUN mkdir /etc/qemu-binfmt && \
     ln -sf /usr/lib/mipsel-linux-gnu    /etc/qemu-binfmt/mipsel && \
     ln -sf /usr/lib/powerpc-linux-gnu   /etc/qemu-binfmt/powerpc && \
     ln -sf /usr/lib/powerpc-linux-gnu64 /etc/qemu-binfmt/powerpc64 && \
-    ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64
+    ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64 && \
+    ln -sf /usr/lib/riscv64-linux-gnu   /etc/qemu-binfmt/riscv64
 
 # Create the Travis user
 USER root

--- a/travis/docker/Dockerfile.travis
+++ b/travis/docker/Dockerfile.travis
@@ -1,7 +1,7 @@
 
 # Some additional debugging tools that are useful
-RUN python  -m pip install ipdb
-RUN python3 -m pip install ipdb
+RUN python2.7 -m pip install ipdb && \
+    python3 -m pip install ipdb
 
 # Install debugging utilities
 USER root
@@ -9,14 +9,14 @@ RUN apt-get -y install gdb gdbserver tmux gdb-multiarch
 
 # Set up binfmt-misc mappings inside the VM
 USER root
-RUN mkdir /etc/qemu-binfmt
-RUN ln -sf /usr/lib/arm-linux-gnueabihf /etc/qemu-binfmt/arm
-RUN ln -sf /usr/lib/aarch64-linux-gnu   /etc/qemu-binfmt/aarch64
-RUN ln -sf /usr/lib/mips-linux-gnu      /etc/qemu-binfmt/mips
-RUN ln -sf /usr/lib/mipsel-linux-gnu    /etc/qemu-binfmt/mipsel
-RUN ln -sf /usr/lib/powerpc-linux-gnu   /etc/qemu-binfmt/powerpc
-RUN ln -sf /usr/lib/powerpc-linux-gnu64 /etc/qemu-binfmt/powerpc64
-RUN ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64
+RUN mkdir /etc/qemu-binfmt && \
+    ln -sf /usr/lib/arm-linux-gnueabihf /etc/qemu-binfmt/arm && \
+    ln -sf /usr/lib/aarch64-linux-gnu   /etc/qemu-binfmt/aarch64 && \
+    ln -sf /usr/lib/mips-linux-gnu      /etc/qemu-binfmt/mips && \
+    ln -sf /usr/lib/mipsel-linux-gnu    /etc/qemu-binfmt/mipsel && \
+    ln -sf /usr/lib/powerpc-linux-gnu   /etc/qemu-binfmt/powerpc && \
+    ln -sf /usr/lib/powerpc-linux-gnu64 /etc/qemu-binfmt/powerpc64 && \
+    ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64
 
 # Create the Travis user
 USER root
@@ -25,9 +25,9 @@ RUN echo "travis ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/travis
 
 # Set up SSH stuff so we can SSH into localhost
 USER pwntools
-RUN ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
-RUN cp ~/.ssh/id_rsa.pub /tmp
-RUN echo \
+RUN ssh-keygen -t rsa -f ~/.ssh/id_rsa -N '' && \
+    cp ~/.ssh/id_rsa.pub /tmp && \
+    echo \
 "Host *\n\
     User travis\n\
     HostName 127.0.0.1\n\
@@ -35,22 +35,19 @@ RUN echo \
 
 # Set up authorized_keys so we can login as travis with no creds
 USER travis
-RUN mkdir -m 0700 ~/.ssh
-RUN echo 'from="127.0.0.1"' $(cat /tmp/id_rsa.pub) > ~/.ssh/authorized_keys
+RUN mkdir -m 0700 ~/.ssh && \
+    echo 'from="127.0.0.1"' $(cat /tmp/id_rsa.pub) > ~/.ssh/authorized_keys
 
 # Add the doctest entrypoint to /usr/bin so we don't have to supply the full path
 USER root
-ADD doctest2 /usr/bin
-ADD doctest3 /usr/bin
+ADD doctest2 doctest3 /usr/bin
 
 # Switch back to pwntools to actually run the image
 USER pwntools
 WORKDIR /home/pwntools
 
 # Copy in the Doctest script
-COPY doctest2 /home/pwntools
-COPY doctest3 /home/pwntools
-COPY tmux.sh /home/pwntools
+COPY doctest2 doctest3 tmux.sh /home/pwntools
 
 # Do everything in UTF-8 mode!
 ENV LANG=C.UTF-8

--- a/travis/docker/Dockerfile.travis
+++ b/travis/docker/Dockerfile.travis
@@ -16,7 +16,8 @@ RUN mkdir /etc/qemu-binfmt && \
     ln -sf /usr/lib/mipsel-linux-gnu    /etc/qemu-binfmt/mipsel && \
     ln -sf /usr/lib/powerpc-linux-gnu   /etc/qemu-binfmt/powerpc && \
     ln -sf /usr/lib/powerpc-linux-gnu64 /etc/qemu-binfmt/powerpc64 && \
-    ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64
+    ln -sf /usr/lib/sparc64-linux-gnu   /etc/qemu-binfmt/sparc64 && \
+    ln -sf /usr/lib/riscv64-linux-gnu   /etc/qemu-binfmt/riscv64
 
 # Create the Travis user
 USER root


### PR DESCRIPTION
Running the docker workflow manually would associate the run with the `dev` branch. The generated tags would all point to the `dev` tag, so tag the image manually to the correct branch.

The `travis/docker` image failed to build due to running `python` instead of `python2.7`.