### PR TITLE
Add `ELF.stripped` and `ELF.debuginfo` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2310][2310] Add support to start a process on Windows
 - [#2334][2334] Speed up disasm commandline tool with colored output
 - [#2328][2328] Lookup using $PATHEXT file extensions in `which` on Windows
+- [#2336][2336] Add `ELF.stripped` and `ELF.debuginfo` properties
 
 [2242]: https://github.com/Gallopsled/pwntools/pull/2242
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
@@ -95,6 +96,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2310]: https://github.com/Gallopsled/pwntools/pull/2310
 [2334]: https://github.com/Gallopsled/pwntools/pull/2334
 [2328]: https://github.com/Gallopsled/pwntools/pull/2328
+[2336]: https://github.com/Gallopsled/pwntools/pull/2336
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -2119,10 +2119,10 @@ class ELF(ELFFile):
             res.append("IBT:".ljust(12) + green("Enabled"))
         
         if not self.stripped:
-            res.append("Stripped:".ljust(12) + green("No"))
+            res.append("Stripped:".ljust(12) + red("No"))
         
         if self.debuginfo:
-            res.append("Debuginfo:".ljust(12) + green("Yes"))
+            res.append("Debuginfo:".ljust(12) + red("Yes"))
 
         # Check for Linux configuration, it must contain more than
         # just the version.


### PR DESCRIPTION
Show status in checksec output too. This can be used to avoid trying to apply debug symbols if the binary already contains some #2324

The detection is [aligned](https://github.com/file/file/blob/1ba0b612ee0c0791a10622f9797d6266710a1ec3/src/readelf.c#L1409) with the output of `file`.