### PR TITLE
Redirect kitty kill command stderr to /dev/null

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -481,7 +481,7 @@ end tell
                 if terminal == 'qdbus':
                     os.kill(pid, signal.SIGHUP)
                 elif terminal == 'kitty':
-                    subprocess.Popen(["kitten", "@", "close-window", "--match", "id:{}".format(kittyid)])
+                    subprocess.Popen(["kitten", "@", "close-window", "--match", "id:{}".format(kittyid)], stderr=stderr)
                 else:
                     os.kill(pid, signal.SIGTERM)
             except OSError:


### PR DESCRIPTION
If one closes the window then quickly Ctrl+C's on the pwntools process they might get a message like
`Error: No matching windows for expression: id:38`

This is also very apparent if the debugee SIGSEGVS, then after closing the debugging window an interactive shell will not close automatically and requires a Ctrl+C, always getting the error message.

We don't want to show this error message to the user since in reality everything is fine and it will just confuse them.

Note that this doesn't fix the weird bytes that get printed when closing the process.