### PR TITLE
Fix readline omitting a trailing \n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ The table below shows which release corresponds to each branch, and what date th
 [2257]: https://github.com/Gallopsled/pwntools/pull/2257
 [2225]: https://github.com/Gallopsled/pwntools/pull/2225
 
+## 4.11.2
+- [#2349][2349] Fix term.readline omitting a trailing \n
+
+[2349]: https://github.com/Gallopsled/pwntools/pull/2349
+
 ## 4.11.1 (`stable`)
 
 - [#2271][2271] FIX: Generated shebang with path to python invalid if path contains spaces

--- a/pwnlib/term/readline.py
+++ b/pwnlib/term/readline.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import six
 import sys
+import os
 
 from pwnlib.term import keyconsts as kc
 from pwnlib.term import keymap as km
@@ -404,7 +405,7 @@ def readline(_size=-1, prompt='', float=True, priority=10):
                     buffer = (buffer_left + buffer_right)
                     if buffer:
                         history.insert(0, buffer)
-                    return force_to_bytes(buffer)
+                    return force_to_bytes(buffer) + b'\n'
             except KeyboardInterrupt:
                 control_c()
     finally:
@@ -432,7 +433,7 @@ def raw_input(prompt='', float=True):
         float(bool): If set to `True`, prompt and input will float to the
                      bottom of the screen when `term.term_mode` is enabled.
     """
-    return readline(-1, prompt, float)
+    return readline(-1, prompt, float).rstrip(os.linesep.encode())
 
 def str_input(prompt='', float=True):
     r"""str_input(prompt='', float=True)
@@ -445,7 +446,7 @@ def str_input(prompt='', float=True):
         float(bool): If set to `True`, prompt and input will float to the
                      bottom of the screen when `term.term_mode` is enabled.
     """
-    return readline(-1, prompt, float).decode()
+    return readline(-1, prompt, float).decode().rstrip(os.linesep)
 
 def eval_input(prompt='', float=True):
     """eval_input(prompt='', float=True)
@@ -471,7 +472,7 @@ def eval_input(prompt='', float=True):
         Favorite object? 20
     """
     from pwnlib.util import safeeval
-    return safeeval.const(readline(-1, prompt, float))
+    return safeeval.const(readline(-1, prompt, float).rstrip(os.linesep.encode()))
 
 def init():
     global safeeval

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -900,8 +900,8 @@ class tube(Timeout, Logger):
             while not go.isSet():
                 if term.term_mode:
                     data = term.readline.readline(prompt = prompt, float = True)
-                    if data:
-                        data += self.newline
+                    if data.endswith(b'\n') and self.newline != b'\n':
+                        data = data[:-1] + self.newline
                 else:
                     stdin = getattr(sys.stdin, 'buffer', sys.stdin)
                     data = stdin.read(1)


### PR DESCRIPTION
This is a regression from #2129 which was based on a bogus test which mixed `input` and `readline` calls.

Only [`input`](https://docs.python.org/3/library/functions.html#input) (and [`raw_input`](https://docs.python.org/2.7/library/functions.html#raw_input)) are documented to strip the newline, but `readline` itself should include it.

Fixes #2342