### PR TITLE
add timeout to gdbserver

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -315,7 +315,14 @@ def _gdbserver_port(gdbserver, ssh):
 
     # Process /bin/bash created; pid = 14366
     # Listening on port 34816
-    process_created = gdbserver.recvline()
+    process_created = gdbserver.recvline(timeout=3)
+
+    if not process_created:
+        log.error(
+            'No output from gdbserver after 3 seconds. Try setting the SHELL=/bin/sh '
+            'environment variable or using the env={} argument if you are affected by '
+            'https://sourceware.org/bugzilla/show_bug.cgi?id=26116'
+        )
 
     if process_created.startswith(b'ERROR:'):
         raise ValueError(


### PR DESCRIPTION
[Bug 26116 in gdbserver](https://sourceware.org/bugzilla/show_bug.cgi?id=26116) causes `pwn.gdb.debug()` to hang on certain systems. Several users are affected by this, see #2030, #2060, and [here](https://github.com/cvanloo/rop/blob/ec10a12e3256344e38e4c745781962f5245f5715/README.md?plain=1#L481). Since it doesn't look like the bug is getting fixed soon, we should try to detect it and offer a workaround. Many users had success with `env={}`. This will cause gdbserver [to use `/bin/sh` instead of `$SHELL`](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdbsupport/pathstuff.cc;h=685f8fc3e60e970a6b92c92344f4251b372359bd;hb=HEAD#l376).

I'm experiencing this bug with `SHELL=/bin/fish`. Setting `SHELL=/bin/bash` or using `env={}` fixes it.