### PR TITLE
fix: x-terminal does not work properly gdb.attach

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -460,6 +460,8 @@ end tell
         with subprocess.Popen((qdbus, konsole_dbus_service, '/Sessions/{}'.format(last_konsole_session),
                                'org.kde.konsole.Session.processId'), stdout=subprocess.PIPE) as proc:
             pid = int(proc.communicate()[0].decode())
+    elif terminal == 'x-terminal-emulator':
+        pid = p.pid + 1
     else:
         pid = p.pid
 


### PR DESCRIPTION
## env
```bash
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.6 LTS
Release:	20.04
Codename:	focal
```
```
python --version                                                                                                                                                      130 ↵
Python 3.8.10
```
When I tried to use attach in x-terminal, I found that I could not attach normally. After attaching, it always ran the script directly. Through tracing, I found that run_in_new_terminal returned the wrong gdb_pid.
```c
//gcc test.c -o 1
#include <stdio.h>
int main(){
    puts("hello world");
    char buf[0x20] = {0};
    read(0,buf,0x20);
    puts("hello world");
    read(0,buf,0x20);
}
```
test.py
```python
from pwn import*
context.log_level = "debug"
# context.terminal = ["tmux","split","-h"]
p = process('./1')
p.send("bbbb")
attach(p)
p.send("aaaa")
p.interactive()
```
![image](https://github.com/Gallopsled/pwntools/assets/60732685/94ab9f89-949d-47b9-b870-b406ca1b4a1a)



