### PR TITLE
fix: follow symlink for libs on ssh connection

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -324,6 +324,7 @@ class ssh_process(ssh_channel):
 
         for lib in maps:
             remote_path = lib.split(self.parent.host)[-1]
+            remote_path = self.parent.readlink('-f', remote_path).decode()
             for line in maps_raw.splitlines():
                 if line.endswith(remote_path):
                     address = line.split('-')[0]


### PR DESCRIPTION
# Pwntools Pull Request

When running a process over SSH, if the lib used is a symlink, then the addresses returned are wrong. This is because we get the address from `/proc/PID/maps` but we use the symlink lib name, and not the "real" lib name.  
I corrected it by using `readlink -f` which return the actual lib used.

## Changelog

Since it's a really small change, should I still push a change to the Changelog?
