### PR TITLE
Throw error when using `sni` and setting `server_hostname` manually in `remote`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2444][2444] Add `ELF.close()` to release resources
 - [#2413][2413] libcdb: improve the search speed of `search_by_symbol_offsets` in local libc-database
 - [#2470][2470] Fix waiting for gdb under WSL2
+- [#2482][2482] Throw error when using `sni` and setting `server_hostname` manually in `remote`
 
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
@@ -86,6 +87,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2444]: https://github.com/Gallopsled/pwntools/pull/2444
 [2413]: https://github.com/Gallopsled/pwntools/pull/2413
 [2470]: https://github.com/Gallopsled/pwntools/pull/2470
+[2482]: https://github.com/Gallopsled/pwntools/pull/2482
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -89,6 +89,8 @@ class remote(sock):
                 import ssl as _ssl
 
                 ssl_args = ssl_args or {}
+                if "server_hostname" in ssl_args and sni:
+                    log.error("sni and server_hostname cannot be set at the same time")
                 ssl_context = ssl_context or _ssl.SSLContext(_ssl.PROTOCOL_TLSv1_2)
                 if isinstance(sni, str):
                     ssl_args["server_hostname"] = sni


### PR DESCRIPTION
Prevents silently replacing the `server_hostname` that was provided in `ssl_args`.

Fixes #2425