### PR TITLE
elf: Resolve more relocations into GOT entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,11 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.13.0 (`dev`)
 
+- [#2277][2277] elf: Resolve more relocations into GOT entries
 - [#2281][2281] FIX: Getting right amount of data for search fix
 - [#2293][2293] Add x86 CET status to checksec output
 
+[2277]: https://github.com/Gallopsled/pwntools/pull/2277
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
 [2293]: https://github.com/Gallopsled/pwntools/pull/2293
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ requires-python = ">=2.7"
 dependencies = [
     "paramiko>=1.15.2",
     "mako>=1.0.0",
-    "pyelftools>=0.24, <0.30; python_version < '3'",
-    "pyelftools>=0.24; python_version >= '3'",
+    "pyelftools>=0.29, <0.30; python_version < '3'",
+    "pyelftools>=0.29; python_version >= '3'",
     "capstone>=3.0.5rc2",  # see Gallopsled/pwntools#971, Gallopsled/pwntools#1160
     "ropgadget>=5.3",
     "pyserial>=2.7",


### PR DESCRIPTION
So far only relocations pointing to external symbols were considered when filling GOT.  Relocations in libc are a different thing, often found in CTF challenges (libc with partial RELRO has many interesting overridable function pointers, like strlen & strchrnul).