### PR TITLE
Add support for search in kernel modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2482][2482] Throw error when using `sni` and setting `server_hostname` manually in `remote`
 - [#2478][2478] libcdb-cli: add `--offline-only`, refactor unstrip and add fetch parser for download libc-database
 - [#2484][2484] Allow to disable caching
+- [#2496][2496] Add linux ko file search support
 
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
@@ -96,6 +97,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2482]: https://github.com/Gallopsled/pwntools/pull/2482
 [2478]: https://github.com/Gallopsled/pwntools/pull/2478
 [2484]: https://github.com/Gallopsled/pwntools/pull/2484
+[2496]: https://github.com/Gallopsled/pwntools/pull/2496
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1258,6 +1258,23 @@ class ELF(ELFFile):
                     break
                 yield (addr + offset + load_address_fixup)
                 offset += 1
+        if not segments:
+            for section in super().iter_sections():
+                if section.name==".text":
+                    addr = section['sh_addr']
+                    memsz = section['sh_size']
+                    filesz = section['sh_size']
+                    zeroed = memsz - filesz
+                    offset = section['sh_offset']
+                    data = self.mmap[offset:offset + filesz]
+                    data += b'\x00'
+                    offset = 0
+                    while True:
+                        offset = data.find(needle, offset)
+                        if offset == -1:
+                            break
+                        yield (addr + offset + load_address_fixup)
+                        offset += 1
 
     def offset_to_vaddr(self, offset):
         """offset_to_vaddr(offset) -> int

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -1297,7 +1297,7 @@ class ELF(ELFFile):
                         for section in super().iter_sections():
                             if section.name.startswith(".rodata"):
                                 rodata_filesz += section['sh_size']
-                            elif section.name.startswith(".node"):
+                            elif section.name.startswith(".note"):
                                 note_filesz += section['sh_size']
                         addr = (text_filesz//PAGESIZE + 1 + (note_filez+rodata_filesz)//PAGESIZE + 1)*PAGESIZE
                     yield (addr + offset + load_address_fixup)

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -53,7 +53,7 @@ from elftools.elf.constants import P_FLAGS
 from elftools.elf.constants import SHN_INDICES
 from elftools.elf.descriptions import describe_e_type
 from elftools.elf.dynamic import DynamicSection
-from elftools.elf.elffile import ELFFile, PAGESIZE
+from elftools.elf.elffile import ELFFile
 from elftools.elf.enums import ENUM_GNU_PROPERTY_X86_FEATURE_1_FLAGS
 from elftools.elf.gnuversions import GNUVerDefSection
 from elftools.elf.relocation import RelocationSection, RelrRelocationSection
@@ -1266,6 +1266,14 @@ class ELF(ELFFile):
                 ko_check_segments = [".text"]
             else:
                 ko_check_segments = [".text",".note",".rodata",".data"]
+            pagesize = 4096
+            for section in super().iter_sections():
+                alignment = section['sh_addralign']
+                if alignment > pagesize:
+                    pagesize = alignment
+            if pagesize > 4096 and pagesize % 4096 > 0:
+                pagesize = (pagesize // 4096 + 1) * 4096
+                # I don't know how to test the pagesize; it might have issues
             for section in super().iter_sections():
                 if section.name not in ko_check_segments and \
                        not any(section.name.startswith(ko_check_segment) for ko_check_segment in ko_check_segments):
@@ -1285,23 +1293,25 @@ class ELF(ELFFile):
                         addr = 0
                     elif section.name.startswith(".note") :
                         text_filesz=self.get_section_by_name(".text")['sh_size']
-                        addr = (text_filesz//PAGESIZE + 1)*PAGESIZE + section['sh_offset'] - self.header['e_ehsize']
+                        addr = (text_filesz//pagesize + 1)*pagesize + section['sh_offset'] - self.header['e_ehsize']
+                        addr = (text_filesz//pagesize + 1)*pagesize + section['sh_offset'] - self.header['e_ehsize']
                     elif section.name.startswith(".rodata"):
                         text_filesz=self.get_section_by_name(".text")['sh_size']
                         text_offset=self.get_section_by_name(".text")['sh_offset']
-                        addr = (text_filesz//PAGESIZE + 1)*PAGESIZE + text_offset - self.header['e_ehsize']
+                        addr = (text_filesz//pagesize + 1)*pagesize + text_offset - self.header['e_ehsize']
                     elif section.name == ".data" :
                         text_filesz=self.get_section_by_name(".text")['sh_size']
                         rodata_filesz=0
-                        note_filez=0
+                        note_filesz=0
                         for section in super().iter_sections():
                             if section.name.startswith(".rodata"):
                                 rodata_filesz += section['sh_size']
                             elif section.name.startswith(".note"):
                                 note_filesz += section['sh_size']
-                        addr = (text_filesz//PAGESIZE + 1 + (note_filez+rodata_filesz)//PAGESIZE + 1)*PAGESIZE
+                        addr = (text_filesz // pagesize + 1 + (note_filesz + rodata_filesz) // pagesize + 1) * pagesize
                     yield (addr + offset + load_address_fixup)
                     offset += 1
+
     def offset_to_vaddr(self, offset):
         """offset_to_vaddr(offset) -> int
 


### PR DESCRIPTION
There are so many parts related to the elf header, so I just put it at the end of the search function, which would be awesome if you had a better way to handle it.

```bash
┌──(zt㉿pwntools)-[~/study/kernel/test-config]
└─$ cat t.py && python t.py
from pwn import ELF,asm
test=ELF("./rop.ko")
test_ret=test.search(asm("ret"))
print(hex(test_ret.__next__()))
print(hex(test_ret.__next__()))
print(hex(test_ret.__next__()))
print(hex(test_ret.__next__()))

[*] '/home/zt/study/kernel/test-config/rop.ko'
    Arch:       amd64-64-little
    RELRO:      No RELRO
    Stack:      No canary found
    NX:         NX enabled
    PIE:        No PIE (0x0)
    Stripped:   No
    Debuginfo:  Yes
0x13
0x33
0x5d
0x7a

┌──(zt㉿pwntools)-[~/study/kernel/test-config]
└─$ objdump -d ./rop.ko|grep 'ret'
  13:   c3                      ret
  33:   c3                      ret
  5d:   c3                      ret
  7a:   c3                      ret
```