### PR TITLE
Fix collecting coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,13 @@ jobs:
       with:
         name: packages
         path: dist/
+        include-hidden-files: true
 
     - uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ matrix.python_version }}
         path: .coverage*
+        include-hidden-files: true
 
   windows-test:
     runs-on: windows-latest


### PR DESCRIPTION
The upload-artifact action v4.4.0 excluded hidden files from uploads by default. We want to upload only hidden `.coverage*` files though. Enable hidden files again using the `include-hidden-files` input.

https://github.com/actions/upload-artifact/releases/tag/v4.4.0

Fixes #2468 