### PR TITLE
pwn template: Don't search for challenge binary when already given

### DIFF
--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -47,10 +47,11 @@ def detect_missing_binaries(args):
         else:
             if os.access(filename, os.X_OK):
                 other_files.append(filename)
-    if len(other_files) == 1:
-        exe = other_files[0]
-    elif len(other_files) > 1:
-        log.warning("Failed to find challenge binary. There are multiple binaries in the current directory: %s", other_files)
+    if not exe:
+        if len(other_files) == 1:
+            exe = other_files[0]
+        elif len(other_files) > 1:
+            log.warning("Failed to find challenge binary. There are multiple binaries in the current directory: %s", other_files)
 
     if exe != args.exe:
         log.success("Found challenge binary %r", exe)


### PR DESCRIPTION
The auto detection in `pwn template` would still try to look for the challenge binary even when there was one supplied on the command line. Don't try to outsmart the user!