### PR TITLE
Explicitly select readthedocs.com theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,9 @@ build:
   tools:
     python: "3"
 
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
   install:
   - requirements: docs/requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -169,7 +169,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -265,8 +265,8 @@ latex_documents = [
    u'2016, Gallopsled et al.', 'manual'),
 ]
 
-intersphinx_mapping = {'python': ('https://docs.python.org/3.8', None),
-                       'paramiko': ('https://paramiko-docs.readthedocs.org/en/2.1/', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
+                       'paramiko': ('https://docs.paramiko.org/en/2.1/', None)}
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -381,8 +381,6 @@ if build_dash:
         html_theme = 'alabaster'
         html_theme_path = [alabaster.get_path()]
         html_theme_options = { 'nosidebar' : True }
-
-    # otherwise, readthedocs.org uses their theme by default, so no need to specify it
 
 
 # -- Customization to Sphinx autodoc generation --------------------------------------------


### PR DESCRIPTION
The `sphinx_rtd_theme` has to be selected manually and isn't the default on RTD anymore. This seems to be part of a wave of deprecations in their build system.

https://blog.readthedocs.com/defaulting-latest-build-tools/
https://github.com/readthedocs/tutorial-template/blob/f594c40889a4d9949339bd4e0d64275fc99c22f5/docs/source/conf.py#L32