### PR TITLE
Fix loading ELF files without valid .dynamic section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2484][2484] Allow to disable caching
 - [#2291][2291] Fix attaching to a gdbserver with tuple `gdb.attach(('0.0.0.0',12345))`
 - [#2410][2410] Add `tube.upload_manually` to upload files in chunks
+- [#2502][2502] Fix loading ELF files without valid .dynamic section
 
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
@@ -100,6 +101,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2484]: https://github.com/Gallopsled/pwntools/pull/2484
 [2291]: https://github.com/Gallopsled/pwntools/pull/2291
 [2410]: https://github.com/Gallopsled/pwntools/pull/2410
+[2502]: https://github.com/Gallopsled/pwntools/pull/2502
 
 ## 4.14.0 (`beta`)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -52,6 +52,7 @@ from collections import namedtuple, defaultdict
 from elftools.elf.constants import P_FLAGS
 from elftools.elf.constants import SHN_INDICES
 from elftools.elf.descriptions import describe_e_type
+from elftools.elf.dynamic import DynamicSection
 from elftools.elf.elffile import ELFFile
 from elftools.elf.enums import ENUM_GNU_PROPERTY_X86_FEATURE_1_FLAGS
 from elftools.elf.gnuversions import GNUVerDefSection
@@ -1607,7 +1608,7 @@ class ELF(ELFFile):
         dt      = None
         dynamic = self.get_section_by_name('.dynamic')
 
-        if not dynamic:
+        if not dynamic or not isinstance(dynamic, DynamicSection):
             return None
 
         try:

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -294,6 +294,15 @@ def search_by_hash(search_target, search_type='build_id', unstrip=True, offline_
     return cache
 
 def _search_debuginfo_by_hash(base_url, hex_encoded_id):
+    """
+    Given a hex-encoded build_id, attempt to download a matching debuginfo from the debuginfod server.
+
+    >>> debuginfo_file = _search_debuginfo_by_hash(DEBUGINFOD_SERVERS[0], 'd1704d25fbbb72fa95d517b883131828c0883fe9')
+    >>> debuginfo_file is not None
+    True
+    >>> 'main_arena' in ELF(debuginfo_file).symbols
+    True
+    """
     # Deferred import because it's slow
     import requests
     from six.moves import urllib


### PR DESCRIPTION
This allows to load separate debuginfo files and access their symbols. The .dynamic section wasn't of type `SHT_DYNAMIC` for those files apparently.

Fixes #2489