### PR TITLE
Allow to disable caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2444][2444] Add `ELF.close()` to release resources
 - [#2413][2413] libcdb: improve the search speed of `search_by_symbol_offsets` in local libc-database
 - [#2470][2470] Fix waiting for gdb under WSL2
+- [#2484][2484] Allow to disable caching
 
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
@@ -86,6 +87,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2444]: https://github.com/Gallopsled/pwntools/pull/2444
 [2413]: https://github.com/Gallopsled/pwntools/pull/2413
 [2470]: https://github.com/Gallopsled/pwntools/pull/2470
+[2484]: https://github.com/Gallopsled/pwntools/pull/2484
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -765,9 +765,10 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
         The output is cached:
 
         >>> start = time.time()
-        >>> asm("lea rax, [rip+0]", arch = 'amd64')
+        >>> asm("lea rax, [rip+0]", arch = 'amd64', cache_dir = None) # force uncached time
         b'H\x8d\x05\x00\x00\x00\x00'
         >>> uncached_time = time.time() - start
+        >>> asm("lea rax, [rip+0]", arch = 'amd64') # cache it
         >>> start = time.time()
         >>> asm("lea rax, [rip+0]", arch = 'amd64')
         b'H\x8d\x05\x00\x00\x00\x00'

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -769,6 +769,7 @@ def asm(shellcode, vma = 0, extract = True, shared = False):
         b'H\x8d\x05\x00\x00\x00\x00'
         >>> uncached_time = time.time() - start
         >>> asm("lea rax, [rip+0]", arch = 'amd64') # cache it
+        b'H\x8d\x05\x00\x00\x00\x00'
         >>> start = time.time()
         >>> asm("lea rax, [rip+0]", arch = 'amd64')
         b'H\x8d\x05\x00\x00\x00\x00'

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1377,9 +1377,9 @@ class ContextType(object):
     def cache_dir_base(self, new_base):
         """Base directory to use for caching content.
 
-        Changing this to a different value will clear the `cache_dir` path
+        Changing this to a different value will clear the :attr:`cache_dir` path
         stored in TLS since a new path will need to be generated to respect the
-        new `cache_dir_base` value.
+        new :attr:`cache_dir_base` value.
         """
 
         if new_base != self.cache_dir_base:
@@ -1394,6 +1394,9 @@ class ContextType(object):
 
         Note:
             May be either a path string, or :const:`None`.
+            Set to :const:`None` to disable caching.
+            Set to :const:`True` to generate the default cache directory path
+            based on :attr:`cache_dir_base` again.
 
         Example:
 
@@ -1401,11 +1404,17 @@ class ContextType(object):
             >>> cache_dir is not None
             True
             >>> os.chmod(cache_dir, 0o000)
-            >>> del context._tls['cache_dir']
+            >>> context.cache_dir = True
             >>> context.cache_dir is None
             True
             >>> os.chmod(cache_dir, 0o755)
             >>> cache_dir == context.cache_dir
+            True
+            >>> context.cache_dir = None
+            >>> context.cache_dir is None
+            True
+            >>> context.cache_dir = True
+            >>> context.cache_dir is not None
             True
         """
         try:
@@ -1451,7 +1460,9 @@ class ContextType(object):
 
     @cache_dir.setter
     def cache_dir(self, v):
-        if os.access(v, os.W_OK):
+        if v is True:
+            del self._tls["cache_dir"]
+        elif v is None or os.access(v, os.W_OK):
             # Stash this in TLS for later reuse
             self._tls["cache_dir"] = v
 


### PR DESCRIPTION
Disable caching by setting `context.cache_dir = None`. Generate default cache dir again by setting `context.cache_dir = True`.

Fixes #2440 