### PR TITLE
Improved DynELF address resolutions and symbol lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2308][2308] Fix WinExec shellcraft to make sure it's 16 byte aligned
 - [#2279][2279] Make `pwn template` always set context.binary
 - [#2310][2310] Add support to start a process on Windows
+- [#2335][2335] Added lookup optimizations in DynELF 
 
 [2242]: https://github.com/Gallopsled/pwntools/pull/2242
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
@@ -91,6 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2308]: https://github.com/Gallopsled/pwntools/pull/2308
 [2279]: https://github.com/Gallopsled/pwntools/pull/2279
 [2310]: https://github.com/Gallopsled/pwntools/pull/2310
+[2335]: https://github.com/Gallopsled/pwntools/pull/2335
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -690,7 +690,7 @@ class DynELF(object):
         symtab = self._make_absolute_ptr(symtab)
         jmprel = self._make_absolute_ptr(jmprel)
 
-        w = self.waitfor(f"Looking for {symb} in .real.plt")
+        w = self.waitfor(f"Looking for {symb} in .rel.plt")
         # We look for the symbol by iterating through each Elf64_Rel entry.
         # For each Elf64_Rel, get the Elf64_Sym for that entry
         # Then compare the Elf64_Sym.st_name with the symbol name

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -778,6 +778,8 @@ class DynELF(object):
         resolved_addr = routine(self.libbase, symb, hshtab, strtab, symtab)
 
         if resolved_addr:
+            # Restore the original leaker
+            self.leak = real_leak
             return resolved_addr
 
         # if symbol not found in GNU_Hash, try looking in JMPREL

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -368,7 +368,7 @@ class DynELF(object):
         ptr = self.elf.dynamic_value_by_tag(name)
         if ptr:
             ptr = self._make_absolute_ptr(ptr)
-            self.success(f"Found {name} at 0x{ptr:x}")
+            self.success("Found %s at %#x" % (name, ptr))
             return ptr
         return None
 
@@ -676,7 +676,7 @@ class DynELF(object):
 
         # If elf is available look for the symbol in it
         if elf_obj and symb_name in elf_obj.symbols:
-            self.success(f"Symbol '{symb_name}' found in ELF!")
+            self.success("Symbol '%s' found in ELF!" % symb_name)
             return elf_obj.symbols[symb_name]
 
         log.warning("Looking up symbol through DT_JMPREL. This might be slower...")
@@ -690,7 +690,7 @@ class DynELF(object):
         symtab = self._make_absolute_ptr(symtab)
         jmprel = self._make_absolute_ptr(jmprel)
 
-        w = self.waitfor(f"Looking for {symb} in .rel.plt")
+        w = self.waitfor("Looking for %s in .rel.plt" % symb)
         # We look for the symbol by iterating through each Elf64_Rel entry.
         # For each Elf64_Rel, get the Elf64_Sym for that entry
         # Then compare the Elf64_Sym.st_name with the symbol name
@@ -713,7 +713,7 @@ class DynELF(object):
             symb_str = leak.s(strtab+sym_str_off)
 
             if symb_str == symb:
-                w.success(f"Found matching Elf64_Rel entry!")
+                w.success("Found matching Elf64_Rel entry!")
                 break
 
             rel_addr += sizeof(Rel)

--- a/pwnlib/elf/datatypes.py
+++ b/pwnlib/elf/datatypes.py
@@ -399,6 +399,15 @@ class Elf64_Sym(ctypes.Structure):
                 ("st_value", Elf64_Addr),
                 ("st_size", Elf64_Xword),]
 
+class Elf64_Rel(ctypes.Structure):
+    _fields_ = [("r_offset", Elf64_Addr),
+                ("r_info", Elf64_Xword),
+                ("r_addend", Elf64_Sxword),]
+
+class Elf32_Rel(ctypes.Structure):
+    _fields_ = [("r_offset", Elf32_Addr),
+                ("r_info", Elf32_Word),]
+
 class Elf32_Link_Map(ctypes.Structure):
     _fields_ = [("l_addr", Elf32_Addr),
                 ("l_name", Elf32_Addr),


### PR DESCRIPTION
Most changes are centered around not using the leaker function when we can directly read from the ELF object instead (where possible). This especially improves resolving section addresses, even when having an inconsistent leaker function.

Added the Elf64_Rel and Elf32_Rel datatypes (the entries of DT_JMPREL)

Added another way to lookup symbols by using DT_JMPREL when the default way through GNU_HASH fails (as it often does with FULL RELRO binaries).

Also the older `_find_linkmap_assisted(self, path)` was removed as it is no longer needed. `_find_dt(self, tag)` will use the elf object  to resolve tags, if it can, automatically.

This should overall make DynELF more stable, faster and more informative.