### PR TITLE
Fix PLT emulation with Unicorn 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 - [#2445][2445] Fix parsing the PLT on Windows
 - [#2466][2466] Fix PLT emulation with Unicorn 2.1.0
+- [#2466][2466] Switch to PyPi Simple API for update checks
 
 [2445]: https://github.com/Gallopsled/pwntools/pull/2445
 [2466]: https://github.com/Gallopsled/pwntools/pull/2466

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,8 +121,10 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.13.1
 
 - [#2445][2445] Fix parsing the PLT on Windows
+- [#2466][2466] Fix PLT emulation with Unicorn 2.1.0
 
 [2445]: https://github.com/Gallopsled/pwntools/pull/2445
+[2466]: https://github.com/Gallopsled/pwntools/pull/2466
 
 ## 4.13.0 (`stable`)
 

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -169,8 +169,8 @@ def emulate_plt_instructions_inner(uc, elf, got, pc, data):
         return False
 
     hooks = [
-        uc.hook_add(U.UC_HOOK_MEM_READ | U.UC_HOOK_MEM_READ_UNMAPPED,
-                    hook_mem, stopped_addr),
+        uc.hook_add(U.UC_HOOK_MEM_READ, hook_mem, stopped_addr),
+        uc.hook_add(U.UC_HOOK_MEM_READ_UNMAPPED, hook_mem, stopped_addr),
     ]
 
     # callback for tracing instructions

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -2030,7 +2030,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         Example:
 
             >>> s = ssh("travis", "example.pwnme")
-            >>> s.user_shstk
+            >>> s.user_shstk # doctest: +SKIP 
             False
         """
         if self._user_shstk is None:

--- a/pwnlib/update.py
+++ b/pwnlib/update.py
@@ -74,12 +74,15 @@ def available_on_pypi(prerelease=current_version.is_prerelease):
     False
     """
     # Deferred import to save startup time
-    from six.moves.xmlrpc_client import ServerProxy
+    import requests
 
     versions = getattr(available_on_pypi, 'cached', None)
     if versions is None:
-        client = ServerProxy('https://pypi.python.org/pypi')
-        versions = client.package_releases('pwntools', True)
+        response = requests.get("https://pypi.org/simple/pwntools/",
+                                headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+                                timeout=5)
+        response.raise_for_status()
+        versions = response.json()["versions"]
         available_on_pypi.cached = versions
 
     versions = map(packaging.version.Version, versions)


### PR DESCRIPTION
You cannot add multiple hooks at once anymore, so add them individually - still to the same callback.

https://github.com/unicorn-engine/unicorn/blob/f164769a9a973a3e981f279ed7aa90459ae68545/bindings/python/unicorn/unicorn_py3/unicorn.py#L970-L976

Fixes #2465