### PR TITLE
Only print `checksec` output of `ELF.libc` when it was printed for the `ELF` already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2444][2444] Add `ELF.close()` to release resources
 - [#2413][2413] libcdb: improve the search speed of `search_by_symbol_offsets` in local libc-database
 - [#2470][2470] Fix waiting for gdb under WSL2
+- [#2483][2483] Only print `checksec` output of `ELF.libc` when it was printed for the `ELF` already
 
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
@@ -86,6 +87,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2444]: https://github.com/Gallopsled/pwntools/pull/2444
 [2413]: https://github.com/Gallopsled/pwntools/pull/2413
 [2470]: https://github.com/Gallopsled/pwntools/pull/2470
+[2483]: https://github.com/Gallopsled/pwntools/pull/2483
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -358,6 +358,7 @@ class ELF(ELFFile):
         self._populate_functions()
         self._populate_kernel_version()
 
+        self._print_checksec = checksec
         if checksec:
             self._describe()
 
@@ -730,12 +731,13 @@ class ELF(ELFFile):
         """:class:`.ELF`: If this :class:`.ELF` imports any libraries which contain ``'libc[.-]``,
         and we can determine the appropriate path to it on the local
         system, returns a new :class:`.ELF` object pertaining to that library.
+        Prints the `checksec` output of the library if it was printed for the original ELF too.
 
         If not found, the value will be :const:`None`.
         """
         for lib in self.libs:
             if '/libc.' in lib or '/libc-' in lib:
-                return ELF(lib)
+                return ELF(lib, self._print_checksec)
 
     def _populate_libraries(self):
         """


### PR DESCRIPTION
Accessing `ELF.libc` would always print the `checksec` output of the libc without a way to suppress it easily. Remember if we opened the file with `ELF(bin, checksec=False)` and don't print it when accessing `.libc`.

Fixes #2414