### PR TITLE
Lookup using $PATHEXT file extensions in `which` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2279][2279] Make `pwn template` always set context.binary
 - [#2310][2310] Add support to start a process on Windows
 - [#2334][2334] Speed up disasm commandline tool with colored output
+- [#2328][2328] Lookup using $PATHEXT file extensions in `which` on Windows
 
 [2242]: https://github.com/Gallopsled/pwntools/pull/2242
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
@@ -93,6 +94,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2279]: https://github.com/Gallopsled/pwntools/pull/2279
 [2310]: https://github.com/Gallopsled/pwntools/pull/2310
 [2334]: https://github.com/Gallopsled/pwntools/pull/2334
+[2328]: https://github.com/Gallopsled/pwntools/pull/2328
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -580,8 +580,6 @@ class process(tube):
         if not isinstance(executable, str):
             executable = executable.decode('utf-8')
 
-        pathexts = os.environ.get('PATHEXT', '').split(os.pathsep) if sys.platform == 'win32' else []
-        pathexts = [''] + pathexts
         path = env and env.get(b'PATH')
         if path:
             path = path.decode()
@@ -593,15 +591,10 @@ class process(tube):
 
         # If there's no path component, it's in $PATH or relative to the
         # target directory.
-        # Try all of the file extensions in $PATHEXT on Windows too.
         #
         # For example, 'sh'
-        elif os.path.sep not in executable and any(which(executable + pathext, path=path) for pathext in pathexts):
-            for pathext in pathexts:
-                resolved_path = which(executable + pathext, path=path)
-                if resolved_path:
-                    executable = resolved_path
-                    break
+        elif os.path.sep not in executable and which(executable, path=path):
+            executable = which(executable, path=path)
 
         # Either there is a path component, or the binary is not in $PATH
         # For example, 'foo/bar' or 'bar' with cwd=='foo'

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -139,6 +139,7 @@ def which(name, all = False, path=None):
 
     Works as the system command ``which``; searches $PATH for ``name`` and
     returns a full path if found.
+    Tries all of the file extensions in $PATHEXT on Windows too.
 
     If `all` is :const:`True` the set of all found locations is returned, else
     the first occurrence or :const:`None` is returned.
@@ -160,26 +161,35 @@ def which(name, all = False, path=None):
     if os.path.sep in name:
         return name
 
-    isroot = False if sys.platform == 'win32' else (os.getuid() == 0)
+    if sys.platform == 'win32':
+        pathexts = os.environ.get('PATHEXT', '').split(os.pathsep)
+        isroot = False
+    else:
+        pathexts = []
+        isroot = os.getuid() == 0
+    pathexts = [''] + pathexts
     out = set()
     try:
         path = path or os.environ['PATH']
     except KeyError:
         log.exception('Environment variable $PATH is not set')
-    for p in path.split(os.pathsep):
-        p = os.path.join(p, name)
-        if os.access(p, os.X_OK):
-            st = os.stat(p)
-            if not stat.S_ISREG(st.st_mode):
-                continue
-            # work around this issue: https://bugs.python.org/issue9311
-            if isroot and not \
-              st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
-                continue
-            if all:
-                out.add(p)
-            else:
-                return p
+    for path_part in path.split(os.pathsep):
+        for ext in pathexts:
+            nameext = name + ext
+            p = os.path.join(path_part, nameext)
+            if os.access(p, os.X_OK):
+                st = os.stat(p)
+                if not stat.S_ISREG(st.st_mode):
+                    continue
+                # work around this issue: https://bugs.python.org/issue9311
+                if isroot and not \
+                st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                    continue
+                if all:
+                    out.add(p)
+                    break
+                else:
+                    return p
     if all:
         return out
     else:


### PR DESCRIPTION
Windows uses some file extensions to determine which file to run when given a non-existing file. Try all file extensions in the $PATHEXT environment variable, which defaults to `.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL` on Windows 11.

This allows to run `process("calc")` instead of `process("calc.exe")`.