### PR TITLE
Add x86 CET status to checksec output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,10 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.13.0 (`dev`)
 - [#2281][2281] FIX: Getting right amount of data for search fix
+- [#2293][2293] Add x86 CET status to checksec output
 
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
+[2293]: https://github.com/Gallopsled/pwntools/pull/2293
 
 ## 4.12.0 (`beta`)
 - [#2202][2202] Fix `remote` and `listen` in sagemath

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -17,6 +17,7 @@ import types
 
 from pwnlib import term
 from pwnlib.context import context, LocalContext
+from pwnlib.exception import PwnlibException
 from pwnlib.log import Logger
 from pwnlib.log import getLogger
 from pwnlib.term import text
@@ -2150,7 +2151,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
     def _cpuinfo(self):
         if self._cpuinfo_cache is None:
             with context.quiet:
-                self._cpuinfo_cache = self.read('/proc/cpuinfo')
+                try:
+                    self._cpuinfo_cache = self.read('/proc/cpuinfo')
+                except PwnlibException:
+                    self._cpuinfo_cache = b''
         return self._cpuinfo_cache
 
     @property

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -613,7 +613,9 @@ class ssh(Timeout, Logger):
         self._platform_info = {}
         self._aslr = None
         self._aslr_ulimit = None
+        self._cpuinfo_cache = None
         self._user_shstk = None
+        self._ibt = None
 
         misc.mkdir_p(self._cachedir)
 
@@ -2145,6 +2147,12 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         return self._aslr_ulimit
 
+    def _cpuinfo(self):
+        if self._cpuinfo_cache is None:
+            with context.quiet:
+                self._cpuinfo_cache = self.read('/proc/cpuinfo')
+        return self._cpuinfo_cache
+
     @property
     def user_shstk(self):
         """:class:`bool`: Whether userspace shadow stack is supported on the system.
@@ -2161,11 +2169,31 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 self._user_shstk = False
 
             else:
-                with context.quiet:
-                    cpuinfo = self.read('/proc/cpuinfo')
+                cpuinfo = self._cpuinfo()
 
                 self._user_shstk = b' user_shstk' in cpuinfo
         return self._user_shstk
+
+    @property
+    def ibt(self):
+        """:class:`bool`: Whether kernel indirect branch tracking is supported on the system.
+
+        Example:
+
+            >>> s = ssh("travis", "example.pwnme")
+            >>> s.ibt
+            False
+        """
+        if self._ibt is None:
+            if self.os != 'linux':
+                self.warn_once("Only Linux is supported for kernel indirect branch tracking checks.")
+                self._ibt = False
+
+            else:
+                cpuinfo = self._cpuinfo()
+
+                self._ibt = b' ibt ' in cpuinfo or b' ibt\n' in cpuinfo
+        return self._ibt
 
     def _checksec_cache(self, value=None):
         path = self._get_cachefile('%s-%s' % (self.host, self.port))
@@ -2208,6 +2236,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 True: green("Enabled"),
                 False: red("Disabled")
             }[self.user_shstk],
+            "IBT:".ljust(10) + {
+                True: green("Enabled"),
+                False: red("Disabled")
+            }[self.ibt],
         ]
 
         if self.aslr_ulimit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ requires-python = ">=2.7"
 dependencies = [
     "paramiko>=1.15.2",
     "mako>=1.0.0",
-    "pyelftools>=0.24, <0.30; python_version < '3'",
-    "pyelftools>=0.24; python_version >= '3'",
+    "pyelftools>=0.28, <0.30; python_version < '3'",
+    "pyelftools>=0.28; python_version >= '3'",
     "capstone>=3.0.5rc2",  # see Gallopsled/pwntools#971, Gallopsled/pwntools#1160
     "ropgadget>=5.3",
     "pyserial>=2.7",


### PR DESCRIPTION
Check if the binary was compiled with Control-flow Enforcement Technology (CET) and display if it supports shadowstack (SHSTK) and indirect branch tracking (IBT). Even though IBT hardware is rare (using those endbr instructions) it's useful to be futureproof here.

A binary compiled with `-fcf-protection=full` will now show both features in the checksec output:

```
[*] './test'
    Arch:     amd64-64-little
    RELRO:    Full RELRO
    Stack:    No canary found
    NX:       NX enabled
    PIE:      PIE enabled
    SHSTK:    Enabled
    IBT:      Enabled
```

This requires bumping of the minimum pyelftools version, which shouldn't be a problem and is required anyways as shown in #2280.

Similarly, the target machine's cpuinfo features are checked for "user_shstk" capabilities in `ssh.checksec` to know if the cpu and kernel support userspace shadowstack as described in the [shstk docs](https://kernel.org/doc/html/next/arch/x86/shstk.html#requirements-to-use-shadow-stack).

Closes #2288