### PR TITLE
CI: Install pwntools on Windows and import it once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,27 @@ jobs:
         name: coverage-${{ matrix.python_version }}
         path: .coverage*
 
+  windows-test:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install --upgrade --editable .
+    
+    - name: Sanity checks
+      run: |
+        python -bb -c 'from pwn import *'
+        python -bb examples/text.py
 
   upload-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is just a basic smoke test for now to prevent problems like https://github.com/Gallopsled/pwntools/commit/4879590a37f4fe726dbd9ec276154b05449abefe. It can fail and won't break the whole workflow.

Lots of tests rely on common unix paths to be available so just running doctests isn't an option. We'd need to exclude certain tests from running on windows, which I don't like since it might clutter the code. Maybe add some external tests for the windows-only features?

#2446