### PR TITLE
Fix pwn constgrep when it matches a non-constant type (Fixes #2344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
         pwn constgrep -c freebsd -m ^PROT_ '3 + 4'
         pwn constgrep ^MAP_ 0
         pwn constgrep -e O_RDWR
+        pwn constgrep C
 
         pwn libcdb file /lib/x86_64-linux-gnu/libc.so.6
         pwn libcdb lookup puts 5f0 __libc_start_main_ret d0a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2161][2161] Fix freebsd amd64 SyscallABI
 - [#2160][2161] Fix invalid shellcraft.mov on arm64
 - [#2284][2161] Fix invalid shellcraft.pushstr_array on arm64
+- [#2345][2345] Fix pwn constgrep when it matches a non-constant type
 
 [2242]: https://github.com/Gallopsled/pwntools/pull/2242
 [2277]: https://github.com/Gallopsled/pwntools/pull/2277
@@ -110,6 +111,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2325]: https://github.com/Gallopsled/pwntools/pull/2325
 [2336]: https://github.com/Gallopsled/pwntools/pull/2336
 [2161]: https://github.com/Gallopsled/pwntools/pull/2161
+[2345]: https://github.com/Gallopsled/pwntools/pull/2345
 
 ## 4.12.0 (`beta`)
 

--- a/pwnlib/commandline/constgrep.py
+++ b/pwnlib/commandline/constgrep.py
@@ -91,9 +91,13 @@ def main(args):
             if not matcher.search(k):
                 continue
 
+            # Check if the value has proper type
+            val = getattr(mod, k)
+            if not isinstance(val, pwnlib.constants.constant.Constant):
+                continue
+
             # Check the constant
             if constant is not None:
-                val = getattr(mod, k)
                 if args.mask_mode:
                     if constant & val != val:
                         continue
@@ -102,7 +106,7 @@ def main(args):
                         continue
 
             # Append it
-            out.append((getattr(mod, k), k))
+            out.append((val, k))
             maxlen = max(len(k), maxlen)
 
         # Output all matching constants


### PR DESCRIPTION
This commit fixes https://github.com/Gallopsled/pwntools/issues/2344 - the following issue:

```
root@pwndbg:~# pwn constgrep a
Traceback (most recent call last):
  File "/usr/local/bin/pwn", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/commandline/main.py", line 58, in main
    commands[args.command](args)
  File "/usr/local/lib/python3.10/dist-packages/pwnlib/commandline/constgrep.py", line 110, in main
    for _, k in sorted(out):
TypeError: '<' not supported between instances of 'Constant' and 'type'
```

Note that it was caused because of the following type object being matched and fetched from the module object:

```
ipdb> out[25:27]
[(Constant('CS', 0xd), 'CS'), (<class 'pwnlib.constants.constant.Constant'>, 'Constant')]
ipdb> sorted(out[24:27])
*** TypeError: '<' not supported between instances of 'type' and 'Constant'
```

