### PR TITLE
Only run docker workflow on upstream repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'Gallopsled'
     steps:
       # Required for subdirectories in Git context
       - name: Set up Docker Buildx


### PR DESCRIPTION
Don't run it in forks which can't push to the dockerhub.