### PR TITLE
Nicely handle non ELF files in checksec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,10 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.15.0 (`dev`)
 
 - [#2358][2358] Cache output of `asm()`
+- [#2457][2457] Catch exception of non-ELF files in checksec.
 
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
+[2457]: https://github.com/Gallopsled/pwntools/pull/2457
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/commandline/checksec.py
+++ b/pwnlib/commandline/checksec.py
@@ -35,7 +35,10 @@ def main(args):
         return
 
     for f in files:
-        e = ELF(f.name)
+        try:
+            e = ELF(f.name)
+        except Exception as e:
+            print("{name}: {error}".format(name=f.name, error=e))
 
 if __name__ == '__main__':
     common.main(__file__)


### PR DESCRIPTION
Otherwise we have a traceback that contains 1/3 of a screen.
```
Traceback (most recent call last):
...
elftools.common.exceptions.ELFError: Magic number does not match
```