### PR TITLE
Fix parsing the PLT on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,12 @@ The table below shows which release corresponds to each branch, and what date th
 [2435]: https://github.com/Gallopsled/pwntools/pull/2435
 [2437]: https://github.com/Gallopsled/pwntools/pull/2437
 
+## 4.13.1
+
+- [#2445][2445] Fix parsing the PLT on Windows
+
+[2445]: https://github.com/Gallopsled/pwntools/pull/2445
+
 ## 4.13.0 (`stable`)
 
 - [#2242][2242] Term module revamp: activating special handling of terminal only when necessary

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -2,7 +2,6 @@
 """
 from __future__ import division
 import logging
-import sys
 
 from pwnlib.args import args
 from pwnlib.log import getLogger

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -62,9 +62,6 @@ def __ensure_memory_to_run_unicorn():
 
     This is a bug in Unicorn Engine, see: https://github.com/unicorn-engine/unicorn/issues/1766
     """
-    # Can only mmap files on Windows, would need to use VirtualAlloc.
-    if sys.platform == "win32":
-        return
     try:
         from mmap import mmap, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE
 
@@ -74,6 +71,9 @@ def __ensure_memory_to_run_unicorn():
         mm.close()
     except OSError:
         raise OSError("Cannot allocate 1GB memory to run Unicorn Engine")
+    except ImportError:
+        # Can only mmap files on Windows, would need to use VirtualAlloc.
+        pass
 
 
 def prepare_unicorn_and_context(elf, got, address, data):

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -2,6 +2,7 @@
 """
 from __future__ import division
 import logging
+import sys
 
 from pwnlib.args import args
 from pwnlib.log import getLogger
@@ -61,6 +62,9 @@ def __ensure_memory_to_run_unicorn():
 
     This is a bug in Unicorn Engine, see: https://github.com/unicorn-engine/unicorn/issues/1766
     """
+    # Can only mmap files on Windows, would need to use VirtualAlloc.
+    if sys.platform == "win32":
+        return
     try:
         from mmap import mmap, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE
 


### PR DESCRIPTION
The Unicorn Engine 1GB workaround doesn't work since `mmap` has different semantics on Windows.