### PR TITLE
Make sure TERM_PROGRAM points to a valid program in `run_in_new_terminal`

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -297,7 +297,7 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
         elif 'STY' in os.environ and which('screen'):
             terminal = 'screen'
             args     = ['-t','pwntools-gdb','bash','-c']
-        elif 'TERM_PROGRAM' in os.environ:
+        elif 'TERM_PROGRAM' in os.environ and which(os.environ['TERM_PROGRAM']):
             terminal = os.environ['TERM_PROGRAM']
             args     = []
         elif 'DISPLAY' in os.environ and which('x-terminal-emulator'):


### PR DESCRIPTION
Visual Studio Code sets the $TERM_PROGRAM environment variable to `vscode` in its terminal pane, but doesn't support opening new panes from the command line and there is no "vscode" binary.

`misc.run_in_new_terminal` reports `pwnlib.exception.PwnlibException: Could not find terminal binary 'vscode'. Set context.terminal to your terminal.`

Make sure the target binary exists before trying to launch it. This appears to be mostly set by terminals on macOS, so this should be tested in those setups if someone uses a mac ❤️ 