### PR TITLE
Cache HTTP requests to external libcdb services in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,21 @@ jobs:
             os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    services:
+      libcdb-cache:
+        image: nginx
+        volumes:
+          - /home/runner/libcdb-cache:/var/cache/nginx
+        ports:
+          - 3000:3000  # https://debuginfod.elfutils.org proxy cache
+          - 3001:3001  # https://libc.rip/ proxy cache
+          - 3002:3002  # http://archive.ubuntu.com/ proxy cache
+          - 3003:3003  # https://gitlab.com/ proxy cache
+    env:
+      DEBUGINFOD_URLS: http://localhost:3000/
+      PWN_LIBCRIP_URL: http://localhost:3001/
+      PWN_UBUNTU_ARCHIVE_URL: http://localhost:3002/
+      PWN_GITLAB_LIBCDB_URL:  http://localhost:3003/
     steps:
     - uses: actions/checkout@v4
       with:
@@ -21,6 +36,28 @@ jobs:
       run: |
         git fetch origin
         git log --oneline --graph -10
+    
+    - name: Fix libcdb-cache permissions
+      id: fix-perms
+      run: |
+        sudo chown -R runner:runner /home/runner/libcdb-cache
+        echo "date=$(/bin/date -u "+%Y%m%d%H%M%S")" >> $GITHUB_OUTPUT
+
+    - name: Cache for libcdb requests
+      uses: actions/cache@v4
+      with:
+        path: ~/libcdb-cache
+        key: libcdb-python${{ matrix.python_version }}-${{ steps.fix-perms.outputs.date }}
+        restore-keys: |
+          libcdb-python${{ matrix.python_version }}-
+          libcdb-
+
+    - name: Install libcdb-cache service config
+      run: |
+        sudo chown -R 101:101 /home/runner/libcdb-cache
+        container_id=$(docker ps --all --filter volume=/home/runner/libcdb-cache --no-trunc --format "{{.ID}}")
+        docker cp ./travis/libcdb_nginx_cache.conf $container_id:/etc/nginx/nginx.conf
+        docker restart $container_id
 
     - name: Install RPyC for gdb
       run: |
@@ -29,11 +66,10 @@ jobs:
         sudo apt-get update && sudo apt-get install -y python3-pip gdb gdbserver
         /usr/bin/python -m pip install --break-system-packages rpyc || /usr/bin/python -m pip install rpyc
         gdb --batch --quiet --nx --nh --ex 'py import rpyc; print(rpyc.version.version)'
-
+    
     - name: Cache for pip
       uses: actions/cache@v4
       if: matrix.python_version == '2.7'
-      id: cache-pip
       with:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-${{ matrix.python_version }}-cache-pip-${{ hashFiles('**/pyproject.toml', '**/requirements*.txt') }}
@@ -224,6 +260,12 @@ jobs:
         name: coverage-${{ matrix.python_version }}
         path: .coverage*
         include-hidden-files: true
+    
+    - name: Fix libcdb-cache permissions
+      run: |
+        container_id=$(docker ps --filter volume=/home/runner/libcdb-cache --no-trunc --format "{{.ID}}")
+        docker stop $container_id
+        sudo chown -R runner:runner /home/runner/libcdb-cache
 
   windows-test:
     runs-on: windows-latest

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -652,7 +652,7 @@ class DynELF(object):
                 break
 
             if name:
-                self.status('Skipping %s' % name)
+                self.status('Skipping %r' % name)
 
             cur = leak.field(cur, LinkMap.l_next)
         else:

--- a/travis/libcdb_nginx_cache.conf
+++ b/travis/libcdb_nginx_cache.conf
@@ -1,0 +1,69 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    proxy_cache_path /var/cache/nginx keys_zone=my_cache:1m max_size=1g inactive=12w use_temp_path=off;
+    log_format cache_st '$remote_addr - $remote_user - $upstream_cache_status [$time_local]  '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+    access_log /dev/stdout cache_st;
+
+    server {
+        listen 3000;
+        proxy_cache my_cache;
+
+        location / {
+            proxy_set_header Host debuginfod.elfutils.org;
+            proxy_cache_revalidate on;
+            proxy_cache_key $scheme://$host$uri$is_args$query_string;
+            proxy_cache_valid 200 404 12w;
+            proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
+            proxy_pass https://debuginfod.elfutils.org/;
+        }
+    }
+
+    server {
+        listen 3001;
+        proxy_cache my_cache;
+
+        location / {
+            proxy_set_header Host libc.rip;
+            proxy_cache_methods GET HEAD POST;
+            proxy_cache_revalidate on;
+            proxy_cache_key $scheme://$host$uri$is_args$query_string$request_body;
+            proxy_cache_valid 200 404 12w;
+            proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
+            proxy_pass https://libc.rip/;
+        }
+    }
+
+    server {
+        listen 3002;
+        proxy_cache my_cache;
+
+        location / {
+            proxy_set_header Host archive.ubuntu.com;
+            proxy_cache_revalidate on;
+            proxy_cache_key $scheme://$host$uri$is_args$query_string;
+            proxy_cache_valid 200 404 12w;
+            proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
+            proxy_pass http://archive.ubuntu.com/;
+        }
+    }
+
+    server {
+        listen 3003;
+        proxy_cache my_cache;
+
+        location / {
+            proxy_set_header Host gitlab.com;
+            proxy_ssl_server_name on;
+            proxy_cache_revalidate on;
+            proxy_cache_key $scheme://$host$uri$is_args$query_string;
+            proxy_cache_valid 200 404 12w;
+            proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
+            proxy_pass https://gitlab.com/;
+        }
+    }
+}


### PR DESCRIPTION
Start a local nginx proxy service in Github Actions to cache the libc.rip, gitlab.com, debuginfod.elfutils.org, and archive.ubuntu.com requests and responses which are issued during the libcdb doctests. This improves CI runtime by about 1 minute and hopefully allows the remote services to be offline without our CI being flakey and failing randomly.

The results can be seen in the `Stop containers` workflow step:
```
 172.18.0.1 - - - MISS [12/Oct/2024:16:36:33 +0000]  "GET /libcdb/libcdb/raw/master/hashes/build_id/fe136e485814fee2268cf19e5c124ed0f73f4400 HTTP/1.1" 200 47 "-" "python-requests/2.27.1"
 172.18.0.1 - - - MISS [12/Oct/2024:16:36:33 +0000]  "GET /libcdb/libcdb/raw/master/libc/libc6-i386-2.18-6/lib32/libc-2.18.so HTTP/1.1" 200 1742516 "-" "python-requests/2.27.1"
 172.18.0.1 - - - HIT [12/Oct/2024:16:36:34 +0000]  "GET /buildid/fe136e485814fee2268cf19e5c124ed0f73f4400/debuginfo HTTP/1.1" 404 9 "-" "python-requests/2.27.1"
 172.18.0.1 - - - MISS [12/Oct/2024:16:36:35 +0000]  "GET /libcdb/libcdb/raw/master/hashes/build_id/XX HTTP/1.1" 404 8307 "-" "python-requests/2.27.1"
 172.18.0.1 - - - HIT [12/Oct/2024:16:36:35 +0000]  "POST /api/find HTTP/1.1" 200 3 "-" "python-requests/2.27.1"
 ```
You see the HIT and MISSes.

![grafik](https://github.com/user-attachments/assets/d31f2242-edd2-481d-8213-22dcb155a0ca)

![grafik](https://github.com/user-attachments/assets/a7196e21-2ade-4d48-9ca5-c4bb49e6dc7b)

Fixes #2348
