### PR TITLE
Extract libraries from Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2444][2444] Add `ELF.close()` to release resources
 - [#2413][2413] libcdb: improve the search speed of `search_by_symbol_offsets` in local libc-database
 - [#2470][2470] Fix waiting for gdb under WSL2
+- [#2479][2479] Support extracting libraries from Docker image in `pwn template`
 
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2444]: https://github.com/Gallopsled/pwntools/pull/2444
 [2413]: https://github.com/Gallopsled/pwntools/pull/2413
 [2470]: https://github.com/Gallopsled/pwntools/pull/2470
+[2479]: https://github.com/Gallopsled/pwntools/pull/2479
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from pwn import *
 from pwnlib.commandline import common
+from pwnlib.util.misc import which, parse_ldd_output, write
 
 from sys import stderr
 from mako.lookup import TemplateLookup, Template
@@ -41,7 +42,7 @@ def get_docker_image_libraries():
     Supports regular Docker images as well as jail images.
     """
     with log.progress("Extracting challenge libraries from Docker image") as progress:
-        if not util.misc.which("docker"):
+        if not which("docker"):
             progress.failure("docker command not found")
             return None, None
         # maps jail image name to the root directory of the child image
@@ -104,7 +105,7 @@ def get_docker_image_libraries():
                     stderr=subprocess.PIPE, 
                     shell=False
                 )
-                util.misc.write(basename, contents)
+                write(basename, contents)
 
         except subprocess.CalledProcessError as e:
             print(e.stderr.decode())

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -53,11 +53,10 @@ def get_docker_image_libraries():
         ldd_output = subprocess.check_output([
                 "docker",
                 "run",
-                "--rm",
-                *(["--privileged"] if is_jailed else ["--entrypoint", "/bin/sh"]),
-                image_sha,
-                *ldd_command,
-            ],
+                "--rm"
+                ] + (["--privileged"] if is_jailed else ["--entrypoint", "/bin/sh"]) + [
+                    image_sha,
+                ] + ldd_command,
             shell=False
         ).decode()
         
@@ -83,10 +82,9 @@ def get_docker_image_libraries():
                     "docker",
                     "run",
                     "--rm",
-                    *(["--privileged"] if is_jailed else ["--entrypoint", "/bin/sh"]),
-                    image_sha,
-                    *cat_command,
-                ],
+                    ] + (["--privileged"] if is_jailed else ["--entrypoint", "/bin/sh"]) + [
+                        image_sha
+                    ] + cat_command,
                 shell=False
             )
             open(basename, "wb").write(contents)


### PR DESCRIPTION
# Pwntools Pull Request

Implements #2313.
Supports both normal Dockerfiles as well as the ones using pwn.red/jail, the most common way to sandbox pwn challenges.

## Testing

I tested the changes manually on a chall of each kind (no Dockerfile, Dockerfile and Dockerfile using pwn.red/jail as the base image).
I'm open to adding automated tests but would need some input on how to do so, I don't think we want to add random chall binaries to the repo just to test this.