### PR TITLE
gdb.debug: avoid 2s timeout if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2405][2405] Add "none" ssh authentication method
 - [#2427][2427] Document behaviour of remote()'s sni argument as string.
 - [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
+- [#2435][2435] Speed up gdbserver handshake in gdb.debug()
 
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -717,12 +717,13 @@ def debug(args, gdbscript=None, gdb_args=None, exe=None, ssh=None, env=None, por
 
     # gdbserver outputs a message when a client connects
     garbage = gdbserver.recvline(timeout=1)
-
     # Some versions of gdbserver output an additional message
-    try:
-        garbage2 = gdbserver.recvline_startswith(b"Remote debugging from host ", timeout=2)
-    except EOFError:
-        pass
+    message = b"Remote debugging from host "
+    if not garbage.startswith(message):
+        try:
+            garbage2 = gdbserver.recvline_startswith(message, timeout=2)
+        except EOFError:
+            pass
 
     return gdbserver
 


### PR DESCRIPTION
On Ubuntu 22.04 gdb.debug() takes at least 2 seconds. This is because it prints only "Remote debugging from host 127.0.0.1, port 33398", but the code expects 2 lines.

It's very unclear what the second line is supposed to be; the only lead is "* Handle extra newline printed by gdb" in commit 338fbeba ("Improve pwnup template, gdbserver detection (#1148)"), but I could not trace it back to the GDB source code, both historic and modern. Perhaps, there is a non-upstreamed patch in some distro that introduces it.

It should still be safe to skip waiting for the second line if the first one already starts with "Remote debugging ...", so do it.
