### PR TITLE
add RETURN_CONST as an allowed _const_code in safeeval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,8 +92,10 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.11.2
 - [#2349][2349] Fix term.readline omitting a trailing \n
+- [#2352][2352] add `RETURN_CONST` as an allowed `_const_code` in safeeval
 
 [2349]: https://github.com/Gallopsled/pwntools/pull/2349
+[2352]: https://github.com/Gallopsled/pwntools/pull/2352
 
 ## 4.11.1 (`stable`)
 
@@ -102,14 +104,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2281][2281] FIX: Getting right amount of data for search fix
 - [#2287][2287] Fix `_countdown_handler` not invoking `timeout_change`
 - [#2294][2294] Fix atexit SEGV in aarch64 loader
-- [#2352][2352] add `RETURN_CONST` as an allowed `_const_code` in safeeval
 
 [2271]: https://github.com/Gallopsled/pwntools/pull/2271
 [2272]: https://github.com/Gallopsled/pwntools/pull/2272
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
 [2287]: https://github.com/Gallopsled/pwntools/pull/2287
 [2294]: https://github.com/Gallopsled/pwntools/pull/2294
-[2352]: https://github.com/Gallopsled/pwntools/pull/2352
 
 ## 4.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,12 +102,14 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2281][2281] FIX: Getting right amount of data for search fix
 - [#2287][2287] Fix `_countdown_handler` not invoking `timeout_change`
 - [#2294][2294] Fix atexit SEGV in aarch64 loader
+- [#2352][2352] add `RETURN_CONST` as an allowed `_const_code` in safeeval
 
 [2271]: https://github.com/Gallopsled/pwntools/pull/2271
 [2272]: https://github.com/Gallopsled/pwntools/pull/2272
 [2281]: https://github.com/Gallopsled/pwntools/pull/2281
 [2287]: https://github.com/Gallopsled/pwntools/pull/2287
 [2294]: https://github.com/Gallopsled/pwntools/pull/2294
+[2352]: https://github.com/Gallopsled/pwntools/pull/2352
 
 ## 4.11.0
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1077,10 +1077,7 @@ os.execve(exe, argv, env)
                 python.recvline_contains(b'PWNTOOLS')   # Magic flag so that any sh/bash initialization errors are swallowed
                 try:
                     if b'python' not in python.recvline():  # Python interpreter that was selected
-                        self.warn_once('Could not find a Python interpreter on %s\n' % self.host
-                                       + "Use ssh.run() instead of ssh.process()\n")
-                        h.failure("Process creation failed")
-                        return None
+                        raise ValueError("Python not found on remote host")
                 except (EOFError, ValueError):
                     self.warn_once('Could not find a Python interpreter on %s\n' % self.host
                                    + "Use ssh.system() instead of ssh.process()\n")

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1075,7 +1075,13 @@ os.execve(exe, argv, env)
 
             try:
                 python.recvline_contains(b'PWNTOOLS')   # Magic flag so that any sh/bash initialization errors are swallowed
-                if b'python' not in python.recvline():  # Python interpreter that was selected
+                try:
+                    if b'python' not in python.recvline():  # Python interpreter that was selected
+                        self.warn_once('Could not find a Python interpreter on %s\n' % self.host
+                                       + "Use ssh.run() instead of ssh.process()\n")
+                        h.failure("Process creation failed")
+                        return None
+                except (EOFError, ValueError):
                     self.warn_once('Could not find a Python interpreter on %s\n' % self.host
                                    + "Use ssh.system() instead of ssh.process()\n")
                     h.failure("Process creation failed")

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1075,7 +1075,7 @@ os.execve(exe, argv, env)
 
             try:
                 python.recvline_contains(b'PWNTOOLS')   # Magic flag so that any sh/bash initialization errors are swallowed
-                if not b'python' in python.recvline():  # Python interpreter that was selected
+                if b'python' not in python.recvline():  # Python interpreter that was selected
                     self.warn_once('Could not find a Python interpreter on %s\n' % self.host
                                    + "Use ssh.system() instead of ssh.process()\n")
                     h.failure("Process creation failed")
@@ -1085,7 +1085,6 @@ os.execve(exe, argv, env)
             except (EOFError, ValueError):
                 h.failure("Process creation failed")
                 return None
-
 
             # If an error occurred, try to grab as much output
             # as we can.

--- a/pwnlib/util/safeeval.py
+++ b/pwnlib/util/safeeval.py
@@ -6,7 +6,7 @@ _const_codes = [
     'BUILD_CONST_KEY_MAP', 'BUILD_STRING',
     'LOAD_CONST','RETURN_VALUE','STORE_SUBSCR', 'STORE_MAP',
     'LIST_TO_TUPLE', 'LIST_EXTEND', 'SET_UPDATE', 'DICT_UPDATE', 'DICT_MERGE',
-    'COPY', 'RESUME',
+    'COPY', 'RESUME', 'RETURN_CONST'
     ]
 
 _expr_codes = _const_codes + [


### PR DESCRIPTION
On my m1 mac, with python 3.12.1, evaluating safeeval.const('1') requires 'RETURN_CONST' as an allowed opcode. I added this opcode to allowed opcodes, and also changed some error mesage generation in ssh.process() (which is where the problem occured for me). I removed the python.recvall() call in the error message generation, since this caused everything to hang for me in a very confusing way, but I can re-add it if you want me to.