### PR TITLE
shellcraft.aarch64: Fix atexit SEGV in loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2271][2271] FIX: Generated shebang with path to python invalid if path contains spaces
 - [#2272][2272] Fix `tube.clean_and_log` not logging buffered data
 - [#2281][2281] FIX: Getting right amount of data for search fix
+- [#2294][2294] Fix atexit SEGV in aarch64 loader
 
 [2271]: https://github.com/Gallopsled/pwntools/pull/2271
 [2272]: https://github.com/Gallopsled/pwntools/pull/2272
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
+[2294]: https://github.com/Gallopsled/pwntools/pull/2294
 
 ## 4.11.0
 

--- a/pwnlib/shellcraft/templates/aarch64/linux/loader.asm
+++ b/pwnlib/shellcraft/templates/aarch64/linux/loader.asm
@@ -107,14 +107,14 @@ PT_LOAD  = 1
     mov x3, sp
     stp  x2, x3, [sp, #-16]!
 
-    /* argc, argv[0], argv[1], envp */
+    /* argc, argv[0], argv[1], envp; x0 must be zero! */
     /* ideally these could all be empty, but unfortunately
        we have to keep the stack aligned.  it's easier to
        just push an extra argument than care... */
     stp  x0, x1, [sp, #-16]! /* argv[1] = NULL, envp = NULL */
-    mov  x0, 1
-    mov  x1, sp
-    stp  x0, x1, [sp, #-16]! /* argc = 1, argv[0] = "" */
+    mov  x2, 1
+    mov  x3, sp
+    stp  x2, x3, [sp, #-16]! /* argc = 1, argv[0] = "" */
 
     br x8
 


### PR DESCRIPTION
Fixes #2289