### PR TITLE
Fix displaying bright color variation in terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,11 @@ The table below shows which release corresponds to each branch, and what date th
 [2347]: https://github.com/Gallopsled/pwntools/pull/2347
 [2233]: https://github.com/Gallopsled/pwntools/pull/2233
 
+## 4.12.1
+- [#2373][2373] Fix displaying bright color variation in terminal output
+
+[2373]: https://github.com/Gallopsled/pwntools/pull/2373
+
 ## 4.12.0 (`stable`)
 
 - [#2202][2202] Fix `remote` and `listen` in sagemath

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -28,8 +28,6 @@ class Module(types.ModuleType):
         self.__file__ = __file__
         self.__name__ = __name__
         self.num_colors = 8
-        self.has_bright = self.num_colors >= 16
-        self.has_gray = self.has_bright
         self.when = 'auto'
         self._colors = {
             'black': 0,
@@ -60,6 +58,14 @@ class Module(types.ModuleType):
     @when.setter
     def when(self, val):
         self._when = eval_when(val)
+
+    @property
+    def has_bright(self):
+        return self.num_colors >= 16
+    
+    @property
+    def has_gray(self):
+        return self.has_bright
 
     def _fg_color(self, c):
         c = termcap.get('setaf', c) or termcap.get('setf', c)

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -27,7 +27,7 @@ class Module(types.ModuleType):
     def __init__(self):
         self.__file__ = __file__
         self.__name__ = __name__
-        self.num_colors = 8
+        self.num_colors = termcap.get('colors') if sys.platform == 'win32' else 8
         self.when = 'auto'
         self._colors = {
             'black': 0,

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -27,7 +27,7 @@ class Module(types.ModuleType):
     def __init__(self):
         self.__file__ = __file__
         self.__name__ = __name__
-        self.num_colors = termcap.get('colors') if sys.platform == 'win32' else 8
+        self.num_colors = termcap.get('colors', 8) if sys.platform == 'win32' else 8
         self.when = 'auto'
         self._colors = {
             'black': 0,


### PR DESCRIPTION
The number of simultaneous colors in the current terminal are queried later during initialization and the text.num_colors attribute is updated accordingly. The text.has_bright attribute wasn't updated when that happened and always remained set to False. Calculate those properties based on num_colors dynamically.

https://github.com/Gallopsled/pwntools/blob/a2acdf9bd9161d4102454d999182fba3417372fe/pwnlib/term/__init__.py#L89