### PR TITLE
FIX: Getting right amount of data for search fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,9 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 4.13.0 (`dev`)
+- [#2281][2281] FIX: Getting right amount of data for search fix
 
-
+[2281]: https://github.com/Gallopsled/pwntools/pull/2281
 
 ## 4.12.0 (`beta`)
 - [#2202][2202] Fix `remote` and `listen` in sagemath

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1195,9 +1195,10 @@ class ELF(ELFFile):
         for seg in segments:
             addr   = seg.header.p_vaddr
             memsz  = seg.header.p_memsz
-            zeroed = memsz - seg.header.p_filesz
+            filesz = seg.header.p_filesz
+            zeroed = memsz - filesz
             offset = seg.header.p_offset
-            data   = self.mmap[offset:offset+memsz]
+            data   = self.mmap[offset:offset+filesz]
             data   += b'\x00' * zeroed
             offset = 0
             while True:


### PR DESCRIPTION
PR for #2266 and #2269 

# Description
As far as I researched ELF and your code, memory layout is looking something like this:
```

                                                            +-----------------------+
                                                            |         zeroes        | 
      |-----------------------------------------------------|-----------------------|
p_vaddr                                             p_vaddr + p_filesz      p_vaddr + p_memsz

```
If it is true, you are reading more data than needed (`[offset:offset+memsz]` instead of `[offset:offset+filesz]`).