### PR TITLE
Fix tube.clean_and_log not logging buffered data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,10 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.11.1 (`stable`)
 
+- [#2272][2272] Fix `tube.clean_and_log` not logging buffered data
 - [#2281][2281] FIX: Getting right amount of data for search fix
 
+[2272]: https://github.com/Gallopsled/pwntools/pull/2272
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
 
 ## 4.11.0

--- a/examples/clean_and_log.py
+++ b/examples/clean_and_log.py
@@ -11,18 +11,24 @@ Solution:
 """
 
 from pwn import *
+from multiprocessing import Process
 
-os.system('''((
-echo prefix sometext ;
-echo prefix someothertext ;
-echo here comes the flag ;
-echo LostInTheInterTubes
-) | nc -l 1337) &
-''')
+def submit_data():
+    with context.quiet:
+        with listen(1337) as io:
+            io.wait_for_connection()
+            io.sendline(b'prefix sometext')
+            io.sendline(b'prefix someothertext')
+            io.sendline(b'here comes the flag')
+            io.sendline(b'LostInTheInterTubes')
 
-r = remote('localhost', 1337)
-atexit.register(r.clean_and_log)
+if __name__ == '__main__':
+    p = Process(target=submit_data)
+    p.start()
 
-while True:
-    line = r.recvline()
-    print(re.findall(r'^prefix (\S+)$', line)[0])
+    r = remote('localhost', 1337)
+    atexit.register(r.clean_and_log)
+
+    while True:
+        line = r.recvline()
+        print(re.findall(br'^prefix (\S+)$', line)[0])

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1034,11 +1034,12 @@ class tube(Timeout, Logger):
             b'hooray_data'
             >>> context.clear()
         """
-        with context.local(log_level='debug'):
-            cached_data = self.buffer.get()
-            if cached_data:
+        cached_data = self.buffer.get()
+        if cached_data and not self.isEnabledFor(logging.DEBUG):
+            with context.local(log_level='debug'):
                 self.debug('Received %#x bytes:' % len(cached_data))
                 self.maybe_hexdump(cached_data, level=logging.DEBUG)
+        with context.local(log_level='debug'):
             return cached_data + self.clean(timeout)
 
     def connect_input(self, other):

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1035,7 +1035,11 @@ class tube(Timeout, Logger):
             >>> context.clear()
         """
         with context.local(log_level='debug'):
-            return self.clean(timeout)
+            cached_data = self.buffer.get()
+            if cached_data:
+                self.debug('Received %#x bytes:' % len(cached_data))
+                self.maybe_hexdump(cached_data, level=logging.DEBUG)
+            return cached_data + self.clean(timeout)
 
     def connect_input(self, other):
         """connect_input(other)


### PR DESCRIPTION
Running the [tube.clean_and_log example](https://github.com/Gallopsled/pwntools/blob/dev/examples/clean_and_log.py) doesn't print anything after the script crashes while it should.

Only new data received after the `clean_and_log` call is printed while data already received and buffered earlier is not. Print the buffered data first before waiting for more so we don't miss anything.

## Before
```
$ python clean_and_log.py
[+] Opening connection to localhost on port 1337: Done
b'sometext'
b'someothertext'
Traceback (most recent call last):
  File "pwntools/examples/clean_and_log.py", line 34, in <module>
    print(re.findall(br'^prefix (\S+)$', line)[0])
IndexError: list index out of range
[*] Closed connection to localhost port 1337
```

## After
```
$ python clean_and_log.py
[+] Opening connection to localhost on port 1337: Done
b'sometext'
b'someothertext'
Traceback (most recent call last):
  File "pwntools/examples/clean_and_log.py", line 34, in <module>
    print(re.findall(br'^prefix (\S+)$', line)[0])
IndexError: list index out of range
[DEBUG] Received 0x14 bytes:
    b'LostInTheInterTubes\n'
[*] Closed connection to localhost port 1337
```

The only problem which might be confusing is when the log level is `debug` already while the data is being received. That causes it to be printed twice - but I think that is acceptable since the normal usecase for this is for non-debug runs.

```
$ python clean_and_log.py
[+] Opening connection to localhost on port 1337: Done
[DEBUG] Received 0x4d bytes:
    b'prefix sometext\n'
    b'prefix someothertext\n'
    b'here comes the flag\n'
    b'LostInTheInterTubes\n'
b'sometext'
b'someothertext'
Traceback (most recent call last):
  File "pwntools/examples/clean_and_log.py", line 34, in <module>
    print(re.findall(br'^prefix (\S+)$', line)[0])
IndexError: list index out of range
[DEBUG] Received 0x14 bytes:
    b'LostInTheInterTubes\n'
[*] Closed connection to localhost port 1337
```

I've fixed the example for Python 3 too and switched to a python-only interaction instead of shelling out.