### PR TITLE
Fix `pwn libcdb file` crashing if "/bin/sh" string was not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,11 +74,13 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2281][2281] FIX: Getting right amount of data for search fix
 - [#2293][2293] Add x86 CET status to checksec output
 - [#1763][1763] Allow to add to the existing environment in `process` instead of replacing it
+- [#2307][2307] Fix `pwn libcdb file` crashing if "/bin/sh" string was not found
 
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
 [2293]: https://github.com/Gallopsled/pwntools/pull/2293
 [1763]: https://github.com/Gallopsled/pwntools/pull/1763
+[2307]: https://github.com/Gallopsled/pwntools/pull/2307
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/commandline/libcdb.py
+++ b/pwnlib/commandline/libcdb.py
@@ -176,10 +176,11 @@ def translate_offset(offs, args, exe):
     return offs
 
 def collect_synthetic_symbols(exe):
-    available_symbols = ['str_bin_sh']
+    available_symbols = []
     try:
         exe.symbols['str_bin_sh'] = next(exe.search(b'/bin/sh\x00'))
-    except:
+        available_symbols.append('str_bin_sh')
+    except StopIteration:
         pass
         
     libc_start_main_return = exe.libc_start_main_return

--- a/pwnlib/commandline/libcdb.py
+++ b/pwnlib/commandline/libcdb.py
@@ -177,8 +177,11 @@ def translate_offset(offs, args, exe):
 
 def collect_synthetic_symbols(exe):
     available_symbols = ['str_bin_sh']
-    exe.symbols['str_bin_sh'] = next(exe.search(b'/bin/sh\x00'))
-
+    try:
+        exe.symbols['str_bin_sh'] = next(exe.search(b'/bin/sh\x00'))
+    except:
+        pass
+        
     libc_start_main_return = exe.libc_start_main_return
     if libc_start_main_return > 0:
         exe.symbols['__libc_start_main_ret'] = libc_start_main_return


### PR DESCRIPTION
fixes #2306
