### PR TITLE
libcdb.unstrip_libc: debug symbols are fetched only if not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,10 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.14.0 (`dev`)
 
 - [#2356][2356] Add local libc database provider for libcdb
+- [#2374][2374] libcdb.unstrip_libc: debug symbols are fetched only if not present
 
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356
+[2374]: https://github.com/Gallopsled/pwntools/pull/2374
 
 ## 4.13.0 (`beta`)
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -291,6 +291,10 @@ def unstrip_libc(filename):
         log.warn_once('Given libc does not have a buildid. Cannot look for debuginfo to unstrip.')
         return False
 
+    if libc.debuginfo:
+        log.debug('Given libc already contains debug information. Skipping unstrip.')
+        return True
+
     log.debug('Trying debuginfod servers: %r', DEBUGINFOD_SERVERS)
 
     for server_url in DEBUGINFOD_SERVERS:


### PR DESCRIPTION
`ELF.debuginfo` was used to check if debug symbols exist in libc before downloading them in the function `libcdb.unstrip_libc`

closes #2324