### PR TITLE
Nicer error when running tmux exploit outside tmux

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -410,7 +410,12 @@ os.execve({argv0!r}, {argv!r}, os.environ)
 
     if terminal == 'tmux':
         out, _ = p.communicate()
-        pid = int(out)
+        try:
+            pid = int(out)
+        except ValueError:
+            pid = None
+        if pid is None:
+            log.error("Could not parse PID from tmux output (%r). Start tmux first.", out)
     elif terminal == 'qdbus':
         with subprocess.Popen((qdbus, konsole_dbus_service, '/Sessions/{}'.format(last_konsole_session),
                                'org.kde.konsole.Session.processId'), stdout=subprocess.PIPE) as proc:


### PR DESCRIPTION
When you set the `context.terminal` to be tmux related but then try to run the exploit outside a tmux session, you'd get a cryptic ValueError while trying to parse the pid of the new pane in tmux.

Print a nicer reminder to start tmux first.

```python
from pwn import *
context.terminal = ['tmux', 'splitw', '-h']
gdb.debug('/bin/cat').interactive()
```

```
[+] Starting local process '/usr/bin/gdbserver': pid 3401
[*] running in new terminal: ['/usr/bin/gdb', '-q', '/bin/cat', '-x', '/tmp/pwni46_dcye.gdb']
Traceback (most recent call last):
  File "/home/peace/dev/pwntools/blabla.py", line 4, in <module>
    gdb.debug('/bin/cat').interactive()
  File "/home/peace/dev/pwntools/pwnlib/context/__init__.py", line 1581, in setter
    return function(*a, **kw)
  File "/home/peace/dev/pwntools/pwnlib/gdb.py", line 582, in debug
    tmp = attach((host, port), exe=exe, gdbscript=gdbscript, ssh=ssh, sysroot=sysroot, api=api)
  File "/home/peace/dev/pwntools/pwnlib/context/__init__.py", line 1581, in setter
    return function(*a, **kw)
  File "/home/peace/dev/pwntools/pwnlib/gdb.py", line 1100, in attach
    gdb_pid = misc.run_in_new_terminal(cmd, preexec_fn = preexec_fn)
  File "/home/peace/dev/pwntools/pwnlib/util/misc.py", line 413, in run_in_new_terminal
    pid = int(out)
ValueError: invalid literal for int() with base 10: b''
[*] Stopped process '/bin/cat' (pid 3404)
```