### PR TITLE
Stop using cmd.exe to keep current directory

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -367,8 +367,6 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
                 with open('/proc/sys/kernel/osrelease', 'rb') as f:
                     is_wsl = b'icrosoft' in f.read()
             if is_wsl and which('cmd.exe') and which('wsl.exe') and which('bash.exe'):
-                terminal    = 'cmd.exe'
-                args        = ['/c', 'start']
                 distro_name = os.getenv('WSL_DISTRO_NAME')
 
                 # Split pane in Windows Terminal

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -366,7 +366,7 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
             if os.path.exists('/proc/sys/kernel/osrelease'):
                 with open('/proc/sys/kernel/osrelease', 'rb') as f:
                     is_wsl = b'icrosoft' in f.read()
-            if is_wsl and which('powershell.exe') and which('wsl.exe') and which('bash.exe'):
+            if is_wsl and which('cmd.exe') and which('wsl.exe') and which('bash.exe'):
                 terminal    = 'cmd.exe'
                 args        = ['/c', 'start']
                 distro_name = os.getenv('WSL_DISTRO_NAME')

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -366,17 +366,17 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
             if os.path.exists('/proc/sys/kernel/osrelease'):
                 with open('/proc/sys/kernel/osrelease', 'rb') as f:
                     is_wsl = b'icrosoft' in f.read()
-            if is_wsl and which('cmd.exe') and which('wsl.exe') and which('bash.exe'):
-                terminal    = 'wt.exe'
-                args = []
+            if is_wsl and which('powershell.exe') and which('wsl.exe') and which('bash.exe'):
+                terminal    = 'cmd.exe'
+                args        = ['/c', 'start']
                 distro_name = os.getenv('WSL_DISTRO_NAME')
+                current_dir = os.getcwd()
 
                 # Split pane in Windows Terminal
                 if 'WT_SESSION' in os.environ and which('wt.exe'):
-                    args.extend(['-w', '0', 'split-pane', '-d', '.'])
-
+                    args.extend(['wt.exe', '-w', '0', 'split-pane'])
                 if distro_name:
-                    args.extend(['wsl.exe', '-d', distro_name, 'bash', '-c'])
+                    args.extend(['wsl.exe', '-d', distro_name, '--cd', current_dir, 'bash', '-c'])
                 else:
                     args.extend(['bash.exe', '-c'])
 

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -367,11 +367,13 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
                 with open('/proc/sys/kernel/osrelease', 'rb') as f:
                     is_wsl = b'icrosoft' in f.read()
             if is_wsl and which('cmd.exe') and which('wsl.exe') and which('bash.exe'):
+                terminal    = 'wt.exe'
+                args = []
                 distro_name = os.getenv('WSL_DISTRO_NAME')
 
                 # Split pane in Windows Terminal
                 if 'WT_SESSION' in os.environ and which('wt.exe'):
-                    args.extend(['wt.exe', '-w', '0', 'split-pane', '-d', '.'])
+                    args.extend(['-w', '0', 'split-pane', '-d', '.'])
 
                 if distro_name:
                     args.extend(['wsl.exe', '-d', distro_name, 'bash', '-c'])


### PR DESCRIPTION
Because `cmd.exe` can't parse the file path of `WSL`, it automatically drop the current directory to `/mnt/c/Windows`. 

![Screenshot 2024-10-13 173943](https://github.com/user-attachments/assets/c276361f-dd6c-4878-8031-114ef44bdb18)


We can call `wt.exe` directly to keep the current directory. Because some CTF challenges needs patching run path of the binary to `.`, so keeping exactly the current directory is convenient for debugging.

![Screenshot 2024-10-13 174014](https://github.com/user-attachments/assets/3ea2cc4b-1a16-4bf9-bb21-f16472a15c42)
