### PR TITLE
feat: multi shellcraft cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,11 +150,18 @@ jobs:
         pwn shellcraft --list |tail
         pwn shellcraft -l --syscalls |tail
         pwn shellcraft -l execve
+        pwn shellcraft -l execve + exit
         pwn shellcraft --show i386.linux.loader_append
+        pwn shellcraft --show i386.linux.loader_append + i386.linux.sh
         pwn shellcraft -f asm --color amd64.linux.sh
+        pwn shellcraft -f asm --color amd64.linux.setreuid + amd64.linux.cat /etc/passwd
+        pwn shellcraft -f asm --color amd64.linux.setreuid = amd64.linux.cat /key+secret --delim =
         pwn shellcraft -f elf amd64.linux.syscalls.exit 0 </dev/null |pwn hex
+        pwn shellcraft -f elf amd64.linux.cat /etc/passwd + amd64.linux.syscalls.exit 0 </dev/null |pwn hex
         pwn shellcraft -f i   --color amd64.linux.cat /etc/passwd </dev/null
+        pwn shellcraft -f i   --color amd64.linux.cat /etc/passwd + amd64.linux.sh </dev/null
         pwn shellcraft -f c   amd64.linux.syscalls.exit 0 </dev/null
+        pwn shellcraft -f c   amd64.linux.cat /etc/passwd + amd64.linux.syscalls.exit 0 </dev/null
         pwn shellcraft -f str aarch64.linux.sh </dev/null
         pwn shellcraft -abr -f elf -o /dev/null amd64.linux.cat /etc/passwd </dev/null
         pwn shellcraft -nzr thumb.linux.syscalls.execve /bin/cat '["/bin/cat", "/etc/os-release"]' </dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2389][2389] Fix passing bytes to `context.log_file` and `crc.BitPolynom`
 - [#2391][2391] Fix error message when passing invalid kwargs to `xor`
 - [#2376][2376] Return buffered data on first EOF in tube.readline()
+- [#2398][2398] Add support for generating multiple shellcodes at a time in shellcraft
 
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356
@@ -91,6 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2389]: https://github.com/Gallopsled/pwntools/pull/2389
 [2391]: https://github.com/Gallopsled/pwntools/pull/2391
 [2376]: https://github.com/Gallopsled/pwntools/pull/2376
+[2398]: https://github.com/Gallopsled/pwntools/pull/2398
 
 ## 4.13.0 (`beta`)
 

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -172,9 +172,9 @@ p.add_argument(
 
 def get_template(name, delim):
     funcs = []
-    func = shellcraft
     names = name.split(delim)
     for n in names:
+        func = shellcraft
         n = n.strip()
         shellcode_and_args = n.split(' ')
         cur_name = shellcode_and_args[0]
@@ -182,7 +182,8 @@ def get_template(name, delim):
         if len(shellcode_and_args) > 1:
             args = shellcode_and_args[1:]
         for attr in cur_name.split('.'):
-            funcs.append((cur_name, getattr(func, attr), args))
+            func = getattr(func, attr)
+        funcs.append((cur_name, func, args))
     return funcs
 
 def is_not_a_syscall_template(name):

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -172,7 +172,7 @@ p.add_argument(
 
 def get_template(name, delim):
     funcs = []
-    names = name.split(delim)
+    names = [n.strip() for n in name.split(delim)]
     for n in names:
         func = shellcraft
         n = n.strip()
@@ -224,14 +224,16 @@ def main(args):
         log.error("Unknown shellcraft template %r. Use --list to see available shellcodes." % args.shellcode)
 
     if args.show:
-        # remove doctests
-        doc = []
-        in_doctest = False
-        block_indent = None
-        caption = None
-        for (_name, func, _args) in funcs:
+        for (name, func, _args) in funcs:
+            # remove doctests
+            doc = []
+            in_doctest = False
+            block_indent = None
+            caption = None
             lines = func.__doc__.splitlines()
             i = 0
+            if len(funcs) > 1:
+                print('%s:' % name)
             while i < len(lines):
                 line = lines[i]
                 if line.lstrip().startswith('>>>'):
@@ -268,7 +270,9 @@ def main(args):
                     doc.append(line)
                 i += 1
             print('\n'.join(doc).rstrip())
-            exit()
+            if len(funcs) > 1:
+                print('')
+        exit()
 
     code_array = []
     for (name, func, func_args) in funcs:

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -205,10 +205,10 @@ def main(args):
             template_array = []
             for s in shellcodes:
                 shellcode = s.split(' ')
-                template_array.append(filter(lambda a: shellcode in a, templates))
+                template_array.extend(list(filter(lambda a: shellcode[0] in a, templates)))
             templates = template_array
         elif not args.syscalls:
-            templates = filter(is_not_a_syscall_template, templates)
+            templates = list(filter(is_not_a_syscall_template, templates))
 
         print('\n'.join(templates))
         exit()

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -71,17 +71,9 @@ p.add_argument(
 
 p.add_argument(
     'shellcode',
-    nargs = '?',
-    help = 'The shellcode you want',
-    type = str
-)
-
-p.add_argument(
-    'args',
     nargs = '*',
-    metavar = 'arg',
-    default = (),
-    help = 'Argument to the chosen shellcode',
+    help = 'The shellcodes you want.  shellcode [args ...] [+ shellcode [args ...]]',
+    type = str
 )
 
 p.add_argument(
@@ -89,6 +81,12 @@ p.add_argument(
     '--debug',
     help='Debug the shellcode with GDB',
     action='store_true'
+)
+
+p.add_argument(
+    '--delim',
+    help='Set the delimiter between multilple shellcodes',
+    default='+'
 )
 
 p.add_argument(
@@ -172,22 +170,43 @@ p.add_argument(
     help='Generated ELF is a shared library'
 )
 
-def get_template(name):
+def get_template(name, delim):
+    funcs = []
     func = shellcraft
-    for attr in name.split('.'):
-        func = getattr(func, attr)
-    return func
+    names = name.split(delim)
+    for n in names:
+        n = n.strip()
+        shellcode_and_args = n.split(' ')
+        cur_name = shellcode_and_args[0]
+        args = []
+        if len(shellcode_and_args) > 1:
+            args = shellcode_and_args[1:]
+        for attr in cur_name.split('.'):
+            funcs.append((cur_name, getattr(func, attr), args))
+    return funcs
 
 def is_not_a_syscall_template(name):
     template_src = shellcraft._get_source(name)
     return '/syscalls' not in template_src
 
 def main(args):
+    delim = '+'
+    if args.delim:
+        delim = args.delim.strip()
+
+    if args.shellcode:
+        args.shellcode = " ".join(args.shellcode)
+        shellcodes = args.shellcode.split(delim)
+
     if args.list:
         templates = shellcraft.templates
 
         if args.shellcode:
-            templates = filter(lambda a: args.shellcode in a, templates)
+            template_array = []
+            for s in shellcodes:
+                shellcode = s.split(' ')
+                template_array.append(filter(lambda a: shellcode in a, templates))
+            templates = template_array
         elif not args.syscalls:
             templates = filter(is_not_a_syscall_template, templates)
 
@@ -199,7 +218,7 @@ def main(args):
         exit()
 
     try:
-        func = get_template(args.shellcode)
+        funcs = get_template(args.shellcode, delim)
     except AttributeError:
         log.error("Unknown shellcraft template %r. Use --list to see available shellcodes." % args.shellcode)
 
@@ -209,73 +228,77 @@ def main(args):
         in_doctest = False
         block_indent = None
         caption = None
-        lines = func.__doc__.splitlines()
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-            if line.lstrip().startswith('>>>'):
-                # this line starts a doctest
-                in_doctest = True
-                block_indent = None
-                if caption:
-                    # delete back up to the caption
-                    doc = doc[:caption - i]
-                    caption = None
-            elif line == '':
-                # skip blank lines
-                pass
-            elif in_doctest:
-                # indentation marks the end of a doctest
-                indent = len(line) - len(line.lstrip())
-                if block_indent is None:
-                    if not line.lstrip().startswith('...'):
-                        block_indent = indent
-                elif indent < block_indent:
-                    in_doctest = False
+        for (_name, func, _args) in funcs:
+            lines = func.__doc__.splitlines()
+            i = 0
+            while i < len(lines):
+                line = lines[i]
+                if line.lstrip().startswith('>>>'):
+                    # this line starts a doctest
+                    in_doctest = True
                     block_indent = None
-                    # re-evalutate this line
-                    continue
-            elif line.endswith(':'):
-                # save index of caption
-                caption = i
+                    if caption:
+                        # delete back up to the caption
+                        doc = doc[:caption - i]
+                        caption = None
+                elif line == '':
+                    # skip blank lines
+                    pass
+                elif in_doctest:
+                    # indentation marks the end of a doctest
+                    indent = len(line) - len(line.lstrip())
+                    if block_indent is None:
+                        if not line.lstrip().startswith('...'):
+                            block_indent = indent
+                    elif indent < block_indent:
+                        in_doctest = False
+                        block_indent = None
+                        # re-evalutate this line
+                        continue
+                elif line.endswith(':'):
+                    # save index of caption
+                    caption = i
+                else:
+                    # this is not blank space and we're not in a doctest, so the
+                    # previous caption (if any) was not for a doctest
+                    caption = None
+
+                if not in_doctest:
+                    doc.append(line)
+                i += 1
+            print('\n'.join(doc).rstrip())
+            exit()
+
+    code_array = []
+    for (name, func, func_args) in funcs:
+        defargs = len(six.get_function_defaults(func) or ())
+        reqargs = six.get_function_code(func).co_argcount - defargs
+
+        if len(func_args) < reqargs:
+            if defargs > 0:
+                log.critical('%s takes at least %d arguments' % (name, reqargs))
+                sys.exit(1)
             else:
-                # this is not blank space and we're not in a doctest, so the
-                # previous caption (if any) was not for a doctest
-                caption = None
+                log.critical('%s takes exactly %d arguments' % (name, reqargs))
+                sys.exit(1)
 
-            if not in_doctest:
-                doc.append(line)
-            i += 1
-        print('\n'.join(doc).rstrip())
-        exit()
+        # Captain uglyness saves the day!
+        for i, val in enumerate(func_args):
+            try:
+                func_args[i] = util.safeeval.expr(val)
+            except ValueError:
+                pass
 
-    defargs = len(six.get_function_defaults(func) or ())
-    reqargs = six.get_function_code(func).co_argcount - defargs
-    if len(args.args) < reqargs:
-        if defargs > 0:
-            log.critical('%s takes at least %d arguments' % (args.shellcode, reqargs))
-            sys.exit(1)
-        else:
-            log.critical('%s takes exactly %d arguments' % (args.shellcode, reqargs))
-            sys.exit(1)
+        # And he strikes again!
+        list(map(common.context_arg, name.split('.')))
+        code_array.append(func(*func_args))
 
-    # Captain uglyness saves the day!
-    for i, val in enumerate(args.args):
-        try:
-            args.args[i] = util.safeeval.expr(val)
-        except ValueError:
-            pass
-
-    # And he strikes again!
-    list(map(common.context_arg, args.shellcode.split('.')))
-    code = func(*args.args)
-
+    code = "".join(code_array)
 
     if args.before:
         code = shellcraft.trap() + code
     if args.after:
         code = code + shellcraft.trap()
-
 
     if args.format in ['a', 'asm', 'assembly']:
         if args.color:
@@ -319,7 +342,7 @@ def main(args):
         else:
             args.format = 'raw'
 
-    arch = args.shellcode.split('.')[0]
+    arch = name.split('.')[0]
 
     if args.debug:
         if not args.avoid:

--- a/pwnlib/commandline/shellcraft.py
+++ b/pwnlib/commandline/shellcraft.py
@@ -197,7 +197,7 @@ def main(args):
 
     if args.shellcode:
         args.shellcode = " ".join(args.shellcode)
-        shellcodes = args.shellcode.split(delim)
+        shellcodes = [s.strip() for s in args.shellcode.split(delim)]
 
     if args.list:
         templates = shellcraft.templates


### PR DESCRIPTION
Hi, this is a draft PR that allows shellcraft to take multiple commands at a time and generate corresponding output. For example,

```bash
# before
$ pwn shellcraft -f d setreuid
$ pwn shellcraft -f d sh

# after
$ pwn shellcraft -f d setreuid + sh
```

I made this feature a while ago but was not sure if you'd like it to be in this tool. If you're interested in this feature, I can write some tests for this feature :)