### PR TITLE
Add resolution_addr parameter to Ret2dlresolvePayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.14.0 (`dev`)
 
+- [#2430][2430] Add resolution_addr parameter to Ret2dlresolvePayload
 - [#2371][2371] Add functions for retrieving process mappings
 - [#2360][2360] Add offline parameter for `search_by_hash` series function
 - [#2356][2356] Add local libc database provider for libcdb
@@ -91,6 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
 - [#2435][2435] Speed up gdbserver handshake in gdb.debug()
 
+[2430]: https://github.com/Gallopsled/pwntools/pull/2430
 [2371]: https://github.com/Gallopsled/pwntools/pull/2371
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.14.0 (`dev`)
 
-- [#2430][2430] Add resolution_addr parameter to Ret2dlresolvePayload
+- [#2436][2436] Add resolution_addr parameter to Ret2dlresolvePayload
 - [#2371][2371] Add functions for retrieving process mappings
 - [#2360][2360] Add offline parameter for `search_by_hash` series function
 - [#2356][2356] Add local libc database provider for libcdb
@@ -92,7 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
 - [#2435][2435] Speed up gdbserver handshake in gdb.debug()
 
-[2430]: https://github.com/Gallopsled/pwntools/pull/2430
+[2436]: https://github.com/Gallopsled/pwntools/pull/2436
 [2371]: https://github.com/Gallopsled/pwntools/pull/2371
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
 [2356]: https://github.com/Gallopsled/pwntools/pull/2356

--- a/pwnlib/rop/ret2dlresolve.py
+++ b/pwnlib/rop/ret2dlresolve.py
@@ -219,9 +219,22 @@ class Ret2dlresolvePayload(object):
         elf (ELF): Binary to search
         symbol (str): Function to search for
         args (list): List of arguments to pass to the function
+        data_addr (int|None): The address where the payload will 
+            be written to. If not provided, a suitable address will
+            be chosen automatically (recommended).
+        resolution_addr (int|None): The address where the location
+            of the resolved symbol will be written to. If not provided
+            will be equal to data_addr.
 
     Returns:
-        A ``Ret2dlresolvePayload`` object which can be passed to ``rop.ret2dlresolve``
+        A ``Ret2dlresolvePayload`` object. It can be passed to ``rop.ret2dlresolve``
+        for automatic exploitation.
+
+        If that is not suitable the object generates useful values (.reloc_index 
+        and .payload) which can be used to aid manual exploitation. In this case
+        it is recommended to set .resolution_addr to the GOT address of an easily
+        callable function (do not set it when passing the object to 
+        rop.ret2dlresolve).
     """
     def __init__(self, elf, symbol, args, data_addr=None):
         self.elf = elf


### PR DESCRIPTION
This PR implements point number two from https://github.com/Gallopsled/pwntools/issues/2429 (thus it *shouldn't* close the issue).
+ Adds an optional parameter called resolution_addr to Ret2dlresolvePayload making the loaders `_dl_runtime_resolve` function write the resolved function address to that location instead of the beginning of the payload (as is the default).