### PR TITLE
Fix corefile module after pyelftools update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,9 +88,11 @@ The table below shows which release corresponds to each branch, and what date th
 
 - [#2214][2214] Fix bug at ssh.py:`download` and `download_file` with relative paths
 - [#2241][2241] Fix ssh.process not setting ssh_process.cwd attribute
+- [#2261][2261] Fix corefile module after pyelftools update
 
 [2214]: https://github.com/Gallopsled/pwntools/pull/2214
 [2241]: https://github.com/Gallopsled/pwntools/pull/2241
+[2261]: https://github.com/Gallopsled/pwntools/pull/2261
 
 ## 4.10.0
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -76,7 +76,6 @@ import tempfile
 from io import BytesIO, StringIO
 
 import elftools
-from elftools.common.py3compat import bytes2str
 from elftools.common.utils import roundup
 from elftools.common.utils import struct_parse
 from elftools.construct import CString
@@ -94,6 +93,7 @@ from pwnlib.util.fiddling import enhex
 from pwnlib.util.fiddling import unhex
 from pwnlib.util.misc import read
 from pwnlib.util.misc import write
+from pwnlib.util.packing import _decode
 from pwnlib.util.packing import pack
 from pwnlib.util.packing import unpack_many
 
@@ -134,12 +134,13 @@ def iter_notes(self):
         self.stream.seek(offset)
         # n_namesz is 4-byte aligned.
         disk_namesz = roundup(note['n_namesz'], 2)
-        note['n_name'] = bytes2str(
-            CString('').parse(self.stream.read(disk_namesz)))
-        offset += disk_namesz
+        with context.local(encoding='latin-1'):
+            note['n_name'] = _decode(
+                CString('').parse(self.stream.read(disk_namesz)))
+            offset += disk_namesz
 
-        desc_data = bytes2str(self.stream.read(note['n_descsz']))
-        note['n_desc'] = desc_data
+            desc_data = _decode(self.stream.read(note['n_descsz']))
+            note['n_desc'] = desc_data
         offset += roundup(note['n_descsz'], 2)
         note['n_size'] = offset - note['n_offset']
         yield note

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -1065,6 +1065,9 @@ def _encode(s):
     return s.encode(context.encoding)
 
 def _decode(b):
+    if isinstance(b, (str, six.text_type)):
+        return b   # already text
+
     if context.encoding == 'auto':
         try:
             return b.decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ for filename in glob.glob('pwnlib/commandline/*'):
 
 install_requires     = ['paramiko>=1.15.2',
                         'mako>=1.0.0',
-                        'pyelftools>=0.2.4, <0.3.0; python_version < "3"',
-                        'pyelftools>=0.2.4; python_version >= "3"',
+                        'pyelftools>=0.24, <0.30; python_version < "3"',
+                        'pyelftools>=0.24; python_version >= "3"',
                         'capstone>=3.0.5rc2', # See Gallopsled/pwntools#971, Gallopsled/pwntools#1160
                         'ropgadget>=5.3',
                         'pyserial>=2.7',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ for filename in glob.glob('pwnlib/commandline/*'):
 
 install_requires     = ['paramiko>=1.15.2',
                         'mako>=1.0.0',
-                        'pyelftools>=0.2.4',
+                        'pyelftools>=0.2.4, <0.3.0; python_version < "3"',
+                        'pyelftools>=0.2.4; python_version >= "3"',
                         'capstone>=3.0.5rc2', # See Gallopsled/pwntools#971, Gallopsled/pwntools#1160
                         'ropgadget>=5.3',
                         'pyserial>=2.7',


### PR DESCRIPTION
The `bytes2str` internal method was moved while Python 2 support was removed in pyelftools 0.3.0.
Just use our own python aware decoder wrapper to avoid problems in Python 3 when users have pyelftools 0.3.0 installed. Python 2 will grab the latest < 0.3.0 release anyways.

Fixes #2260