### PR TITLE
Retry failed lookups after one week in libcdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2309][2309] Detect challenge binary and libc in `pwn template`
 - [#2308][2308] Fix WinExec shellcraft to make sure it's 16 byte aligned
 - [#2279][2279] Make `pwn template` always set context.binary
+- [#2323][2323] Retry failed lookups after one week in libcdb
 
 [2242]: https://github.com/Gallopsled/pwntools/pull/2242
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
@@ -89,6 +90,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2309]: https://github.com/Gallopsled/pwntools/pull/2309
 [2308]: https://github.com/Gallopsled/pwntools/pull/2308
 [2279]: https://github.com/Gallopsled/pwntools/pull/2279
+[2323]: https://github.com/Gallopsled/pwntools/pull/2323
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import os
+import time
 import six
 import tempfile
 
@@ -28,6 +29,9 @@ DEBUGINFOD_SERVERS = [
 if 'DEBUGINFOD_URLS' in os.environ:
     urls = os.environ['DEBUGINFOD_URLS'].split(' ')
     DEBUGINFOD_SERVERS = urls + DEBUGINFOD_SERVERS
+
+# Retry failed lookups after some time
+NEGATIVE_CACHE_EXPIRY = 60 * 60 * 24 * 7 # 1 week
 
 # https://gitlab.com/libcdb/libcdb wasn't updated after 2019,
 # but still is a massive database of older libc binaries.
@@ -109,6 +113,10 @@ def search_by_hash(hex_encoded_id, hash_type='build_id', unstrip=True):
     cache, cache_valid = _check_elf_cache('libcdb', hex_encoded_id, hash_type)
     if cache_valid:
         return cache
+    
+    # We searched for this buildid before, but didn't find anything.
+    if cache is None:
+        return None
 
     # Run through all available libc database providers to see if we have a match.
     for provider in PROVIDERS:
@@ -141,6 +149,10 @@ def _search_debuginfo_by_hash(base_url, hex_encoded_id):
     cache, cache_valid = _check_elf_cache('libcdb_dbg', hex_encoded_id, 'build_id')
     if cache_valid:
         return cache
+    
+    # We searched for this buildid before, but didn't find anything.
+    if cache is None:
+        return None
 
     # Try to find separate debuginfo.
     url  = '/buildid/{}/debuginfo'.format(hex_encoded_id)
@@ -191,8 +203,11 @@ def _check_elf_cache(cache_type, hex_encoded_id, hash_type):
 
     data = read(cache)
     if not data.startswith(b'\x7FELF'):
-        log.info_once("Skipping unavailable ELF %s", hex_encoded_id)
-        return cache, False
+        # Retry failed lookups after some time
+        if time.time() > os.path.getmtime(cache) + NEGATIVE_CACHE_EXPIRY:
+            return cache, False
+        log.info_once("Skipping invalid cached ELF %s", hex_encoded_id)
+        return None, False
 
     log.info_once("Using cached data from %r", cache)
     return cache, True


### PR DESCRIPTION
The libc databases might be updated to include the searched version, so a request that failed once might work in the future. This tries to find the libc again online after one week has passed since the last failed attempt.

Refs #983