### PR TITLE
Fix gdb and other doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
 
     - name: Coverage doctests
       run: |
+        # Python version installed using setup-python interferes with gdb's python
+        # by setting LD_LIBRARY_PATH and gdb's python becoming unable to load built-in modules
+        # like _socket. This is a workaround.
+        unset LD_LIBRARY_PATH
         PWNLIB_NOTERM=1 python -bb -m coverage run -m sphinx -b doctest docs/source docs/build/doctest
 
     - name: Coverage running examples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,6 +71,7 @@ doctest_global_setup = '''
 import sys, os
 os.environ['PWNLIB_NOTERM'] = '1'
 os.environ['PWNLIB_RANDOMIZE'] = '0'
+import six
 import pwnlib.update
 import pwnlib.util.fiddling
 import logging
@@ -98,6 +99,7 @@ github_actions = os.environ.get('USER') == 'runner'
 travis_ci = os.environ.get('USER') == 'travis'
 local_doctest = os.environ.get('USER') == 'pwntools'
 skip_android = True
+is_python2 = six.PY2
 '''
 
 autoclass_content = 'both'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,7 +82,6 @@ Each of the ``pwntools`` modules is documented here.
    :hidden:
 
    testexample
-   rop/call
 
 .. only:: not dash
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -51,13 +51,11 @@ Command-Line Tools
 
 When installed with ``sudo`` the above commands will install Pwntools' command-line tools to somewhere like ``/usr/bin``.
 
-However, if you run as an unprivileged user, you may see a warning message that looks like this:
+However, if you run as an unprivileged user, you may see a warning message that looks like this::
 
-.. code-block::
-
-      WARNING: The scripts asm, checksec, common, constgrep, cyclic, debug, disablenx, disasm, 
-      elfdiff, elfpatch, errno, hex, main, phd, pwn, pwnstrip, scramble, shellcraft, template, 
-      unhex, update and version are installed in '/home/user/.local/bin' which is not on PATH.
+    WARNING: The scripts asm, checksec, common, constgrep, cyclic, debug, disablenx, disasm, 
+    elfdiff, elfpatch, errno, hex, main, phd, pwn, pwnstrip, scramble, shellcraft, template, 
+    unhex, update and version are installed in '/home/user/.local/bin' which is not on PATH.
 
 Follow the instructions listed and add ``~/.local/bin`` to your ``$PATH`` environment variable.
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -830,6 +830,7 @@ class ContextType(object):
         The default value is ``32``, but changes according to :attr:`arch`.
 
         Examples:
+
             >>> context.clear()
             >>> context.bits == 32
             True

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1346,6 +1346,7 @@ class ELF(ELFFile):
             or :const:`None`.
 
         Examples:
+
             >>> bash = ELF(which('bash'))
             >>> bash.vaddr_to_offset(bash.address)
             0
@@ -1496,6 +1497,7 @@ class ELF(ELFFile):
             that it stays in the same segment.
 
         Examples:
+
           >>> bash = ELF(which('bash'))
           >>> bash.read(bash.address+1, 3)
           b'ELF'
@@ -2387,6 +2389,7 @@ class ELF(ELFFile):
             A new ELF instance is returned after patching the binary with the external ``patchelf`` tool.
 
         Example:
+
             >>> tmpdir = tempfile.mkdtemp()
             >>> ls_path = os.path.join(tmpdir, 'ls')
             >>> _ = shutil.copy(which('ls'), ls_path)

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -129,6 +129,7 @@ def normalize_writes(writes):
     such that all values are raw bytes and consecutive writes are merged to a single key.
 
     Examples:
+
         >>> context.clear(endian="little", bits=32)
         >>> normalize_writes({0x0: [p32(0xdeadbeef)], 0x4: p32(0xf00dface), 0x10: 0x41414141})
         [(0, b'\xef\xbe\xad\xde\xce\xfa\r\xf0'), (16, b'AAAA')]
@@ -215,6 +216,7 @@ class AtomWrite(object):
         given the current format string write counter (how many bytes have been written until now).
 
         Examples:
+
             >>> hex(pwnlib.fmtstr.AtomWrite(0x0, 0x2, 0x2345).compute_padding(0x1111))
             '0x1234'
             >>> hex(pwnlib.fmtstr.AtomWrite(0x0, 0x2, 0xaa00).compute_padding(0xaabb))
@@ -246,6 +248,7 @@ class AtomWrite(object):
         Combine adjacent writes into a single write.
 
         Example:
+
             >>> context.clear(endian = "little")
             >>> pwnlib.fmtstr.AtomWrite(0x0, 0x1, 0x1, 0xff).union(pwnlib.fmtstr.AtomWrite(0x1, 0x1, 0x2, 0x77))
             AtomWrite(start=0, size=2, integer=0x201, mask=0x77ff)
@@ -285,11 +288,13 @@ def make_atoms_simple(address, data, badbytes=frozenset()):
 
     This function is simple and does not try to minimize the number of atoms. For example, if there are no
     bad bytes, it simply returns one atom for each byte:
+
         >>> pwnlib.fmtstr.make_atoms_simple(0x0, b"abc", set())
         [AtomWrite(start=0, size=1, integer=0x61, mask=0xff), AtomWrite(start=1, size=1, integer=0x62, mask=0xff), AtomWrite(start=2, size=1, integer=0x63, mask=0xff)]
     
     If there are bad bytes, it will try to bypass by skipping addresses containing bad bytes, otherwise a
     RuntimeError will be raised:
+
         >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'abc', b'\x62')
         [AtomWrite(start=97, size=2, integer=0x6261, mask=0xffff), AtomWrite(start=99, size=1, integer=0x63, mask=0xff)]
         >>> pwnlib.fmtstr.make_atoms_simple(0x61, b'a'*0x10, b'\x62\x63\x64\x65\x66\x67\x68')
@@ -325,6 +330,7 @@ def merge_atoms_writesize(atoms, maxsize):
     This function simply merges adjacent atoms as long as the merged atom's size is not larger than ``maxsize``.
 
     Examples:
+
         >>> from pwnlib.fmtstr import *
         >>> merge_atoms_writesize([AtomWrite(0, 1, 1), AtomWrite(1, 1, 1), AtomWrite(2, 1, 2)], 2)
         [AtomWrite(start=0, size=2, integer=0x101, mask=0xffff), AtomWrite(start=2, size=1, integer=0x2, mask=0xff)]
@@ -364,6 +370,7 @@ def find_min_hamming_in_range_step(prev, step, carry, strict):
         A tuple (score, value, mask) where score equals the number of matching bytes between the returned value and target.
 
     Examples:
+
         >>> initial = {(0,0): (0,0,0), (0,1): None, (1,0): None, (1,1): None}
         >>> pwnlib.fmtstr.find_min_hamming_in_range_step(initial, (0, 0xFF, 0x1), 0, 0)
         (1, 1, 255)
@@ -419,6 +426,7 @@ def find_min_hamming_in_range(maxbytes, lower, upper, target):
         target(int): the target value that should be approximated
 
     Examples:
+
         >>> pp = lambda svm: (svm[0], hex(svm[1]), hex(svm[2]))
         >>> pp(pwnlib.fmtstr.find_min_hamming_in_range(1, 0x0, 0x100, 0xaa))
         (1, '0xaa', '0xff')
@@ -470,6 +478,7 @@ def merge_atoms_overlapping(atoms, sz, szmax, numbwritten, overflows):
         overflows(int): how many extra overflows (of size sz) to tolerate to reduce the number of atoms
 
     Examples:
+
         >>> from pwnlib.fmtstr import *
         >>> merge_atoms_overlapping([AtomWrite(0, 1, 1), AtomWrite(1, 1, 1)], 2, 8, 0, 1)
         [AtomWrite(start=0, size=2, integer=0x101, mask=0xffff)]
@@ -557,6 +566,7 @@ def overlapping_atoms(atoms):
     Finds pairs of atoms that write to the same address.
 
     Basic examples:
+
         >>> from pwnlib.fmtstr import *
         >>> list(overlapping_atoms([AtomWrite(0, 2, 0), AtomWrite(2, 10, 1)])) # no overlaps
         []
@@ -564,6 +574,7 @@ def overlapping_atoms(atoms):
         [(AtomWrite(start=0, size=2, integer=0x0, mask=0xffff), AtomWrite(start=1, size=2, integer=0x1, mask=0xffff))]
 
     When there are transitive overlaps, only the largest overlap is returned. For example:
+
         >>> list(overlapping_atoms([AtomWrite(0, 3, 0), AtomWrite(1, 4, 1), AtomWrite(2, 4, 1)]))
         [(AtomWrite(start=0, size=3, integer=0x0, mask=0xffffff), AtomWrite(start=1, size=4, integer=0x1, mask=0xffffffff)), (AtomWrite(start=1, size=4, integer=0x1, mask=0xffffffff), AtomWrite(start=2, size=4, integer=0x1, mask=0xffffffff))]
 
@@ -629,6 +640,7 @@ def sort_atoms(atoms, numbwritten):
         numbwritten(int): the value at which the counter starts
 
     Examples:
+
         >>> from pwnlib.fmtstr import *
         >>> sort_atoms([AtomWrite(0, 1, 0xff), AtomWrite(1, 1, 0xfe)], 0) # the example described above
         [AtomWrite(start=1, size=1, integer=0xfe, mask=0xff), AtomWrite(start=0, size=1, integer=0xff, mask=0xff)]
@@ -694,6 +706,7 @@ def make_payload_dollar(data_offset, atoms, numbwritten=0, countersize=4, no_dol
         no_dollars(bool) : flag to generete the payload with or w/o $ notation 
 
     Examples:
+
         >>> pwnlib.fmtstr.make_payload_dollar(1, [pwnlib.fmtstr.AtomWrite(0x0, 0x1, 0xff)])
         (b'%255c%1$hhn', b'\x00\x00\x00\x00')
     '''
@@ -840,6 +853,7 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte', write_size_
         The payload in order to do needed writes
 
     Examples:
+
         >>> context.clear(arch = 'amd64')
         >>> fmtstr_payload(1, {0x0: 0x1337babe}, write_size='int')
         b'%322419390c%4$llnaaaabaa\x00\x00\x00\x00\x00\x00\x00\x00'

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -141,14 +141,11 @@ Member Documentation
 from __future__ import absolute_import
 from __future__ import division
 
-from contextlib import contextmanager
 import os
-import sys
 import platform
 import psutil
 import random
 import re
-import shlex
 import six
 import six.moves
 import socket
@@ -512,6 +509,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, api=
         >>> io.close()
         
         Start a new process with modified argv[0]
+
         >>> io = gdb.debug(args=[b'\xde\xad\xbe\xef'], gdbscript='continue', exe="/bin/sh")
         >>> io.sendline(b"echo $0")
         >>> io.recvline()
@@ -519,6 +517,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, api=
         >>> io.close()
 
         Demonstrate that LD_PRELOAD is respected
+
         >>> io = process(["grep", "libc.so.6", "/proc/self/maps"])
         >>> real_libc_path = io.recvline().split()[-1]
         >>> io.close()
@@ -578,10 +577,12 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, api=
         >>> io.sendline(b"echo hello")
 
         Interact with the process
+
         >>> io.interactive() # doctest: +SKIP
         >>> io.close()
 
         Using a modified args[0] on a remote process
+
         >>> io = gdb.debug(args=[b'\xde\xad\xbe\xef'], gdbscript='continue', exe="/bin/sh", ssh=shell)
         >>> io.sendline(b"echo $0")
         >>> io.recvline()
@@ -589,6 +590,7 @@ def debug(args, gdbscript=None, exe=None, ssh=None, env=None, sysroot=None, api=
         >>> io.close()
 
         Using an empty args[0] on a remote process
+
         >>> io = gdb.debug(args=[], gdbscript='continue', exe="/bin/sh", ssh=shell)
         >>> io.sendline(b"echo $0")
         >>> io.recvline()

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -249,6 +249,7 @@ def unstrip_libc(filename):
         :const:`True` if binary was unstripped, :const:`False` otherwise.
 
     Examples:
+
         >>> filename = search_by_build_id('69389d485a9793dbe873f0ea2c93e02efaa9aa3d', unstrip=False)
         >>> libc = ELF(filename)
         >>> 'main_arena' in libc.symbols
@@ -432,6 +433,7 @@ def download_libraries(libc_path, unstrip=True):
         The path to the cached directory containing the downloaded libraries.
 
     Example:
+
         >>> libc_path = ELF(which('ls'), checksec=False).libc.path
         >>> lib_path = download_libraries(libc_path)
         >>> lib_path is not None
@@ -545,6 +547,7 @@ def search_by_symbol_offsets(symbols, select_index=None, unstrip=True, return_as
         is returned instead.
 
     Examples:
+
         >>> filename = search_by_symbol_offsets({'puts': 0x420, 'printf': 0xc90}, select_index=1)
         >>> libc = ELF(filename)
         >>> libc.sym.system == 0x52290
@@ -597,6 +600,7 @@ def search_by_build_id(hex_encoded_id, unstrip=True):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+
         >>> filename = search_by_build_id('fe136e485814fee2268cf19e5c124ed0f73f4400')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'
@@ -622,6 +626,7 @@ def search_by_md5(hex_encoded_id, unstrip=True):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+
         >>> filename = search_by_md5('7a71dafb87606f360043dcd638e411bd')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'
@@ -647,6 +652,7 @@ def search_by_sha1(hex_encoded_id, unstrip=True):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+
         >>> filename = search_by_sha1('34471e355a5e71400b9d65e78d2cd6ce7fc49de5')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'
@@ -673,6 +679,7 @@ def search_by_sha256(hex_encoded_id, unstrip=True):
         Path to the downloaded library on disk, or :const:`None`.
 
     Examples:
+
         >>> filename = search_by_sha256('5e877a8272da934812d2d1f9ee94f73c77c790cbc5d8251f5322389fc9667f21')
         >>> hex(ELF(filename).symbols.read)
         '0xda260'

--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1499,6 +1499,7 @@ class ROP(object):
                 .dynamic section. .got.plt entries are a good target. Required
                 for PIE binaries.
         Test:
+
             >>> context.clear(binary=pwnlib.data.elf.ret2dlresolve.get("amd64"))
             >>> r = ROP(context.binary)
             >>> r.ret2csu(1, 2, 3, 4, 5, 6, 7, 8, 9)

--- a/pwnlib/shellcraft/templates/aarch64/pushstr_array.asm
+++ b/pwnlib/shellcraft/templates/aarch64/pushstr_array.asm
@@ -17,6 +17,7 @@ Arguments:
         ends with exactly one NULL byte.
 
 Example:
+
     >>> assembly = shellcraft.execve("/bin/sh", ["sh", "-c", "echo Hello string $WORLD"], {"WORLD": "World!"})
     >>> ELF.from_assembly(assembly).process().recvall()
     b'Hello string World!\n'

--- a/pwnlib/shellcraft/templates/arm/ret.asm
+++ b/pwnlib/shellcraft/templates/arm/ret.asm
@@ -5,6 +5,7 @@ Args:
     return_value: Value to return
 
 Examples:
+
     >>> with context.local(arch='arm'):
     ...     print(enhex(asm(shellcraft.ret())))
     ...     print(enhex(asm(shellcraft.ret(0))))

--- a/pwnlib/shellcraft/templates/i386/xor.asm
+++ b/pwnlib/shellcraft/templates/i386/xor.asm
@@ -19,6 +19,7 @@ Args:
                  the number of bytes to XOR.
 
 Example:
+
     >>> sc  = shellcraft.read(0, 'esp', 32)
     >>> sc += shellcraft.xor(0xdeadbeef, 'esp', 32)
     >>> sc += shellcraft.write(1, 'esp', 32)

--- a/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/findpeer.asm
@@ -8,6 +8,7 @@
     against the peer port. Resulting socket is left in r6.
 
     Example:
+
         >>> enhex(asm(shellcraft.findpeer(1337)))
         '6ff00006ee4606f101064ff001074fea072707f11f07f54630461fb401a96a4601df0130efdd01994fea11414ff039024fea022202f105029142e4d1'
 </%docstring>

--- a/pwnlib/shellcraft/templates/thumb/linux/listen.asm
+++ b/pwnlib/shellcraft/templates/thumb/linux/listen.asm
@@ -8,6 +8,7 @@
     Port is the TCP port to listen on, network is either 'ipv4' or 'ipv6'.
 
     Example:
+
         >>> enhex(asm(shellcraft.listen(1337, 'ipv4')))
         '4ff001074fea072707f119074ff002004ff0010182ea020201df0646004901e00200053906b469464ff0100207f1010701df30464ff0010107f1020701df304681ea010182ea020207f1010701df0646'
 </%docstring>

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1007,12 +1007,15 @@ class ssh(Timeout, Logger):
         if os.path.sep in program:
             return program
 
-        result = self.run('export PATH=$PATH:$PWD; command -v %s' % program).recvall().strip().decode()
+        if isinstance(program, six.text_type):
+            program = packing._encode(program)
 
-        if ('/%s' % program) not in result:
+        result = self.system(b'export PATH=$PATH:$PWD; command -v ' + program).recvall().strip()
+
+        if (b'/' + program) not in result:
             return None
 
-        return result
+        return packing._decode(result)
 
     def system(self, process, tty = True, cwd = None, env = None, timeout = None, raw = True, wd = None):
         r"""system(process, tty = True, cwd = None, env = None, timeout = Timeout.default, raw = True) -> ssh_channel

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1011,8 +1011,7 @@ class ssh(Timeout, Logger):
         if os.path.sep in program:
             return program
 
-        if isinstance(program, six.text_type):
-            program = packing._encode(program)
+        program = packing._encode(program)
 
         result = self.system(b'export PATH=$PATH:$PWD; command -v ' + program).recvall().strip()
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -340,6 +340,7 @@ class ssh_process(ssh_channel):
         automatically.
 
         Examples:
+
             >>> s =  ssh(host='example.pwnme')
             >>> p = s.process('true')
             >>> p.libc  # doctest: +ELLIPSIS
@@ -383,6 +384,7 @@ class ssh_process(ssh_channel):
         r"""Retrieve the address of an environment variable in the remote process.
 
         Examples:
+
             >>> s = ssh(host='example.pwnme')
             >>> p = s.process(['python', '-c', 'import time; time.sleep(10)'])
             >>> hex(p.getenv('PATH'))  # doctest: +ELLIPSIS
@@ -751,6 +753,7 @@ class ssh(Timeout, Logger):
             Return a :class:`pwnlib.tubes.ssh.ssh_channel` object.
 
         Examples:
+
             >>> s =  ssh(host='example.pwnme')
             >>> sh = s.shell('/bin/sh')
             >>> sh.sendline(b'echo Hello; exit')
@@ -829,6 +832,7 @@ class ssh(Timeout, Logger):
             Requires Python on the remote server.
 
         Examples:
+
             >>> s = ssh(host='example.pwnme')
             >>> sh = s.process('/bin/sh', env={'PS1':''})
             >>> sh.sendline(b'echo Hello; exit')
@@ -1029,6 +1033,7 @@ class ssh(Timeout, Logger):
         Return a :class:`pwnlib.tubes.ssh.ssh_channel` object.
 
         Examples:
+
             >>> s =  ssh(host='example.pwnme')
             >>> py = s.system('python3 -i')
             >>> _ = py.recvuntil(b'>>> ')
@@ -1098,6 +1103,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         a TTY on the remote server.
 
         Examples:
+
             >>> s =  ssh(host='example.pwnme')
             >>> print(s.run_to_end('echo Hello; exit 17'))
             (b'Hello\n', 17)
@@ -1124,6 +1130,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         Returns a :class:`pwnlib.tubes.ssh.ssh_connecter` object.
 
         Examples:
+
             >>> from pwn import *
             >>> l = listen()
             >>> s =  ssh(host='example.pwnme')
@@ -1371,6 +1378,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
 
         Examples:
+
             >>> with open('/tmp/bar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
@@ -1398,6 +1406,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             local(str): The local filename to save it to. Default is to infer it from the remote filename.
         
         Examples:
+
             >>> with open('/tmp/foobar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
@@ -1475,6 +1484,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             remote(str): The filename to upload it to.
 
         Example:
+
             >>> s =  ssh(host='example.pwnme')
             >>> s.upload_data(b'Hello, world', '/tmp/upload_foo')
             >>> print(open('/tmp/upload_foo').read())
@@ -1597,6 +1607,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         
 
         Examples:
+
             >>> with open('/tmp/foobar','w+') as f:
             ...     _ = f.write('Hello, world')
             >>> s =  ssh(host='example.pwnme',
@@ -1737,6 +1748,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 that all files in the "old" working directory should be symlinked.
 
         Examples:
+
             >>> s =  ssh(host='example.pwnme')
             >>> cwd = s.set_working_directory()
             >>> s.ls()

--- a/pwnlib/ui.py
+++ b/pwnlib/ui.py
@@ -9,7 +9,6 @@ import struct
 import subprocess
 import sys
 import time
-import types
 
 from pwnlib import term
 from pwnlib.log import getLogger
@@ -61,6 +60,7 @@ def yesno(prompt, default=None):
       `True` if the answer was "yes", `False` if "no"
 
     Examples:
+
         >>> yesno("A number:", 20)
         Traceback (most recent call last):
         ...
@@ -79,6 +79,7 @@ def yesno(prompt, default=None):
          [?] is it good 3 [yes/No] False
 
     Tests:
+
         >>> p = testpwnproc("print(yesno('is it ok??'))")
         >>> b"is it ok" in p.recvuntil(b"??")
         True
@@ -140,12 +141,14 @@ def options(prompt, opts, default = None):
       The users choice in the form of an integer.
 
     Examples:
+
         >>> options("Select a color", ("red", "green", "blue"), "green")
         Traceback (most recent call last):
         ...
         ValueError: options(): default must be a number or None
 
     Tests:
+
         >>> p = testpwnproc("print(options('select a color', ('red', 'green', 'blue')))")
         >>> p.sendline(b"\33[C\33[A\33[A\33[B\33[1;5A\33[1;5B 0310")
         >>> _ = p.recvall()
@@ -256,6 +259,7 @@ def pause(n=None):
     r"""Waits for either user input or a specific number of seconds.
 
     Examples:
+
         >>> with context.local(log_level="INFO"):
         ...     pause(1)
         [x] Waiting
@@ -267,6 +271,7 @@ def pause(n=None):
         ValueError: pause(): n must be a number or None
 
     Tests:
+
         >>> saved_stdin = sys.stdin
         >>> try:
         ...     sys.stdin = io.TextIOWrapper(io.BytesIO(b"\n"))
@@ -311,7 +316,8 @@ def more(text):
     Returns:
       :const:`None`
 
-    Tests:       
+    Tests:      
+ 
         >>> more("text")
         text
         >>> p = testpwnproc("more('text\\n' * (term.height + 2))")

--- a/pwnlib/useragents.py
+++ b/pwnlib/useragents.py
@@ -34,6 +34,7 @@ def getall():
         A set of user agent strings.
 
     Examples:
+
         >>> 'libcurl-agent/1.0' in getall()
         True
         >>> 'wget' in getall()

--- a/pwnlib/util/crc/__init__.py
+++ b/pwnlib/util/crc/__init__.py
@@ -12,6 +12,7 @@ the crc32-sum of ``'A'*40000``.
 An obvious optimization would be to actually generate some lookup-tables.
 
 This doctest is to ensure that the known data are accurate:
+
     >>> known = sys.modules['pwnlib.util.crc.known']
     >>> known.all_crcs == known.generate()
     True
@@ -338,6 +339,7 @@ class Module(types.ModuleType):
             data(str): The data to checksum.
 
         Example:
+
             >>> print(%s(b'123456789'))
             %d
     """ % (name, name, polynom, width, init, refin, refout, xorout, extra_doc, name, check)
@@ -354,6 +356,7 @@ class Module(types.ModuleType):
             data(str): The data to checksum.
 
         Example:
+
             >>> print(cksum(b'123456789'))
             930766865
         """
@@ -371,6 +374,7 @@ class Module(types.ModuleType):
             data(str): Data for which the checksum is known.
 
         Example:
+
             >>> find_crc_function(b'test', 46197)
             [<function crc_crc_16_dnp at ...>]
         """

--- a/pwnlib/util/cyclic.py
+++ b/pwnlib/util/cyclic.py
@@ -298,6 +298,7 @@ def cyclic_metasploit(length = None, sets = None):
         sets: List of strings to generate the sequence over.
 
     Example:
+
         >>> cyclic_metasploit(32)
         b'Aa0Aa1Aa2Aa3Aa4Aa5Aa6Aa7Aa8Aa9Ab'
         >>> cyclic_metasploit(sets = [b"AB",b"ab",b"12"])

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -193,6 +193,7 @@ def unbits(s, endian = 'big'):
        A string of the decoded bits.
 
     Example:
+
        >>> unbits([1])
        b'\\x80'
        >>> unbits([1], endian = 'little')
@@ -233,6 +234,7 @@ def bitswap(s):
     Reverses the bits in every byte of a given string.
 
     Example:
+
         >>> bitswap(b"1234")
         b'\\x8cL\\xcc,'
     """
@@ -254,6 +256,7 @@ def bitswap_int(n, width):
         width (int): The width of the integer
 
     Examples:
+
         >>> hex(bitswap_int(0x1234, 8))
         '0x2c'
         >>> hex(bitswap_int(0x1234, 16))

--- a/pwnlib/util/iters.py
+++ b/pwnlib/util/iters.py
@@ -84,6 +84,7 @@ def take(n, iterable):
       `n` elements in `iterable` they will all be returned.
 
     Examples:
+
       >>> take(2, range(10))
       [0, 1]
       >>> i = count()
@@ -107,6 +108,7 @@ def tabulate(func, start = 0):
       An iterator with the elements ``func(start), func(start + 1), ...``.
 
     Examples:
+
       >>> take(2, tabulate(str))
       ['0', '1']
       >>> take(5, tabulate(lambda x: x**2, start = 1))
@@ -128,6 +130,7 @@ def consume(n, iterator):
       :const:`None`.
 
     Examples:
+
       >>> i = count()
       >>> consume(5, i)
       >>> next(i)
@@ -168,6 +171,7 @@ def nth(n, iterable, default = None):
       few elements.
 
     Examples:
+
       >>> nth(2, [0, 1, 2, 3])
       2
       >>> nth(2, [0, 1], 42)
@@ -195,6 +199,7 @@ def quantify(iterable, pred = bool):
       :const:`True`.
 
     Examples:
+
       >>> quantify([1, 2, 3, 4], lambda x: x % 2 == 0)
       2
       >>> quantify(['1', 'two', '3', '42'], str.isdigit)
@@ -217,6 +222,7 @@ def pad(iterable, value = None):
       `value` indefinitely.
 
     Examples:
+
       >>> take(3, pad([1, 2]))
       [1, 2, None]
       >>> i = pad(iter([1, 2, 3]), 42)
@@ -243,6 +249,7 @@ def cyclen(n, iterable):
       times.
 
     Examples:
+
       >>> take(4, cyclen(2, [1, 2]))
       [1, 2, 1, 2]
       >>> list(cyclen(10, []))
@@ -263,6 +270,7 @@ def dotproduct(x, y):
       The dot product of `x` and `y`, i.e.: ``x[0] * y[0] + x[1] * y[1] + ...``.
 
     Example:
+
       >>> dotproduct([1, 2, 3], [4, 5, 6])
       ... # 1 * 4 + 2 * 5 + 3 * 6 == 32
       32
@@ -284,6 +292,7 @@ def flatten(xss):
       `xss`.
 
     Examples:
+
       >>> list(flatten([[1, 2], [3, 4]]))
       [1, 2, 3, 4]
       >>> take(6, flatten([[43, 42], [41, 40], count()]))
@@ -309,6 +318,7 @@ def repeat_func(func, *args, **kwargs):
       **kwargs)`` repeatedly.
 
     Examples:
+
       >>> def f(x):
       ...     x[0] += 1
       ...     return x[0]
@@ -346,6 +356,7 @@ def pairwise(iterable):
       `iterable`.
 
     Examples:
+
       >>> list(pairwise([1, 2, 3, 4]))
       [(1, 2), (2, 3), (3, 4)]
       >>> i = starmap(operator.add, pairwise(count()))
@@ -372,6 +383,7 @@ def group(n, iterable, fill_value = None):
       An iterator whoose elements are `n`-tuples of the elements of `iterable`.
 
     Examples:
+
       >>> list(group(2, range(5)))
       [(0, 1), (2, 3), (4, None)]
       >>> take(3, group(2, count()))
@@ -395,6 +407,7 @@ def roundrobin(*iterables):
       fashion.
 
     Examples:
+
       >>> ''.join(roundrobin('ABC', 'D', 'EF'))
       'ADEBFC'
       >>> ''.join(take(10, roundrobin('ABC', 'DE', repeat('x'))))
@@ -424,6 +437,7 @@ def powerset(iterable, include_empty = True):
       The powerset of `iterable` as an interator of tuples.
 
     Examples:
+
       >>> list(powerset(range(3)))
       [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]
       >>> list(powerset(range(2), include_empty = False))
@@ -452,6 +466,7 @@ def unique_everseen(iterable, key = None):
       An iterator of the unique elements in `iterable`.
 
     Examples:
+
       >>> ''.join(unique_everseen('AAAABBBCCDAABBB'))
       'ABCD'
       >>> ''.join(unique_everseen('ABBCcAD', str.lower))
@@ -487,6 +502,7 @@ def unique_justseen(iterable, key = None):
       An iterator of the unique elements in `iterable`.
 
     Examples:
+
       >>> ''.join(unique_justseen('AAAABBBCCDAABBB'))
       'ABCDAB'
       >>> ''.join(unique_justseen('ABBCcAD', str.lower))
@@ -512,6 +528,7 @@ def unique_window(iterable, window, key = None):
       An iterator of the unique elements in `iterable`.
 
     Examples:
+
       >>> ''.join(unique_window('AAAABBBCCDAABBB', 6))
       'ABCDA'
       >>> ''.join(unique_window('ABBCcAD', 5, str.lower))
@@ -550,6 +567,7 @@ def iter_except(func, exception):
       exception matching `exception` is raised.
 
     Examples:
+
       >>> s = {1, 2, 3}
       >>> i = iter_except(s.pop, KeyError)
       >>> next(i)
@@ -580,6 +598,7 @@ def random_product(*args, **kwargs):
       A random element from ``itertools.product(*args, repeat = repeat)``.
 
     Examples:
+
       >>> args = (range(2), range(2))
       >>> random_product(*args) in {(0, 0), (0, 1), (1, 0), (1, 1)}
       True
@@ -607,6 +626,7 @@ def random_permutation(iterable, r = None):
       A random element from ``itertools.permutations(iterable, r = r)``.
 
     Examples:
+
       >>> random_permutation(range(2)) in {(0, 1), (1, 0)}
       True
       >>> random_permutation(range(10), r = 2) in permutations(range(10), r = 2)
@@ -627,6 +647,7 @@ def random_combination(iterable, r):
       A random element from ``itertools.combinations(iterable, r = r)``.
 
     Examples:
+
       >>> random_combination(range(2), 2)
       (0, 1)
       >>> random_combination(range(10), r = 2) in combinations(range(10), r = 2)
@@ -649,6 +670,7 @@ def random_combination_with_replacement(iterable, r):
       r = r)``.
 
     Examples:
+
       >>> cs = {(0, 0), (0, 1), (1, 1)}
       >>> random_combination_with_replacement(range(2), 2) in cs
       True
@@ -675,6 +697,7 @@ def lookahead(n, iterable):
       The element in `iterable` at index `n`.
 
     Examples:
+
       >>> i = count()
       >>> lookahead(4, i)
       4
@@ -706,6 +729,7 @@ def lexicographic(alphabet):
       order.
 
     Example:
+
       >>> take(8, map(lambda x: ''.join(x), lexicographic('01')))
       ['', '0', '1', '00', '01', '10', '11', '000']
     """
@@ -726,6 +750,7 @@ def chained(func):
       values from ``func(*args, **kwargs)``.
 
     Example:
+
       >>> @chained
       ... def g():
       ...     for x in count():
@@ -771,6 +796,7 @@ def bruteforce(func, alphabet, length, method = 'upto', start = None, databag = 
       if the search space was exhausted.
 
     Example:
+
       >>> bruteforce(lambda x: x == 'yes', string.ascii_lowercase, length=5)
       'yes'
     """
@@ -861,6 +887,7 @@ def mbruteforce(func, alphabet, length, method = 'upto', start = None, threads =
       threads: Amount of threads to spawn, default is the amount of cores.
 
     Example:
+
       >>> mbruteforce(lambda x: x == 'hello', string.ascii_lowercase, length = 10)
       'hello'
       >>> mbruteforce(lambda x: x == 'hello', 'hlo', 5, 'downfrom') is None

--- a/pwnlib/util/lists.py
+++ b/pwnlib/util/lists.py
@@ -22,6 +22,7 @@ def partition(lst, f, save_keys = False):
                        returned instead of just the values
 
     Example:
+
       >>> partition([1,2,3,4,5], lambda x: x&1)
       [[1, 3, 5], [2, 4]]
       >>> partition([1,2,3,4,5], lambda x: x%3, save_keys=True)
@@ -55,6 +56,7 @@ def group(n, lst, underfull_action = 'ignore', fill_value = None):
       A list containing the grouped values.
 
     Example:
+
       >>> group(3, "ABCDEFG")
       ['ABC', 'DEF', 'G']
       >>> group(3, 'ABCDEFG', 'drop')
@@ -119,6 +121,7 @@ def concat_all(*args):
     Concats all the arguments together.
 
     Example:
+
        >>> concat_all(0, [1, (2, 3)], [([[4, 5, 6]])])
        [0, 1, 2, 3, 4, 5, 6]
     """
@@ -139,6 +142,7 @@ def ordlist(s):
     Turns a string into a list of the corresponding ascii values.
 
     Example:
+
       >>> ordlist("hello")
       [104, 101, 108, 108, 111]
     """
@@ -150,6 +154,7 @@ def unordlist(cs):
     Takes a list of ascii values and returns the corresponding string.
 
     Example:
+
       >>> unordlist([104, 101, 108, 108, 111])
       'hello'
     """
@@ -162,6 +167,7 @@ def findall(haystack, needle):
     Knuth-Morris-Pratt algorithm.
 
     Example:
+
       >>> foo = findall([1,2,3,4,4,3,4,2,1], 4)
       >>> next(foo)
       3

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -30,6 +30,7 @@ def align(alignment, x):
     Rounds `x` up to nearest multiple of the `alignment`.
 
     Example:
+
       >>> [align(5, n) for n in range(15)]
       [0, 5, 5, 5, 5, 5, 10, 10, 10, 10, 10, 15, 15, 15, 15]
     """
@@ -42,6 +43,7 @@ def align_down(alignment, x):
     Rounds `x` down to nearest multiple of the `alignment`.
 
     Example:
+
         >>> [align_down(5, n) for n in range(15)]
         [0, 0, 0, 0, 0, 5, 5, 5, 5, 5, 10, 10, 10, 10, 10]
     """
@@ -54,6 +56,7 @@ def binary_ip(host):
     Resolve host and return IP as four byte string.
 
     Example:
+
         >>> binary_ip("127.0.0.1")
         b'\\x7f\\x00\\x00\\x01'
     """
@@ -71,6 +74,7 @@ def size(n, abbrev = 'B', si = False):
       abbrev(str): String appended to the size, defaults to ``'B'``.
 
     Example:
+
         >>> size(451)
         '451B'
         >>> size(1000)
@@ -116,6 +120,7 @@ def read(path, count=-1, skip=0):
     Open file, return content.
 
     Examples:
+
         >>> read('/proc/self/exe')[:4]
         b'\x7fELF'
     """
@@ -481,6 +486,7 @@ def parse_ldd_output(output):
       output(str): The output to parse
 
     Example:
+
         >>> sorted(parse_ldd_output('''
         ...     linux-vdso.so.1 =>  (0x00007fffbf5fe000)
         ...     libtinfo.so.5 => /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007fe28117f000)
@@ -545,6 +551,7 @@ def register_sizes(regs, in_sizes):
     Used in i386/AMD64 shellcode, e.g. the mov-shellcode.
 
     Example:
+
         >>> regs = [['eax', 'ax', 'al', 'ah'],['ebx', 'bx', 'bl', 'bh'],
         ... ['ecx', 'cx', 'cl', 'ch'],
         ... ['edx', 'dx', 'dl', 'dh'],

--- a/pwnlib/util/net.py
+++ b/pwnlib/util/net.py
@@ -166,6 +166,7 @@ def interfaces4(all = False):
       IPv4 addresses.
 
     Examples:
+
         >>> interfaces4(all=True) # doctest: +ELLIPSIS
         {...'127.0.0.1'...}
     """
@@ -191,6 +192,7 @@ def interfaces6(all = False):
       IPv6 addresses.
 
     Examples:
+
         >>> interfaces6() # doctest: +ELLIPSIS
         {...'::1'...}
     """

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -76,6 +76,7 @@ def pack(number, word_size = None, endianness = None, sign = None, **kwargs):
         The packed number as a string.
 
     Examples:
+
         >>> pack(0x414243, 24, 'big', True)
         b'ABC'
         >>> pack(0x414243, 24, 'little', True)
@@ -189,6 +190,7 @@ def unpack(data, word_size = None):
         The unpacked number.
 
     Examples:
+
         >>> hex(unpack(b'\xaa\x55', 16, endian='little', sign=False))
         '0x55aa'
         >>> hex(unpack(b'\xaa\x55', 16, endian='big', sign=False))
@@ -256,6 +258,7 @@ def unpack_many(data, word_size = None):
         The unpacked numbers.
 
     Examples:
+
         >>> list(map(hex, unpack_many(b'\\xaa\\x55\\xcc\\x33', 16, endian='little', sign=False)))
         ['0x55aa', '0x33cc']
         >>> list(map(hex, unpack_many(b'\\xaa\\x55\\xcc\\x33', 16, endian='big', sign=False)))
@@ -510,6 +513,7 @@ def make_packer(word_size = None, sign = None, **kwargs):
         of that number in a packed form.
 
     Examples:
+
         >>> p = make_packer(32, endian='little', sign='unsigned')
         >>> p
         <function _p32lu at 0x...>
@@ -573,6 +577,7 @@ def make_unpacker(word_size = None, endianness = None, sign = None, **kwargs):
         of that string in an unpacked form.
 
     Examples:
+
         >>> u = make_unpacker(32, endian='little', sign='unsigned')
         >>> u
         <function _u32lu at 0x...>
@@ -978,6 +983,7 @@ def dd(dst, src, count = 0, skip = 0, seek = 0, truncate = False):
         modified in-place.
 
     Examples:
+
         >>> dd(tuple('Hello!'), b'?', skip = 5)
         ('H', 'e', 'l', 'l', 'o', b'?')
         >>> dd(list('Hello!'), (63,), skip = 5)

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -34,6 +34,7 @@ def pidof(target):
         A list of found PIDs.
 
     Example:
+
         >>> l = tubes.listen.listen()
         >>> p = process(['curl', '-s', 'http://127.0.0.1:%d'%l.lport])
         >>> pidof(p) == pidof(l) == pidof(('127.0.0.1', l.lport))
@@ -68,6 +69,7 @@ def pid_by_name(name):
         List of PIDs matching `name` sorted by lifetime, youngest to oldest.
 
     Example:
+
         >>> os.getpid() in pid_by_name(name(os.getpid()))
         True
     """
@@ -99,6 +101,7 @@ def name(pid):
         Name of process as listed in ``/proc/<pid>/status``.
 
     Example:
+
         >>> p = process('cat')
         >>> name(p.pid)
         'cat'
@@ -141,6 +144,7 @@ def ancestors(pid):
         List of PIDs of whose parent process is `pid` or an ancestor of `pid`.
 
     Example:
+
         >>> ancestors(os.getpid()) # doctest: +ELLIPSIS
         [..., 1]
     """
@@ -160,6 +164,7 @@ def descendants(pid):
         Dictionary mapping the PID of each child of `pid` to it's descendants.
 
     Example:
+
         >>> d = descendants(os.getppid())
         >>> os.getpid() in d.keys()
         True
@@ -187,6 +192,7 @@ def exe(pid):
         The path of the binary of the process. I.e. what ``/proc/<pid>/exe`` points to.
 
     Example:
+
         >>> exe(os.getpid()) == os.path.realpath(sys.executable)
         True
     """
@@ -203,6 +209,7 @@ def cwd(pid):
         ``/proc/<pid>/cwd`` points to.
 
     Example:
+
         >>> cwd(os.getpid()) == os.getcwd()
         True
     """
@@ -218,6 +225,7 @@ def cmdline(pid):
         A list of the fields in ``/proc/<pid>/cmdline``.
 
     Example:
+
         >>> 'py' in ''.join(cmdline(os.getpid()))
         True
     """
@@ -233,6 +241,7 @@ def memory_maps(pid):
         A list of the memory mappings in the process.
 
     Example:
+
         >>> maps = memory_maps(os.getpid())
         >>> [(m.path, m.perms) for m in maps if '[stack]' in m.path]
         [('[stack]', 'rw-p')]
@@ -250,6 +259,7 @@ def stat(pid):
         A list of the values in ``/proc/<pid>/stat``, with the exception that ``(`` and ``)`` has been removed from around the process name.
 
     Example:
+
         >>> stat(os.getpid())[2]
         'R'
     """
@@ -271,6 +281,7 @@ def starttime(pid):
         The time (in seconds) the process started after system boot
 
     Example:
+
         >>> starttime(os.getppid()) <= starttime(os.getpid())
         True
     """
@@ -314,6 +325,7 @@ def tracer(pid):
         PID of the process tracing `pid`, or None if no `pid` is not being traced.
 
     Example:
+
         >>> tracer(os.getpid()) is None
         True
     """
@@ -330,6 +342,7 @@ def state(pid):
         State of the process as listed in ``/proc/<pid>/status``.  See `proc(5)` for details.
 
     Example:
+
         >>> state(os.getpid())
         'R (running)'
     """


### PR DESCRIPTION
We weren't running a lot of the doctests due to them having text on the previous line. This was noticed due to tests added in #2233 having a typo but not failing (`executable` vs. `exe` argument).

It appears
```
Example:
>>> some code
```

is not run but

```
Example:

>>> some code
```
is.

There were multiple occasions throughout the code base which I've grepped for.

The GDB API doctests were never run due to the `.. doctest` directive trying to only run them on Python 3 having a typo. It should read [`.. doctest::`](https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html#directive-doctest). This revealed a problem with rpyc not being available in gdb's python environment which can be fixed by unsetting the `LD_LIBRARY_PATH` environment variable set by the setup-python Github Action 😄 