### PR TITLE
fix fromsocket to deal with ipv6 socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,12 @@ The table below shows which release corresponds to each branch, and what date th
 [2435]: https://github.com/Gallopsled/pwntools/pull/2435
 [2437]: https://github.com/Gallopsled/pwntools/pull/2437
 
+## 4.13.2
+
+- [#2497][2497] Fix remote.fromsocket() to handle AF_INET6 socket
+
+[2497]: https://github.com/Gallopsled/pwntools/pull/2497
+
 ## 4.13.1 (`stable`)
 
 - [#2445][2445] Fix parsing the PLT on Windows

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -139,7 +139,7 @@ class remote(sock):
             Instance of pwnlib.tubes.remote.remote.
         """
         s = socket
-        host, port = s.getpeername()
+        host, port = s.getpeername()[:2]
         return remote(host, port, fam=s.family, typ=s.type, sock=s)
 
 class tcp(remote):

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -53,12 +53,12 @@ class remote(sock):
         >>> r = remote.fromsocket(s)
         >>> r.recvn(4)
         b'HTTP'
-        >>> s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        >>> s.connect(('2606:4700:4700::1111', 80))
-        >>> s.send(b'GET ' + b'\r\n'*2)
+        >>> s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM) #doctest: +SKIP
+        >>> s.connect(('2606:4700:4700::1111', 80)) #doctest: +SKIP
+        >>> s.send(b'GET ' + b'\r\n'*2) #doctest: +SKIP
         8
-        >>> r = remote.fromsocket(s)
-        >>> r.recvn(4)
+        >>> r = remote.fromsocket(s) #doctest: +SKIP
+        >>> r.recvn(4) #doctest: +SKIP
         b'HTTP'
     """
 

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -53,6 +53,13 @@ class remote(sock):
         >>> r = remote.fromsocket(s)
         >>> r.recvn(4)
         b'HTTP'
+        >>> s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        >>> s.connect(('2606:4700:4700::1111', 80))
+        >>> s.send(b'GET ' + b'\r\n'*2)
+        8
+        >>> r = remote.fromsocket(s)
+        >>> r.recvn(4)
+        b'HTTP'
     """
 
     def __init__(self, host, port,


### PR DESCRIPTION
For [AF_INET6](https://docs.python.org/3/library/socket.html#socket.AF_INET6) address family, getpeername will return a four-tuple, and throw exception. we only need the first two.