### PR TITLE
Backport: Fix typo for fallback to default number of console colors on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,9 +123,11 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2445][2445] Fix parsing the PLT on Windows
 - [#2466][2466] Fix PLT emulation with Unicorn 2.1.0
 - [#2466][2466] Switch to PyPi Simple API for update checks
+- [#2467][2467] Fix loading at all on Windows
 
 [2445]: https://github.com/Gallopsled/pwntools/pull/2445
 [2466]: https://github.com/Gallopsled/pwntools/pull/2466
+[2467]: https://github.com/Gallopsled/pwntools/pull/2467
 
 ## 4.13.0 (`stable`)
 

--- a/pwnlib/term/text.py
+++ b/pwnlib/term/text.py
@@ -27,7 +27,7 @@ class Module(types.ModuleType):
     def __init__(self):
         self.__file__ = __file__
         self.__name__ = __name__
-        self.num_colors = termcap.get('colors', 8) if sys.platform == 'win32' else 8
+        self.num_colors = termcap.get('colors', default=8) if sys.platform == 'win32' else 8
         self.when = 'auto'
         self._colors = {
             'black': 0,


### PR DESCRIPTION
Fix importing of pwntools on Windows in stable. [This patch](https://github.com/Gallopsled/pwntools/commit/4879590a37f4fe726dbd9ec276154b05449abefe) is already in [4.14.0beta0](https://github.com/Gallopsled/pwntools/releases/tag/4.14.0beta0) but wasn't backported to 4.13.1 yet.

```
>>> from pwn import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwn\__init__.py", line 4, in <module>
    from pwn.toplevel import *
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwn\toplevel.py", line 21, in <module>
    import pwnlib
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\__init__.py", line 41, in <module>
    from . import args
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\args.py", line 60, in <module>
    from pwnlib import term
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\term\__init__.py", line 6, in <module>
    from pwnlib.term import completer
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\term\completer.py", line 7, in <module>
    from pwnlib.term import readline
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\term\readline.py", line 14, in <module>
    from pwnlib.term import text
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\term\text.py", line 136, in <module>
    sys.modules[__name__] = Module()
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\term\text.py", line 30, in __init__
    self.num_colors = termcap.get('colors', 8) if sys.platform == 'win32' else 8
  File "C:\Users\student\AppData\Local\Temp\venv\lib\site-packages\pwnlib\term\windows_termcap.py", line 26, in get
    return s(*args)
TypeError: 'int' object is not callable
```

Fixes #2456