### PR TITLE
Updated Mac OS Install Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,6 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2327][2327] Add basic support to debug processes on Windows
 - [#2322][2322] Add basic RISCV64 shellcraft support
 - [#2330][2330] Change `context.newline` when setting `context.os` to `"windows"`
-- [#2392][2392] Updated Mac OS install documentation
 
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356
@@ -85,7 +84,6 @@ The table below shows which release corresponds to each branch, and what date th
 [2327]: https://github.com/Gallopsled/pwntools/pull/2327
 [2322]: https://github.com/Gallopsled/pwntools/pull/2322
 [2330]: https://github.com/Gallopsled/pwntools/pull/2330
-[2392]: https://github.com/Gallopsled/pwntools/pull/2392
 
 ## 4.13.0 (`beta`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2327][2327] Add basic support to debug processes on Windows
 - [#2322][2322] Add basic RISCV64 shellcraft support
 - [#2330][2330] Change `context.newline` when setting `context.os` to `"windows"`
+- [#2392][2392] Updated Mac OS install documentation
 
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356
@@ -84,6 +85,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2327]: https://github.com/Gallopsled/pwntools/pull/2327
 [2322]: https://github.com/Gallopsled/pwntools/pull/2322
 [2330]: https://github.com/Gallopsled/pwntools/pull/2330
+[2392]: https://github.com/Gallopsled/pwntools/pull/2392
 
 ## 4.13.0 (`beta`)
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -15,6 +15,9 @@ following system libraries installed.
 
    install/*
 
+
+Note: For Mac OS X you will need to have cmake ``brew install cmake`` and pkg-config ``brew install pkg-config`` installed.
+
 Released Version
 -----------------
 

--- a/docs/source/install/binutils.rst
+++ b/docs/source/install/binutils.rst
@@ -32,14 +32,15 @@ Mac OS X
 ^^^^^^^^^^^^^^^^
 
 Mac OS X is just as easy, but requires building binutils from source.
-However, we've made ``homebrew`` recipes to make this a single command.
+However, we've made ``homebrew`` recipes to make this just two commands.
 After installing `brew <https://brew.sh>`__, grab the appropriate
 recipe from our `binutils
 repo <https://github.com/Gallopsled/pwntools-binutils/>`__.
 
 .. code-block:: bash
 
-    $ brew install https://raw.githubusercontent.com/Gallopsled/pwntools-binutils/master/macos/binutils-$ARCH.rb
+    $ wget https://raw.githubusercontent.com/Gallopsled/pwntools-binutils/master/macos/binutils-$ARCH.rb
+    $ brew install ./binutils-$ARCH.rb
 
 Alternate OSes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updated the documentation for installing Pwntools on Mac OS. 

Firstly, Homebrew no longer supports direct references for brew install "for security reasons". Simple enough fix, just wget the correct .rb and then install from file.

Second issue, there were two requirements missing that had to be installed before I could pip install Pwntools - cmake and pkg-config. I'm coming from a new/fresh set up MacBook Pro, which didn't have either of these installed and I can't see any mention of them in the documentation.