### PR TITLE
checksec.py: import ELF instead of *

### DIFF
--- a/pwnlib/commandline/checksec.py
+++ b/pwnlib/commandline/checksec.py
@@ -4,7 +4,7 @@ from __future__ import division
 import argparse
 import sys
 
-from pwn import *
+from pwnlib.elf import ELF
 from pwnlib.commandline import common
 
 parser = common.parser_commands.add_parser(


### PR DESCRIPTION
This is a minor improvement which makes checksec.py import only what is needed instead of the whole `pwn` module.