### PR TITLE
Python 2: Fix installing from source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ include *.md *.txt *.sh *.yml MANIFEST.in
 recursive-include docs   *.rst *.png Makefile *.py *.txt
 recursive-include pwnlib *.py *.asm *.rst *.md *.txt *.sh __doc__ *.mako
 recursive-include pwn    *.py *.asm *.rst *.md *.txt *.sh
-recursive-exclude *.pyc
+global-exclude *.pyc

--- a/extra/docker/beta/Dockerfile
+++ b/extra/docker/beta/Dockerfile
@@ -2,6 +2,6 @@ FROM pwntools/pwntools:stable
 
 USER root
 RUN python2.7 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@beta \
-    && python3 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@beta
+    && python3 -m pip install --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@beta
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/extra/docker/dev/Dockerfile
+++ b/extra/docker/dev/Dockerfile
@@ -2,6 +2,6 @@ FROM pwntools/pwntools:stable
 
 USER root
 RUN python2.7 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@dev \
-    && python3 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@dev
+    && python3 -m pip install --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@dev
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/extra/docker/stable/Dockerfile
+++ b/extra/docker/stable/Dockerfile
@@ -2,6 +2,6 @@ FROM pwntools/pwntools:base
 
 USER root
 RUN python2.7 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@stable \
-    && python3 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@stable
+    && python3 -m pip install --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@stable
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,12 @@ from __future__ import print_function
 
 import glob
 import os
-import platform
-import subprocess
 import sys
-import traceback
 from distutils.command.install import INSTALL_SCHEMES
 from distutils.sysconfig import get_python_inc
 from distutils.util import convert_path
 
+from setuptools import find_packages
 from setuptools import setup
 
 # Get all template files
@@ -48,6 +46,7 @@ compat = {}
 if sys.version_info < (3, 4):
     import toml
     project = toml.load('pyproject.toml')['project']
+    compat['packages'] = find_packages()
     compat['install_requires'] = project['dependencies']
     compat['name'] = project['name']
     if '--user' in sys.argv:


### PR DESCRIPTION
Installing pwntools from the repo didn't find any source packages to install.
`python2.7 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@stable` 

The auto-discovery doesn't work for the old setuptools version used in Python 2.
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#flat-layout

To publish to pypi we do `python3 -m build` and let it handle the both python versions in CI, which appears to find the packages automatically just fine.

This fixes our docker images as well, which tried to run the Python2 command line tools and failed. We now overwrite the `pwn` command line tools with the Python 3 ones.
https://github.com/Gallopsled/pwntools/actions/runs/6815444190/job/18534549578#step:5:244