### PR TITLE
Add TTY escape function for file transfer

### DIFF
--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -1097,3 +1097,11 @@ def js_unescape(s, **kwargs):
             p += 1
 
     return b''.join(res)
+
+def tty_escape(s, lnext=b'\x16', dangerous=bytes(bytearray(range(0x20)))):
+    s = s.replace(lnext, lnext * 2)
+    for b in bytearray(dangerous):
+        if b in lnext: continue
+        b = bytearray([b])
+        s = s.replace(b, lnext + b)
+    return s


### PR DESCRIPTION
This can help provide binary data when the other end is emulating a TTY access.

Maybe a tube wrapper function would be beneficial, too.