### PR TITLE
libcdb.py - python 3.12

### DIFF
--- a/pwnlib/commandline/libcdb.py
+++ b/pwnlib/commandline/libcdb.py
@@ -221,7 +221,7 @@ def main(args):
             exe = ELF(file, checksec=False)
             log.info('%s', text.red(os.path.basename(file)))
 
-            libc_version = re.search(b'libc[ -](\d+\.\d+)', exe.data)
+            libc_version = re.search(b'libc[ -](\\d+\\.\\d+)', exe.data)
             if libc_version:
                 log.indented('%-20s %s', text.green('Version:'), libc_version.group(1).decode())
 

--- a/pwnlib/commandline/libcdb.py
+++ b/pwnlib/commandline/libcdb.py
@@ -221,7 +221,7 @@ def main(args):
             exe = ELF(file, checksec=False)
             log.info('%s', text.red(os.path.basename(file)))
 
-            libc_version = re.search(b'libc[ -](\\d+\\.\\d+)', exe.data)
+            libc_version = re.search(br'libc[ -](\d+\.\d+)', exe.data)
             if libc_version:
                 log.indented('%-20s %s', text.green('Version:'), libc_version.group(1).decode())
 


### PR DESCRIPTION
Python 3.12 would complain if the \d atom is not escaped in the binary string.

/usr/lib/python3.12/site-packages/pwnlib/commandline/libcdb.py:224: SyntaxWarning: invalid escape sequence '\d'
  libc_version = re.search(b'libc[ -](\d+\.\d+)', exe.data)

