### PR TITLE
Add `port`, `gdb_args`, and `gdbserver_args` to gdb.debug()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.14.0 (`dev`)
 
-- [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
 - [#2360][2360] Add offline parameter for `search_by_hash` series function
 - [#2356][2356] Add local libc database provider for libcdb
 - [#2374][2374] libcdb.unstrip_libc: debug symbols are fetched only if not present
@@ -83,6 +82,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2391][2391] Fix error message when passing invalid kwargs to `xor`
 - [#2376][2376] Return buffered data on first EOF in tube.readline()
 - [#2387][2387] Convert apport_corefile() output from bytes-like object to string
+- [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
 
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356
@@ -94,6 +94,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2391]: https://github.com/Gallopsled/pwntools/pull/2391
 [2376]: https://github.com/Gallopsled/pwntools/pull/2376
 [2387]: https://github.com/Gallopsled/pwntools/pull/2387
+[2382]: https://github.com/Gallopsled/pwntools/pull/2382
 
 ## 4.13.0 (`beta`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.14.0 (`dev`)
 
-- [#2382][2382] added optional port and gdb_args parameters to gdb.debug()
+- [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
 - [#2360][2360] Add offline parameter for `search_by_hash` series function
 - [#2356][2356] Add local libc database provider for libcdb
 - [#2374][2374] libcdb.unstrip_libc: debug symbols are fetched only if not present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.14.0 (`dev`)
 
+- [#2382][2382] added optional port and gdb_args parameters to gdb.debug()
 - [#2360][2360] Add offline parameter for `search_by_hash` series function
 - [#2356][2356] Add local libc database provider for libcdb
 - [#2374][2374] libcdb.unstrip_libc: debug symbols are fetched only if not present

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -348,7 +348,7 @@ def _gdbserver_args(pid=None, path=None, port=0, args=None, which=None, env=None
     elif env is not None:
         gdbserver_args += ['--wrapper', which('env'), '-i'] + env_args + ['--']
 
-    gdbserver_args += [f'localhost:{port}']
+    gdbserver_args += ['localhost:%d' % port]
     gdbserver_args += args
 
     return gdbserver_args


### PR DESCRIPTION
added two arguments to gdb.debug()
+ port: specifies the port that should be used by the gdbserver, this is useful for alpine, because alpine doesn't support the default openssh port forwarding feature, due to a minimalistic version of openssh
+ gdb_args: allows forwarding arguments to the gdb binary spawned by gdb.attach() (just a passthrough)

also downgraded "GDB Python API is supported only for local processes" to a warning, because it seems to work.

These changes are made for compatibility with my pwntools "plugin" [vagd](https://github.com/gfelber/vagd) which currently uses a workaround on [Pwngd.debug()](https://github.com/gfelber/vagd/blob/67dcdfc08e04144ecf4abf7a661793e627e041b3/src/vagd/virts/pwngd.py#L204) (basically the same behaviour as the patch)

