### PR TITLE
Fixed x86 GAS options

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -247,8 +247,9 @@ def _assembler():
     B = '-%s' % context.bits
 
     assemblers = {
-        'i386'   : [gas, B],
-        'amd64'  : [gas, B],
+        # GAS accepts word size for x86 as long options
+        'i386'   : [gas, '-'+B],
+        'amd64'  : [gas, '-'+B],
 
         # Most architectures accept -EL or -EB
         'thumb'  : [gas, '-mthumb', E],


### PR DESCRIPTION
I fixed the word size options accepted by GAS for the x86 architecture from `-32`/`-64` to `--32`/`--64`.

Source:
https://sourceware.org/binutils/docs/as/i386_002dOptions.html