### PR TITLE
Fix waiting for gdb under WSL2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2358][2358] Cache output of `asm()`
 - [#2457][2457] Catch exception of non-ELF files in checksec.
 - [#2444][2444] Add `ELF.close()` to release resources
+- [#2470][2470] Fix waiting for gdb under WSL2
 
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
 [2457]: https://github.com/Gallopsled/pwntools/pull/2457
 [2444]: https://github.com/Gallopsled/pwntools/pull/2444
+[2470]: https://github.com/Gallopsled/pwntools/pull/2470
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -1251,7 +1251,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
     gdb_pid = misc.run_in_new_terminal(cmd, preexec_fn = preexec_fn)
 
     if pid and context.native:
-        proc.wait_for_debugger(pid, gdb_pid)
+        gdb_pid = proc.wait_for_debugger(pid, gdb_pid)
 
     if not api:
         return gdb_pid

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -441,6 +441,11 @@ end tell
             tmp.flush()
             os.chmod(tmp.name, 0o700)
             argv = [which(terminal), tmp.name]
+    # cmd.exe does not support WSL UNC paths as working directory
+    # so it gets reset to %WINDIR% before starting wsl again.
+    # Set the working directory correctly in WSL.
+    elif terminal == 'cmd.exe':
+        argv[-1] = "cd '{}' && {}".format(os.getcwd(), argv[-1])
 
     log.debug("Launching a new terminal: %r" % argv)
 

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -400,7 +400,7 @@ def wait_for_debugger(pid, debugger_pid=None):
         pid (int): PID of the process.
 
     Returns:
-        None
+        The PID of the debugger that attached to the process.
     """
     t = Timeout()
     with t.countdown(timeout=15):
@@ -418,9 +418,11 @@ def wait_for_debugger(pid, debugger_pid=None):
                 else:
                     time.sleep(0.01)
 
-            if tracer(pid):
+            tracer_pid = tracer(pid)
+            if tracer_pid:
                 l.success()
             elif debugger_pid == 0:
                 l.failure("debugger exited! (maybe check /proc/sys/kernel/yama/ptrace_scope)")
             else:
                 l.failure('Debugger did not attach to pid %d within 15 seconds', pid)
+            return tracer_pid

--- a/pwnlib/util/proc.py
+++ b/pwnlib/util/proc.py
@@ -82,6 +82,8 @@ def pid_by_name(name):
         try:
             if p.exe() == name:
                 return True
+            if p.cmdline()[0] == name:
+                return True
         except Exception:
             pass
         return False


### PR DESCRIPTION
We run cmd.exe and other Windows processes before going back into WSL. The returned pid would be the one for the ephemeral cmd.exe process instead of the real command we wanted to launch.

I don't know how to properly trace the execution and get the command pid, so scan for newer pids matching the command for a while instead as a workaround.

We wrap the command in a script so `psutil.Process.exe()` returns the path to the shell instead of the real command. Look at `psutil.Process.cmdline()` too which contains the real program running right now.