### PR TITLE
Don't go through a shell in `gdb.debug`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The table below shows which release corresponds to each branch, and what date th
 | ---------------- | -------- | ---------------------- |
 | [4.14.0](#4140-dev)  | `dev`   |
 | [4.13.0](#4130-beta)  | `beta`    |
+| [4.12.1](#4121)  |          |
 | [4.12.0](#4120-stable)  | `stable`   | Feb 22, 2024
 | [4.11.1](#4111)  |          | Nov 14, 2023
 | [4.11.0](#4110)  |          | Sep 15, 2023
@@ -128,6 +129,12 @@ The table below shows which release corresponds to each branch, and what date th
 [2268]: https://github.com/Gallopsled/pwntools/pull/2268
 [2347]: https://github.com/Gallopsled/pwntools/pull/2347
 [2233]: https://github.com/Gallopsled/pwntools/pull/2233
+
+## 4.12.1
+
+- [#2378][2378] Don't go though a shell in `gdb.debug`
+
+[2378]: https://github.com/Gallopsled/pwntools/pull/2378
 
 ## 4.12.0 (`stable`)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -287,7 +287,9 @@ def _gdbserver_args(pid=None, path=None, args=None, which=None, env=None):
 
     orig_args = args
 
-    gdbserver_args = [gdbserver, '--multi']
+    # --no-startup-with-shell is required for forking shells like SHELL=/bin/fish
+    # https://github.com/Gallopsled/pwntools/issues/2377
+    gdbserver_args = [gdbserver, '--multi', '--no-startup-with-shell']
     if context.aslr:
         gdbserver_args += ['--no-disable-randomization']
     else:


### PR DESCRIPTION
gdbserver starts a shell and runs the target process through it. This behavior was added in gdbserver 8.0 in 2017 together with the commandline flag `--no-startup-with-shell` to disable it. Some shells can be configured to start the target command in a new process instead of replacing itself with it using execve, which [confuses gdbserver's signal handling](https://sourceware.org/bugzilla/show_bug.cgi?id=26116).

Fixes #2377 