### PR TITLE
feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/extra/docker/base/Dockerfile
+++ b/extra/docker/base/Dockerfile
@@ -40,10 +40,10 @@ RUN apt-get update \
         patchelf \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
-    && PYTHONPATH=`echo /usr/share/python-wheels/pip-*.whl` python2.7 -m pip install --upgrade pip setuptools wheel \
-    && python2.7 -m pip install --upgrade pwntools \
-    && python3 -m pip install --upgrade pip \
-    && python3 -m pip install --upgrade pwntools \
+    && PYTHONPATH=`echo /usr/share/python-wheels/pip-*.whl` python2.7 -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && python2.7 -m pip install --no-cache-dir --upgrade pwntools \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade pwntools \
     && PWNLIB_NOTERM=1 pwn update \
     && useradd -m pwntools \
     && passwd --delete --unlock pwntools \

--- a/extra/docker/beta/Dockerfile
+++ b/extra/docker/beta/Dockerfile
@@ -1,7 +1,7 @@
 FROM pwntools/pwntools:stable
 
 USER root
-RUN python2.7 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@beta \
-    && python3 -m pip install --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@beta
+RUN python2.7 -m pip install --no-cache-dir --upgrade git+https://github.com/Gallopsled/pwntools@beta \
+    && python3 -m pip install --no-cache-dir --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@beta
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/extra/docker/buster/Dockerfile
+++ b/extra/docker/buster/Dockerfile
@@ -5,4 +5,4 @@ RUN apt-get -y dist-upgrade
 RUN apt-get -y install python3 python3-pip
 RUN apt-get -y install git wget unzip
 
-RUN pip3 install --upgrade git+https://github.com/Gallopsled/pwntools@dev
+RUN pip3 install --no-cache-dir --upgrade git+https://github.com/Gallopsled/pwntools@dev

--- a/extra/docker/stable/Dockerfile
+++ b/extra/docker/stable/Dockerfile
@@ -1,7 +1,7 @@
 FROM pwntools/pwntools:base
 
 USER root
-RUN python2.7 -m pip install --upgrade git+https://github.com/Gallopsled/pwntools@stable \
-    && python3 -m pip install --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@stable
+RUN python2.7 -m pip install --no-cache-dir --upgrade git+https://github.com/Gallopsled/pwntools@stable \
+    && python3 -m pip install --no-cache-dir --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@stable
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/travis/docker/Dockerfile
+++ b/travis/docker/Dockerfile
@@ -18,17 +18,17 @@ ENV PATH="/home/pwntools/.local/bin:${PATH}"
 
 # Install Pwntools to the home directory, make it an editable install
 RUN git clone https://github.com/Gallopsled/pwntools \
- && python2.7 -m pip install --upgrade --editable pwntools \
- && python3 -m pip install --upgrade --editable pwntools \
+ && python2.7 -m pip install --no-cache-dir --upgrade --editable pwntools \
+ && python3 -m pip install --no-cache-dir --upgrade --editable pwntools \
  && PWNLIB_NOTERM=1 pwn version
 
 # Requirements for running the tests
-RUN python2.7 -m pip install --upgrade --requirement pwntools/docs/requirements.txt \
-    && python3 -m pip install --upgrade --requirement pwntools/docs/requirements.txt
+RUN python2.7 -m pip install --no-cache-dir --upgrade --requirement pwntools/docs/requirements.txt \
+    && python3 -m pip install --no-cache-dir --upgrade --requirement pwntools/docs/requirements.txt
 
 # Python niceties for debugging
-RUN python2.7 -m pip install -U ipython ipdb \
-    && python3 -m pip install -U ipython ipdb
+RUN python2.7 -m pip install --no-cache-dir -U ipython ipdb \
+    && python3 -m pip install --no-cache-dir -U ipython ipdb
 
 # Dependencies from .travis.yml addons -> apt -> packages
 ARG DEBIAN_FRONTEND=noninteractive
@@ -86,8 +86,8 @@ ADD ipython_config.py  /home/pwntools/.ipython/profile_default
 RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/travis
 
 # Some additional debugging tools that are useful
-RUN python2.7 -m pip install ipdb && \
-    python3 -m pip install ipdb
+RUN python2.7 -m pip install --no-cache-dir ipdb && \
+    python3 -m pip install --no-cache-dir ipdb
 
 # Install debugging utilities
 USER root

--- a/travis/docker/Dockerfile.travis
+++ b/travis/docker/Dockerfile.travis
@@ -1,7 +1,7 @@
 
 # Some additional debugging tools that are useful
-RUN python2.7 -m pip install ipdb && \
-    python3 -m pip install ipdb
+RUN python2.7 -m pip install --no-cache-dir ipdb && \
+    python3 -m pip install --no-cache-dir ipdb
 
 # Install debugging utilities
 USER root


### PR DESCRIPTION
using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>