### PR TITLE
Fix _countdown_handler not invoking timeout_change; Fix value is valu…

### DIFF
--- a/pwnlib/timeout.py
+++ b/pwnlib/timeout.py
@@ -30,9 +30,11 @@ class _countdown_handler(object):
             self.obj._stop = min(self.obj._stop, self.old_stop)
 
         self.obj._timeout = self.timeout
+        self.obj.timeout_change()
     def __exit__(self, *a):
         self.obj._timeout = self.old_timeout
         self.obj._stop    = self.old_stop
+        self.obj.timeout_change()
 
 class _local_handler(object):
     def __init__(self, obj, timeout):
@@ -157,7 +159,7 @@ class Timeout(object):
         else:
             value = float(value)
 
-            if value is value < 0:
+            if value < 0:
                 raise AttributeError("timeout: Timeout cannot be negative")
 
             if value > self.maximum:


### PR DESCRIPTION
When using pwntools, I noticed that sometimes, even though `recvuntil` had a timeout set, it could still wait indefinitely. After examining the source code of pwntools, I eventually identified the root cause of this issue. In `conn.recvuntil -> self.countdown -> _countdown_handler`, there was a missing call to `self.obj.timeout_change()` after modifying `self.obj._stop` and `self.obj._timeout`. This is crucial for setting the timeout of the socket.

```python
class _countdown_handler(object):
    def __init__(self, obj, timeout):
        self.obj     = obj
        self.timeout = timeout

    def __enter__(self):
        self.old_timeout  = self.obj._timeout
        self.old_stop     = self.obj._stop

        self.obj._stop    = time.time() + self.timeout  # line A

        if self.old_stop:
            self.obj._stop = min(self.obj._stop, self.old_stop)

        self.obj._timeout = self.timeout
        # my fix: self.obj.timeout_change()
    def __exit__(self, *a):
        self.obj._timeout = self.old_timeout
        self.obj._stop    = self.old_stop
        # my fix: self.obj.timeout_change()
```

Later in the code, within `conn.recvuntil -> self.recv -> self._recv -> self._fillbuffer -> self.local`, there is this piece of code:

```python
if timeout is self.default or timeout == self.timeout:
    return _DummyContext
```

Where `self.timeout` is a getter:

```python
@property
def timeout(self):
    """
    Timeout for obj operations.  By default, uses ``context.timeout``.
    """
    timeout = self._timeout
    stop    = self._stop

    if not stop:
        return timeout

    return max(stop-time.time(), 0)
```

And `self._stop` was set in Line A of  `_countdown_handler`. It appears that if the code runs fast enough, `timeout == self.timeout` evaluates to True. This situation happens frequently in my case. When it evaluates to True, the returned `_DummyContext` does nothing, and thus, does not set the timeout for the socket.

If `_countdown_handler` were to call `self.obj.timeout_change()` after modifying `self.obj._stop` and self.obj._timeout`, it would directly set the timeout for the socket. This would fix the bug.

I also noticed a conditional statement in the code, `if value is value < 0`(similar to 10 < x < 100, as described in [Python's documentation](https://docs.python.org/3/reference/expressions.html#comparisons)). Its result is the same as `if value < 0`, so I changed it to `if value < 0`.