### PR TITLE
FIX: exclude the latest capstone because it breaks ROPgadget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "mako>=1.0.0",
     "pyelftools>=0.29, <0.30; python_version < '3'",
     "pyelftools>=0.29; python_version >= '3'",
-    "capstone>=3.0.5rc2",  # see Gallopsled/pwntools#971, Gallopsled/pwntools#1160
+    "capstone>=3.0.5rc2, !=6.0.0a1",  # see Gallopsled/pwntools#971, Gallopsled/pwntools#1160
     "ropgadget>=5.3",
     "pyserial>=2.7",
     "requests>=2.0",


### PR DESCRIPTION
FIX for this issue : https://github.com/Gallopsled/pwntools/issues/2491

The idea is that capstone push a new tag that is an Alpha and this breaks ROPgadget.
As ROPgadget does not have requirements to fix this issue (they only mention dependency on capstone) I thought that I could modify the requirements inside of pwntools so it excludes the breaking tag.