### PR TITLE
gdb: fix pid attach

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -1173,7 +1173,7 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
         cmd += [exe]
 
     if pid and not context.os == 'android':
-        cmd += [str(pid)]
+        cmd += ['-p', str(pid)]
 
     if context.os == 'android' and pid:
         runner  = _get_runner()


### PR DESCRIPTION
Missing `-p` meant GDB could not attach to pids.