### PR TITLE
Fix: Allow setting attributes on gdb Breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2334][2334] Speed up disasm commandline tool with colored output
 - [#2328][2328] Lookup using $PATHEXT file extensions in `which` on Windows
 - [#2189][2189] Explicitly define p64/u64 functions for IDE support
+- [#2339][2339] Fix: Allow setting attributes on gdb Breakpoints
 
 [2242]: https://github.com/Gallopsled/pwntools/pull/2242
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
@@ -97,6 +98,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2334]: https://github.com/Gallopsled/pwntools/pull/2334
 [2328]: https://github.com/Gallopsled/pwntools/pull/2328
 [2189]: https://github.com/Gallopsled/pwntools/pull/2189
+[2339]: https://github.com/Gallopsled/pwntools/pull/2339
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -713,6 +713,22 @@ class FinishBreakpoint(Breakpoint):
             self, hasattr(self, 'stop'), hasattr(self, 'out_of_scope'),
             *args, **kwargs)
 
+    def __getattr__(self, item):
+        """Return attributes of the real breakpoint."""
+        if item in (
+                '____id_pack__',
+                '__name__',
+                '____conn__',
+                'stop',
+                'out_of_scope',
+        ):
+            # Ignore RPyC netref attributes.
+            # Also, if stop() or out_of_scope() are not defined, hasattr() call
+            # in our __init__() will bring us here. Don't contact the
+            # server in this case either.
+            raise AttributeError()
+        return getattr(self.server_breakpoint, item)
+
     def exposed_out_of_scope(self):
         # Handle out_of_scope() call from the server.
         return self.out_of_scope()

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -652,7 +652,10 @@ class Breakpoint:
         """
         # Creates a real breakpoint and connects it with this mirror
         self.conn = conn
-        self.server_breakpoint = conn.root.set_breakpoint(
+        self.server_breakpoint = self._server_set_breakpoint(*args, **kwargs)
+
+    def _server_set_breakpoint(self, *args, **kwargs):
+        return self.conn.root.set_breakpoint(
             self, hasattr(self, 'stop'), *args, **kwargs)
 
     def __getattr__(self, item):
@@ -670,47 +673,45 @@ class Breakpoint:
             raise AttributeError()
         return getattr(self.server_breakpoint, item)
 
+    def __setattr__(self, name, value):
+        """Set attributes of the real breakpoint."""
+        if name in (
+            'enabled',
+            'silent',
+            'thread',
+            'task',
+            'ignore_count',
+            'hit_count'
+            'condition',
+            'commands',
+        ):
+            return setattr(self.server_breakpoint, name, value)
+        return super().__setattr__(name, value)
+
     def exposed_stop(self):
         # Handle stop() call from the server.
         return self.stop()
 
-class FinishBreakpoint:
+class FinishBreakpoint(Breakpoint):
     """Mirror of ``gdb.FinishBreakpoint`` class.
 
     See https://sourceware.org/gdb/onlinedocs/gdb/Finish-Breakpoints-in-Python.html
     for more information.
     """
 
-    def __init__(self, conn, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Do not create instances of this class directly.
 
         Use ``pwnlib.gdb.Gdb.FinishBreakpoint`` instead.
         """
-        # Creates a real finish breakpoint and connects it with this mirror
-        self.conn = conn
-        self.server_breakpoint = conn.root.set_finish_breakpoint(
+        # See https://github.com/pylint-dev/pylint/issues/4228
+        # pylint: disable=useless-super-delegation
+        super().__init__(*args, **kwargs)
+
+    def _server_set_breakpoint(self, *args, **kwargs):
+        return self.conn.root.set_finish_breakpoint(
             self, hasattr(self, 'stop'), hasattr(self, 'out_of_scope'),
             *args, **kwargs)
-
-    def __getattr__(self, item):
-        """Return attributes of the real breakpoint."""
-        if item in (
-                '____id_pack__',
-                '__name__',
-                '____conn__',
-                'stop',
-                'out_of_scope',
-        ):
-            # Ignore RPyC netref attributes.
-            # Also, if stop() or out_of_scope() are not defined, hasattr() call
-            # in our __init__() will bring us here. Don't contact the
-            # server in this case either.
-            raise AttributeError()
-        return getattr(self.server_breakpoint, item)
-
-    def exposed_stop(self):
-        # Handle stop() call from the server.
-        return self.stop()
 
     def exposed_out_of_scope(self):
         # Handle out_of_scope() call from the server.

--- a/pwnlib/gdb_api_bridge.py
+++ b/pwnlib/gdb_api_bridge.py
@@ -110,5 +110,6 @@ spawn(ThreadedServer(
     socket_path=socket_path,
     protocol_config={
         'allow_all_attrs': True,
+        'allow_setattr': True,
     },
 ).start)


### PR DESCRIPTION
 This PR enables write access to breakpoint attributes declared writeable in the [docs](https://sourceware.org/gdb/current/onlinedocs/gdb#Breakpoints-In-Python). It fixes #2096 and other use cases, such as disabling a breakpoint.
