### PR TITLE
Properly close spawned kitty window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,10 +72,12 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 4.15.0 (`dev`)
 
+- [#2471][2471] Properly close spawned kitty window
 - [#2358][2358] Cache output of `asm()`
 - [#2457][2457] Catch exception of non-ELF files in checksec.
 - [#2444][2444] Add `ELF.close()` to release resources
 
+[2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
 [2457]: https://github.com/Gallopsled/pwntools/pull/2457
 [2444]: https://github.com/Gallopsled/pwntools/pull/2444

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -443,10 +443,12 @@ end tell
     log.debug("Launching a new terminal: %r" % argv)
 
     stdin = stdout = stderr = open(os.devnull, 'r+b')
-    if terminal == 'tmux':
+    if terminal == 'tmux' or terminal == 'kitty':
         stdout = subprocess.PIPE
 
     p = subprocess.Popen(argv, stdin=stdin, stdout=stdout, stderr=stderr, preexec_fn=preexec_fn)
+
+    kittyid = None
 
     if terminal == 'tmux':
         out, _ = p.communicate()
@@ -460,6 +462,16 @@ end tell
         with subprocess.Popen((qdbus, konsole_dbus_service, '/Sessions/{}'.format(last_konsole_session),
                                'org.kde.konsole.Session.processId'), stdout=subprocess.PIPE) as proc:
             pid = int(proc.communicate()[0].decode())
+    elif terminal == 'kitty':
+        pid = p.pid
+        
+        out, _ = p.communicate()
+        try:
+            kittyid = int(out)
+        except ValueError:
+            kittyid = None
+        if kittyid is None:
+            log.error("Could not parse kitty window ID from output (%r)", out)
     else:
         pid = p.pid
 
@@ -468,6 +480,8 @@ end tell
             try:
                 if terminal == 'qdbus':
                     os.kill(pid, signal.SIGHUP)
+                elif terminal == 'kitty':
+                    subprocess.Popen(["kitten", "@", "close-window", "--match", f"id:{kittyid}"])
                 else:
                     os.kill(pid, signal.SIGTERM)
             except OSError:

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -481,7 +481,7 @@ end tell
                 if terminal == 'qdbus':
                     os.kill(pid, signal.SIGHUP)
                 elif terminal == 'kitty':
-                    subprocess.Popen(["kitten", "@", "close-window", "--match", f"id:{kittyid}"])
+                    subprocess.Popen(["kitten", "@", "close-window", "--match", "id:{}".format(kittyid)])
                 else:
                     os.kill(pid, signal.SIGTERM)
             except OSError:


### PR DESCRIPTION
The PID of the process run inside a spawned kitty window (always gdb in the current code) isn't properly detected. We can instead use the internal window id kitty returns to close it. 

Fixes https://github.com/Gallopsled/pwntools/issues/2428