### PR TITLE
Support asm/disasm on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2427][2427] Document behaviour of remote()'s sni argument as string.
 - [#2382][2382] added optional port, gdb_args and gdbserver_args parameters to gdb.debug()
 - [#2435][2435] Speed up gdbserver handshake in gdb.debug()
+- [#2437][2437] Support asm/disasm on Windows
 
 [2371]: https://github.com/Gallopsled/pwntools/pull/2371
 [2360]: https://github.com/Gallopsled/pwntools/pull/2360
@@ -108,6 +109,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2405]: https://github.com/Gallopsled/pwntools/pull/2405
 [2427]: https://github.com/Gallopsled/pwntools/pull/2405
 [2382]: https://github.com/Gallopsled/pwntools/pull/2382
+[2437]: https://github.com/Gallopsled/pwntools/pull/2437
 
 ## 4.13.0 (`beta`)
 

--- a/docs/source/install/binutils.rst
+++ b/docs/source/install/binutils.rst
@@ -42,6 +42,12 @@ repo <https://github.com/Gallopsled/pwntools-binutils/>`__.
     $ wget https://raw.githubusercontent.com/Gallopsled/pwntools-binutils/master/macos/binutils-$ARCH.rb
     $ brew install ./binutils-$ARCH.rb
 
+Windows
+^^^^^^^^^^^^^^^^
+
+Windows support is experimental. You can try installing a prebuilt version of binutils
+for your desired architecture from the `GNU Toolchains <https://gnutoolchains.com/>`__ project.
+
 Alternate OSes
 ^^^^^^^^^^^^^^^^
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -460,35 +460,21 @@ def cpp(shellcode):
         >>> cpp("SYS_setresuid", os = "freebsd")
         '311\n'
     """
-    code = _include_header() + shellcode
     if platform.system() == 'Windows':
-        # Windows doesn't have /dev/stdin
         cpp = which_binutils('cpp')
-        temp_file = tempfile.NamedTemporaryFile('w', delete=False)
-        temp_file.write(code)
-        temp_file.flush()
-        code = None
-        input_file = temp_file.name
     else:
         cpp = 'cpp'
-        input_file = '/dev/stdin'
-        temp_file = None
 
-    try:
-        cmd  = [
-            cpp,
-            '-C',
-            '-nostdinc',
-            '-undef',
-            '-P',
-            '-I' + _incdir,
-            input_file
-        ]
-        return _run(cmd, code).strip('\n').rstrip() + '\n'
-    finally:
-        if temp_file is not None:
-            temp_file.close()
-            os.unlink(temp_file.name)
+    code = _include_header() + shellcode
+    cmd  = [
+        cpp,
+        '-C',
+        '-nostdinc',
+        '-undef',
+        '-P',
+        '-I' + _incdir,
+    ]
+    return _run(cmd, code).strip('\n').rstrip() + '\n'
 
 
 @LocalContext


### PR DESCRIPTION
Find binutils toolchains like https://gnutoolchains.com/ if they exist in the PATH. This allows to assemble and disassemble shellcode natively on Windows using pwntools.

```powershell
PS C:\> asm -c amd64 "mov rax, 5"
48c7c005000000
PS C:\> disasm -c amd64 48c7c005000000
   0:    48 c7 c0 05 00 00 00     mov    rax,  0x5
PS C:\> shellcraft amd64.windows.cmd
[!] Could not find system include headers for amd64-windows
31f665488b5e60488b5b18488b732048ad489648ad488b5820448b433c4c89c24801da4531c941b1884c01ca448b024901d8418b70204801de4831c949b947657450726f634148ffc18b048e4801d84c390875f2418b70244801de668b0c4e418b701c4801de8b048e4801d84889c748b801010101010101015048b856686f4479646201483104244889e231f665488b4e60488b4918488b712048ad489648ad488b48204883ec30ffd74883c4384889c648b801010101010101015048b8626c652f64796401483104244889e14883ec3031d2ffd64883c438ebfe
```