### PR TITLE
Add `+LINUX` and `+WINDOWS` doctest options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,17 +296,17 @@ jobs:
       run: |
         python -bb -m coverage run -m sphinx -b doctest docs/source docs/build/doctest
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: coverage-windows
-        path: .coverage*
-        include-hidden-files: true
+    # FIXME: Paths are broken when uploading coverage on ubuntu
+    # coverage.exceptions.NoSource: No source for code: '/home/runner/work/pwntools/pwntools/D:\a\pwntools\pwntools\pwn\__init__.py'.
+    # - uses: actions/upload-artifact@v4
+    #   with:
+    #     name: coverage-windows
+    #     path: .coverage*
+    #     include-hidden-files: true
 
   upload-coverage:
     runs-on: ubuntu-latest
-    needs: 
-      - test
-      - windows-test
+    needs: test
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,14 +284,29 @@ jobs:
         pip install --upgrade pip
         pip install --upgrade --editable .
     
+    - name: Install documentation dependencies
+      run: pip install -r docs/requirements.txt
+    
     - name: Sanity checks
       run: |
         python -bb -c 'from pwn import *'
         python -bb examples/text.py
+    
+    - name: Coverage doctests
+      run: |
+        python -bb -m coverage run -m sphinx -b doctest docs/source docs/build/doctest
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: coverage-windows
+        path: .coverage*
+        include-hidden-files: true
 
   upload-coverage:
     runs-on: ubuntu-latest
-    needs: test
+    needs: 
+      - test
+      - windows-test
     steps:
     - uses: actions/checkout@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2507][2507] Add `+LINUX` and `+WINDOWS` doctest options and start proper testing on Windows
+
+[2507]: https://github.com/Gallopsled/pwntools/pull/2507
 
 ## 4.15.0 (`beta`)
 - [#2508][2508] Ignore a warning when compiling with asm on nix

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,6 +19,6 @@ psutil
 requests>=2.5.1
 ropgadget>=5.3
 sphinx==1.8.6; python_version<'3'
-sphinx>=7.0.0; python_version>='3'
+sphinx>=8.1.3, <9; python_version>='3'
 sphinx_rtd_theme
 sphinxcontrib-autoprogram<=0.1.5

--- a/docs/source/adb.rst
+++ b/docs/source/adb.rst
@@ -4,6 +4,9 @@
    from pwn import *
    adb = pwnlib.adb
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.adb` --- Android Debug Bridge
 =====================================================
 

--- a/docs/source/asm.rst
+++ b/docs/source/asm.rst
@@ -4,6 +4,9 @@
    import subprocess
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.asm` --- Assembler functions
 =========================================
 

--- a/docs/source/asm.rst
+++ b/docs/source/asm.rst
@@ -4,8 +4,9 @@
    import subprocess
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.asm` --- Assembler functions
 =========================================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -398,6 +398,11 @@ autodoc_default_options = {'special-members': None, 'private-members': None}
 
 class _DummyClass(object): pass
 
+# doctest optionflags for platform-specific tests
+# they are skipped on other platforms
+WINDOWS = doctest.register_optionflag('WINDOWS')
+LINUX = doctest.register_optionflag('LINUX')
+
 class Py2OutputChecker(_DummyClass, doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
         sup = super(Py2OutputChecker, self).check_output
@@ -425,6 +430,41 @@ class Py2OutputChecker(_DummyClass, doctest.OutputChecker):
                 return False
         return True
 
+import sphinx.ext.doctest
+
+class PlatformDocTestRunner(sphinx.ext.doctest.SphinxDocTestRunner):
+    def run(self, test, compileflags=None, out=None, clear_globs=True):
+        original_optionflags = self.optionflags | test.globs.get('doctest_additional_flags', 0)
+        def filter_platform(example):
+            optionflags = original_optionflags
+            if example.options:
+                for (optionflag, val) in example.options.items():
+                    if val:
+                        optionflags |= optionflag
+                    else:
+                        optionflags &= ~optionflag
+
+            if (optionflags & WINDOWS) == WINDOWS and sys.platform != 'win32':
+                return False
+            if (optionflags & LINUX) == LINUX and sys.platform != 'linux':
+                return False
+            return True
+                
+        test.examples[:] = [example for example in test.examples if filter_platform(example)]
+            
+        return super(PlatformDocTestRunner, self).run(test, compileflags, out, clear_globs)
+
+class PlatformDocTestBuilder(sphinx.ext.doctest.DocTestBuilder):
+    _test_runner = None
+
+    @property
+    def test_runner(self):
+        return self._test_runner
+    
+    @test_runner.setter
+    def test_runner(self, value):
+        self._test_runner = PlatformDocTestRunner(value._checker, value._verbose, value.optionflags)
+
 def py2_doctest_init(self, checker=None, verbose=None, optionflags=0):
     if checker is None:
         checker = Py2OutputChecker()
@@ -432,10 +472,10 @@ def py2_doctest_init(self, checker=None, verbose=None, optionflags=0):
 
 if 'doctest' in sys.argv:
     def setup(app):
-        pass # app.connect('autodoc-skip-member', dont_skip_any_doctests)
+        app.add_builder(PlatformDocTestBuilder, override=True)
+        # app.connect('autodoc-skip-member', dont_skip_any_doctests)
 
     if sys.version_info[:1] < (3,):
-        import sphinx.ext.doctest
         sphinx.ext.doctest.SphinxDocTestRunner.__init__ = py2_doctest_init
     else:
         # monkey patching paramiko due to https://github.com/paramiko/paramiko/pull/1661
@@ -444,8 +484,16 @@ if 'doctest' in sys.argv:
         paramiko.client.hexlify = lambda x: binascii.hexlify(x).decode()
         paramiko.util.safe_string = lambda x: '' # function result never *actually used*
     class EndlessLoop(Exception): pass
-    def alrm_handler(sig, frame):
-        signal.alarm(180) # three minutes
-        raise EndlessLoop()
-    signal.signal(signal.SIGALRM, alrm_handler)
-    signal.alarm(600) # ten minutes
+    if sys.platform == 'win32':
+        def alrm_handler():
+            raise EndlessLoop()
+        import threading
+        timer = threading.Timer(600, alrm_handler)
+        timer.daemon = True
+        timer.start()
+    else:
+        def alrm_handler(sig, frame):
+            signal.alarm(180) # three minutes
+            raise EndlessLoop()
+        signal.signal(signal.SIGALRM, alrm_handler)
+        signal.alarm(600) # ten minutes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -471,13 +471,13 @@ def py2_doctest_init(self, checker=None, verbose=None, optionflags=0):
     doctest.DocTestRunner.__init__(self, checker, verbose, optionflags)
 
 if 'doctest' in sys.argv:
-    def setup(app):
-        app.add_builder(PlatformDocTestBuilder, override=True)
-        # app.connect('autodoc-skip-member', dont_skip_any_doctests)
 
     if sys.version_info[:1] < (3,):
         sphinx.ext.doctest.SphinxDocTestRunner.__init__ = py2_doctest_init
     else:
+        def setup(app):
+            app.add_builder(PlatformDocTestBuilder, override=True)
+            # app.connect('autodoc-skip-member', dont_skip_any_doctests)
         # monkey patching paramiko due to https://github.com/paramiko/paramiko/pull/1661
         import paramiko.client
         import binascii

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -483,17 +483,24 @@ if 'doctest' in sys.argv:
         import binascii
         paramiko.client.hexlify = lambda x: binascii.hexlify(x).decode()
         paramiko.util.safe_string = lambda x: '' # function result never *actually used*
-    class EndlessLoop(Exception): pass
-    if sys.platform == 'win32':
-        def alrm_handler():
-            raise EndlessLoop()
-        import threading
-        timer = threading.Timer(600, alrm_handler)
+    class EndlessLoop(BaseException): pass
+    def sigabrt_handler(signum, frame):
+        raise EndlessLoop()
+    # thread.interrupt_main received the signum parameter in Python 3.10
+    if sys.version_info >= (3, 10):
+        signal.signal(signal.SIGABRT, sigabrt_handler)
+    def alrm_handler():
+        try:
+            import thread
+        except ImportError:
+            import _thread as thread
+        # pre Python 3.10 this raises a KeyboardInterrupt in the main thread.
+        # it might not show a traceback in that case, but it will stop the endless loop.
+        thread.interrupt_main(signal.SIGABRT)
+        timer = threading.Timer(interval=180, function=alrm_handler) # three minutes
         timer.daemon = True
         timer.start()
-    else:
-        def alrm_handler(sig, frame):
-            signal.alarm(180) # three minutes
-            raise EndlessLoop()
-        signal.signal(signal.SIGALRM, alrm_handler)
-        signal.alarm(600) # ten minutes
+    import threading
+    timer = threading.Timer(interval=600, function=alrm_handler) # ten minutes
+    timer.daemon = True
+    timer.start()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -489,24 +489,31 @@ if 'doctest' in sys.argv:
         import binascii
         paramiko.client.hexlify = lambda x: binascii.hexlify(x).decode()
         paramiko.util.safe_string = lambda x: '' # function result never *actually used*
-    class EndlessLoop(BaseException): pass
-    def sigabrt_handler(signum, frame):
-        raise EndlessLoop()
-    # thread.interrupt_main received the signum parameter in Python 3.10
-    if sys.version_info >= (3, 10):
-        signal.signal(signal.SIGABRT, sigabrt_handler)
-    def alrm_handler():
-        try:
-            import thread
-        except ImportError:
-            import _thread as thread
-        # pre Python 3.10 this raises a KeyboardInterrupt in the main thread.
-        # it might not show a traceback in that case, but it will stop the endless loop.
-        thread.interrupt_main(signal.SIGABRT)
-        timer = threading.Timer(interval=180, function=alrm_handler) # three minutes
+    class EndlessLoop(Exception): pass
+    if hasattr(signal, 'alarm'):
+        def alrm_handler(sig, frame):
+            signal.alarm(180) # three minutes
+            raise EndlessLoop()
+        signal.signal(signal.SIGALRM, alrm_handler)
+        signal.alarm(600) # ten minutes
+    else:
+        def sigabrt_handler(signum, frame):
+            raise EndlessLoop()
+        # thread.interrupt_main received the signum parameter in Python 3.10
+        if sys.version_info >= (3, 10):
+            signal.signal(signal.SIGABRT, sigabrt_handler)
+        def alrm_handler():
+            try:
+                import thread
+            except ImportError:
+                import _thread as thread
+            # pre Python 3.10 this raises a KeyboardInterrupt in the main thread.
+            # it might not show a traceback in that case, but it will stop the endless loop.
+            thread.interrupt_main(signal.SIGABRT)
+            timer = threading.Timer(interval=180, function=alrm_handler) # three minutes
+            timer.daemon = True
+            timer.start()
+        import threading
+        timer = threading.Timer(interval=600, function=alrm_handler) # ten minutes
         timer.daemon = True
         timer.start()
-    import threading
-    timer = threading.Timer(interval=600, function=alrm_handler) # ten minutes
-    timer.daemon = True
-    timer.start()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -402,6 +402,10 @@ class _DummyClass(object): pass
 # they are skipped on other platforms
 WINDOWS = doctest.register_optionflag('WINDOWS')
 LINUX = doctest.register_optionflag('LINUX')
+POSIX = doctest.register_optionflag('POSIX')
+
+# doctest optionflag for tests that haven't been looked at yet
+TODO = doctest.register_optionflag('TODO')
 
 class Py2OutputChecker(_DummyClass, doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
@@ -447,6 +451,8 @@ class PlatformDocTestRunner(sphinx.ext.doctest.SphinxDocTestRunner):
             if (optionflags & WINDOWS) == WINDOWS and sys.platform != 'win32':
                 return False
             if (optionflags & LINUX) == LINUX and sys.platform != 'linux':
+                return False
+            if (optionflags & POSIX) == POSIX and os.name != 'posix':
                 return False
             return True
                 

--- a/docs/source/elf/corefile.rst
+++ b/docs/source/elf/corefile.rst
@@ -18,6 +18,9 @@
    # Set the environment here so it's not in the middle of our tests.
    os.environ.setdefault('SHELL', '/bin/sh')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 
 :mod:`pwnlib.elf.corefile` --- Core Files
 ===========================================================

--- a/docs/source/elf/corefile.rst
+++ b/docs/source/elf/corefile.rst
@@ -19,7 +19,7 @@
    os.environ.setdefault('SHELL', '/bin/sh')
 
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 
 :mod:`pwnlib.elf.corefile` --- Core Files

--- a/docs/source/elf/elf.rst
+++ b/docs/source/elf/elf.rst
@@ -5,6 +5,9 @@
    from pwnlib.elf.maps import CAT_PROC_MAPS_EXIT
    import shutil
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.elf.elf` --- ELF Files
 ===========================================================
 

--- a/docs/source/elf/elf.rst
+++ b/docs/source/elf/elf.rst
@@ -5,8 +5,9 @@
    from pwnlib.elf.maps import CAT_PROC_MAPS_EXIT
    import shutil
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.elf.elf` --- ELF Files
 ===========================================================

--- a/docs/source/encoders.rst
+++ b/docs/source/encoders.rst
@@ -2,8 +2,9 @@
 
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
    
 :mod:`pwnlib.encoders` --- Encoding Shellcode
 ===============================================

--- a/docs/source/encoders.rst
+++ b/docs/source/encoders.rst
@@ -1,6 +1,9 @@
 .. testsetup:: *
 
    from pwn import *
+
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
    
 :mod:`pwnlib.encoders` --- Encoding Shellcode
 ===============================================

--- a/docs/source/filesystem.rst
+++ b/docs/source/filesystem.rst
@@ -6,6 +6,9 @@
     from pwnlib.tubes.ssh import ssh
     from pwnlib.filesystem import *
 
+    import doctest
+    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.filesystem` --- Manipulating Files Locally and Over SSH
 ====================================================================
 

--- a/docs/source/filesystem.rst
+++ b/docs/source/filesystem.rst
@@ -6,8 +6,9 @@
     from pwnlib.tubes.ssh import ssh
     from pwnlib.filesystem import *
 
+    # TODO: Remove global POSIX flag
     import doctest
-    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.filesystem` --- Manipulating Files Locally and Over SSH
 ====================================================================

--- a/docs/source/gdb.rst
+++ b/docs/source/gdb.rst
@@ -4,8 +4,9 @@
     context.arch = 'amd64'
     context.terminal = [os.path.join(os.path.dirname(pwnlib.__file__), 'gdb_faketerminal.py')]
 
+    # TODO: Test on cygwin too
     import doctest
-    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.gdb` --- Working with GDB
 ======================================

--- a/docs/source/gdb.rst
+++ b/docs/source/gdb.rst
@@ -4,6 +4,9 @@
     context.arch = 'amd64'
     context.terminal = [os.path.join(os.path.dirname(pwnlib.__file__), 'gdb_faketerminal.py')]
 
+    import doctest
+    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.gdb` --- Working with GDB
 ======================================
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -2,6 +2,9 @@
 
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 Getting Started
 ========================
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -3,7 +3,7 @@
    from pwn import *
 
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 Getting Started
 ========================

--- a/docs/source/libcdb.rst
+++ b/docs/source/libcdb.rst
@@ -3,6 +3,9 @@
    from pwn import *
    from pwnlib.libcdb import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.libcdb` --- Libc Database
 ===========================================
 

--- a/docs/source/libcdb.rst
+++ b/docs/source/libcdb.rst
@@ -3,8 +3,9 @@
    from pwn import *
    from pwnlib.libcdb import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.libcdb` --- Libc Database
 ===========================================

--- a/docs/source/qemu.rst
+++ b/docs/source/qemu.rst
@@ -2,8 +2,9 @@
 
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 
 :mod:`pwnlib.qemu` --- QEMU Utilities

--- a/docs/source/qemu.rst
+++ b/docs/source/qemu.rst
@@ -2,6 +2,9 @@
 
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 
 :mod:`pwnlib.qemu` --- QEMU Utilities
 ==========================================

--- a/docs/source/rop/rop.rst
+++ b/docs/source/rop/rop.rst
@@ -19,6 +19,9 @@
 
    context.clear()
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 
 :mod:`pwnlib.rop.rop` --- Return Oriented Programming
 ==========================================================

--- a/docs/source/rop/rop.rst
+++ b/docs/source/rop/rop.rst
@@ -19,6 +19,7 @@
 
    context.clear()
 
+   # TODO: Remove global LINUX flag
    import doctest
    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
 

--- a/docs/source/rop/srop.rst
+++ b/docs/source/rop/srop.rst
@@ -7,6 +7,9 @@
    from pwnlib.elf import ELF
    from pwnlib.tubes.process import process
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.rop.srop` --- Sigreturn Oriented Programming
 ==========================================================
 

--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -3,8 +3,9 @@
    from pwnlib.runner import *
    from pwnlib.asm import asm
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.runner` --- Running Shellcode
 ===========================================

--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -3,6 +3,9 @@
    from pwnlib.runner import *
    from pwnlib.asm import asm
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.runner` --- Running Shellcode
 ===========================================
 

--- a/docs/source/shellcraft.rst
+++ b/docs/source/shellcraft.rst
@@ -2,6 +2,9 @@
 
    from pwnlib import shellcraft
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft` --- Shellcode generation
 =================================================
 

--- a/docs/source/shellcraft.rst
+++ b/docs/source/shellcraft.rst
@@ -2,8 +2,9 @@
 
    from pwnlib import shellcraft
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.shellcraft` --- Shellcode generation
 =================================================

--- a/docs/source/shellcraft/aarch64.rst
+++ b/docs/source/shellcraft/aarch64.rst
@@ -3,6 +3,9 @@
    from pwn import *
    context.clear(arch='aarch64')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.aarch64` --- Shellcode for AArch64
 ===========================================================
 

--- a/docs/source/shellcraft/amd64.rst
+++ b/docs/source/shellcraft/amd64.rst
@@ -3,6 +3,9 @@
    from pwn import *
    context.clear(arch='amd64')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.amd64` --- Shellcode for AMD64
 ===========================================================
 

--- a/docs/source/shellcraft/amd64.rst
+++ b/docs/source/shellcraft/amd64.rst
@@ -3,6 +3,7 @@
    from pwn import *
    context.clear(arch='amd64')
 
+   # TODO: POSIX/WINDOWS shellcode test
    import doctest
    doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
 

--- a/docs/source/shellcraft/arm.rst
+++ b/docs/source/shellcraft/arm.rst
@@ -3,6 +3,9 @@
    from pwn import *
    context.clear(arch='arm')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.arm` --- Shellcode for ARM
 ===========================================================
 

--- a/docs/source/shellcraft/i386.rst
+++ b/docs/source/shellcraft/i386.rst
@@ -4,7 +4,7 @@
    context.clear(arch='i386')
 
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.shellcraft.i386` --- Shellcode for Intel 80386
 ===========================================================

--- a/docs/source/shellcraft/i386.rst
+++ b/docs/source/shellcraft/i386.rst
@@ -3,6 +3,9 @@
    from pwn import *
    context.clear(arch='i386')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.i386` --- Shellcode for Intel 80386
 ===========================================================
 

--- a/docs/source/shellcraft/mips.rst
+++ b/docs/source/shellcraft/mips.rst
@@ -12,6 +12,9 @@
 
    context.clear(arch='mips')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.mips` --- Shellcode for MIPS
 ===========================================================
 

--- a/docs/source/shellcraft/riscv64.rst
+++ b/docs/source/shellcraft/riscv64.rst
@@ -3,6 +3,9 @@
    from pwn import *
    context.clear(arch='riscv64')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.riscv64` --- Shellcode for RISCV64
 ==========================================================
 

--- a/docs/source/shellcraft/thumb.rst
+++ b/docs/source/shellcraft/thumb.rst
@@ -3,6 +3,9 @@
    from pwn import *
    context.clear(arch='thumb')
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.shellcraft.thumb` --- Shellcode for Thumb Mode
 ===========================================================
 

--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -2,8 +2,9 @@
 
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================

--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -2,6 +2,9 @@
 
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================
 

--- a/docs/source/tubes.rst
+++ b/docs/source/tubes.rst
@@ -2,10 +2,6 @@
 
    from pwn import *
 
-   # TODO: Remove global POSIX flag
-   import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
-
 :mod:`pwnlib.tubes` --- Talking to the World!
 =============================================
 

--- a/docs/source/tubes/buffer.rst
+++ b/docs/source/tubes/buffer.rst
@@ -2,10 +2,6 @@
 
    from pwnlib.tubes.buffer import *
 
-   # TODO: Remove global POSIX flag
-   import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
-
 :mod:`pwnlib.tubes.buffer` --- buffer implementation for tubes
 ==============================================================
 

--- a/docs/source/tubes/buffer.rst
+++ b/docs/source/tubes/buffer.rst
@@ -2,6 +2,9 @@
 
    from pwnlib.tubes.buffer import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.tubes.buffer` --- buffer implementation for tubes
 ==============================================================
 

--- a/docs/source/tubes/buffer.rst
+++ b/docs/source/tubes/buffer.rst
@@ -2,8 +2,9 @@
 
    from pwnlib.tubes.buffer import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.tubes.buffer` --- buffer implementation for tubes
 ==============================================================

--- a/docs/source/tubes/processes.rst
+++ b/docs/source/tubes/processes.rst
@@ -2,8 +2,9 @@
 
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.tubes.process` --- Processes
 ===========================================================

--- a/docs/source/tubes/processes.rst
+++ b/docs/source/tubes/processes.rst
@@ -2,6 +2,9 @@
 
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.tubes.process` --- Processes
 ===========================================================
 

--- a/docs/source/tubes/serial.rst
+++ b/docs/source/tubes/serial.rst
@@ -2,8 +2,9 @@
 
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.tubes.serialtube` --- Serial Ports
 ===========================================================

--- a/docs/source/tubes/serial.rst
+++ b/docs/source/tubes/serial.rst
@@ -2,6 +2,9 @@
 
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.tubes.serialtube` --- Serial Ports
 ===========================================================
 

--- a/docs/source/tubes/sockets.rst
+++ b/docs/source/tubes/sockets.rst
@@ -3,6 +3,9 @@
    from pwn import *
    from pwnlib.tubes.server import server
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.tubes.sock` --- Sockets
 ===========================================================
 

--- a/docs/source/tubes/sockets.rst
+++ b/docs/source/tubes/sockets.rst
@@ -3,10 +3,6 @@
    from pwn import *
    from pwnlib.tubes.server import server
 
-   # TODO: Remove global POSIX flag
-   import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
-
 :mod:`pwnlib.tubes.sock` --- Sockets
 ===========================================================
 

--- a/docs/source/tubes/sockets.rst
+++ b/docs/source/tubes/sockets.rst
@@ -3,8 +3,9 @@
    from pwn import *
    from pwnlib.tubes.server import server
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.tubes.sock` --- Sockets
 ===========================================================

--- a/docs/source/tubes/ssh.rst
+++ b/docs/source/tubes/ssh.rst
@@ -2,8 +2,9 @@
 
    from pwn import *
 
+   # TODO: Remove global POSIX flag
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.tubes.ssh` --- SSH
 ===========================================================

--- a/docs/source/tubes/ssh.rst
+++ b/docs/source/tubes/ssh.rst
@@ -2,6 +2,9 @@
 
    from pwn import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.tubes.ssh` --- SSH
 ===========================================================
 

--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -3,6 +3,9 @@
    from pwn import *
    import io
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.ui` --- Functions for user interaction
 ===================================================
 

--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -4,7 +4,7 @@
    import io
 
    import doctest
-   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['POSIX']
 
 :mod:`pwnlib.ui` --- Functions for user interaction
 ===================================================

--- a/docs/source/util/net.rst
+++ b/docs/source/util/net.rst
@@ -2,6 +2,9 @@
 
    from pwnlib.util.net import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.util.net` --- Networking interfaces
 ===================================================
 

--- a/docs/source/util/proc.rst
+++ b/docs/source/util/proc.rst
@@ -4,6 +4,9 @@
    from pwnlib.tubes.process import process
    import os, sys
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 
 :mod:`pwnlib.util.proc` --- Working with ``/proc/``
 ===================================================

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -310,7 +310,7 @@ class ContextType(object):
         32
 
     .. doctest::
-        :options: +LINUX
+        :options: +POSIX +TODO
 
         >>> def nop():
         ...   print(enhex(pwnlib.asm.asm('nop')))
@@ -875,7 +875,7 @@ class ContextType(object):
         Examples:
 
         .. doctest::
-            :options: +LINUX
+            :options: +POSIX +TODO
 
             >>> context.clear()
             >>> context.arch, context.bits
@@ -1412,7 +1412,7 @@ class ContextType(object):
             True
             >>> os.chmod(cache_dir, 0o000)
             >>> context.cache_dir = True
-            >>> context.cache_dir is None # doctest: +LINUX
+            >>> context.cache_dir is None # doctest: +POSIX +TODO
             True
             >>> os.chmod(cache_dir, 0o755)
             >>> cache_dir == context.cache_dir

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -324,7 +324,7 @@ class ContextType(object):
         >>> _=(thread.start(), thread.join())
         90
         >>> # Pwnthread uses the correct context from creation-time
-        >>> _=(pwnthread.start(), pwnthread.join())
+        >>> _=(pwnthread.start(), pwnthread.join()) # doctest: +LINUX
         00000000
         >>> nop()
         00f020e3
@@ -870,6 +870,9 @@ class ContextType(object):
 
         Examples:
 
+        .. doctest::
+            :options: +LINUX
+
             >>> context.clear()
             >>> context.arch, context.bits
             ('i386', 32)
@@ -1078,7 +1081,7 @@ class ContextType(object):
             >>> context.log_level = 'warn'
             >>> log.warn("Hello")
             [!] Hello
-            >>> context.log_console=open('/dev/null', 'w')
+            >>> context.log_console=open(os.devnull, 'w')
             >>> log.warn("Hello")
             >>> context.clear()
         """
@@ -1405,7 +1408,7 @@ class ContextType(object):
             True
             >>> os.chmod(cache_dir, 0o000)
             >>> context.cache_dir = True
-            >>> context.cache_dir is None
+            >>> context.cache_dir is None # doctest: +LINUX
             True
             >>> os.chmod(cache_dir, 0o755)
             >>> cache_dir == context.cache_dir

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -308,6 +308,10 @@ class ContextType(object):
         'little'
         >>> context.bits
         32
+
+    .. doctest::
+        :options: +LINUX
+
         >>> def nop():
         ...   print(enhex(pwnlib.asm.asm('nop')))
         >>> nop()
@@ -324,7 +328,7 @@ class ContextType(object):
         >>> _=(thread.start(), thread.join())
         90
         >>> # Pwnthread uses the correct context from creation-time
-        >>> _=(pwnthread.start(), pwnthread.join()) # doctest: +LINUX
+        >>> _=(pwnthread.start(), pwnthread.join())
         00000000
         >>> nop()
         00f020e3

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -34,7 +34,7 @@ Let's use this program as an example:
 We can automate the exploitation of the process like so:
 
 .. doctest::
-    :options: +LINUX
+    :options: +POSIX +TODO
 
     >>> program = pwnlib.data.elf.fmtstr.get('i386')
     >>> def exec_fmt(payload):

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -33,6 +33,9 @@ Let's use this program as an example:
 
 We can automate the exploitation of the process like so:
 
+.. doctest::
+    :options: +LINUX
+
     >>> program = pwnlib.data.elf.fmtstr.get('i386')
     >>> def exec_fmt(payload):
     ...     p = process(program)

--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -39,6 +39,9 @@ class MemLeak(object):
 
     Example:
 
+    .. doctest::
+        :options: +LINUX
+
         >>> import pwnlib
         >>> binsh = pwnlib.util.misc.read('/bin/sh')
         >>> @pwnlib.memleak.MemLeak

--- a/pwnlib/memleak.py
+++ b/pwnlib/memleak.py
@@ -40,7 +40,7 @@ class MemLeak(object):
     Example:
 
     .. doctest::
-        :options: +LINUX
+        :options: +POSIX +TODO
 
         >>> import pwnlib
         >>> binsh = pwnlib.util.misc.read('/bin/sh')

--- a/pwnlib/rop/ret2dlresolve.py
+++ b/pwnlib/rop/ret2dlresolve.py
@@ -32,9 +32,9 @@ We can automate the  process of exploitation with these some example binaries.
     0x0014:           0x2b84 [dlresolve index]
     0x0018:          b'gaaa' <return address>
     0x001c:        0x804ae24 arg0
-    >>> p = elf.process()
-    >>> p.sendline(fit({64+context.bytes*3: raw_rop, 200: dlresolve.payload}))
-    >>> p.recvline()
+    >>> p = elf.process() # doctest: +LINUX
+    >>> p.sendline(fit({64+context.bytes*3: raw_rop, 200: dlresolve.payload})) # doctest: +LINUX
+    >>> p.recvline() # doctest: +LINUX
     b'pwned\n'
 
 You can also use ``Ret2dlresolve`` on AMD64:
@@ -56,9 +56,9 @@ You can also use ``Ret2dlresolve`` on AMD64:
     0x0038:         0x601e48 [arg0] rdi = 6299208
     0x0040:         0x4003e0 [plt_init] system
     0x0048:          0x15670 [dlresolve index]
-    >>> p = elf.process()
-    >>> p.sendline(fit({64+context.bytes: raw_rop, 200: dlresolve.payload}))
-    >>> if dlresolve.unreliable:
+    >>> p = elf.process() # doctest: +LINUX
+    >>> p.sendline(fit({64+context.bytes: raw_rop, 200: dlresolve.payload})) # doctest: +LINUX
+    >>> if dlresolve.unreliable: # doctest: +LINUX
     ...     p.poll(True) == -signal.SIGSEGV
     ... else:
     ...     p.recvline() == b'pwned\n'

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -36,13 +36,16 @@ class listen(sock):
         >>> r.recvline()
         b'Hello\n'
 
-        >>> # It works with ipv4 by default
-        >>> l = listen()
-        >>> l.spawn_process('/bin/sh')
-        >>> r = remote('127.0.0.1', l.lport)
-        >>> r.sendline(b'echo Goodbye')
-        >>> r.recvline()
-        b'Goodbye\n'
+        .. doctest::
+            :options: +POSIX +TODO
+            
+            >>> # It works with ipv4 by default
+            >>> l = listen()
+            >>> l.spawn_process('/bin/sh')
+            >>> r = remote('127.0.0.1', l.lport)
+            >>> r.sendline(b'echo Goodbye')
+            >>> r.recvline()
+            b'Goodbye\n'
 
         >>> # and it works with ipv6 by defaut, too!
         >>> l = listen()

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1166,26 +1166,29 @@ class tube(Timeout, Logger):
 
         Examples:
 
-        >>> l = listen()
-        >>> l.spawn_process('/bin/sh')
-        >>> r = remote('127.0.0.1', l.lport)
-        >>> r.upload_manually(b'some\\xca\\xfedata\\n', prompt=b'', chmod_flags='')
-        >>> r.sendline(b'cat ./payload')
-        >>> r.recvline()
-        b'some\\xca\\xfedata\\n'
+        .. doctest::
+            :options: +POSIX +TODO
 
-        >>> r.upload_manually(cyclic(0x1000), target_path='./cyclic_pattern', prompt=b'', chunk_size=0x10, compression='gzip')
-        >>> r.sendline(b'sha256sum ./cyclic_pattern')
-        >>> r.recvlineS(keepends=False).startswith(sha256sumhex(cyclic(0x1000)))
-        True
+            >>> l = listen()
+            >>> l.spawn_process('/bin/sh')
+            >>> r = remote('127.0.0.1', l.lport)
+            >>> r.upload_manually(b'some\\xca\\xfedata\\n', prompt=b'', chmod_flags='')
+            >>> r.sendline(b'cat ./payload')
+            >>> r.recvline()
+            b'some\\xca\\xfedata\\n'
 
-        >>> blob = ELF.from_assembly(shellcraft.echo('Hello world!\\n') + shellcraft.exit(0))
-        >>> r.upload_manually(blob.data, prompt=b'')
-        >>> r.sendline(b'./payload')
-        >>> r.recvline()
-        b'Hello world!\\n'
-        >>> r.close()
-        >>> l.close()
+            >>> r.upload_manually(cyclic(0x1000), target_path='./cyclic_pattern', prompt=b'', chunk_size=0x10, compression='gzip')
+            >>> r.sendline(b'sha256sum ./cyclic_pattern')
+            >>> r.recvlineS(keepends=False).startswith(sha256sumhex(cyclic(0x1000)))
+            True
+
+            >>> blob = ELF.from_assembly(shellcraft.echo('Hello world!\\n') + shellcraft.exit(0))
+            >>> r.upload_manually(blob.data, prompt=b'')
+            >>> r.sendline(b'./payload')
+            >>> r.recvline()
+            b'Hello world!\\n'
+            >>> r.close()
+            >>> l.close()
         """
         echo_end = ""
         if not prompt:

--- a/pwnlib/util/iters.py
+++ b/pwnlib/util/iters.py
@@ -889,7 +889,7 @@ def mbruteforce(func, alphabet, length, method = 'upto', start = None, threads =
     Example:
 
     .. doctest::
-      :options: +LINUX
+      :options: +POSIX +TODO
 
       >>> mbruteforce(lambda x: x == 'hello', string.ascii_lowercase, length = 10)
       'hello'

--- a/pwnlib/util/iters.py
+++ b/pwnlib/util/iters.py
@@ -888,6 +888,9 @@ def mbruteforce(func, alphabet, length, method = 'upto', start = None, threads =
 
     Example:
 
+    .. doctest::
+      :options: +LINUX
+
       >>> mbruteforce(lambda x: x == 'hello', string.ascii_lowercase, length = 10)
       'hello'
       >>> mbruteforce(lambda x: x == 'hello', 'hlo', 5, 'downfrom') is None

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -123,7 +123,7 @@ def read(path, count=-1, skip=0):
 
     Examples:
 
-        >>> read('/proc/self/exe')[:4]
+        >>> read('/proc/self/exe')[:4] # doctest: +LINUX
         b'\x7fELF'
     """
     path = os.path.expanduser(os.path.expandvars(path))
@@ -163,8 +163,10 @@ def which(name, all = False, path=None):
 
     Example:
 
-        >>> which('sh') # doctest: +ELLIPSIS
+        >>> which('sh') # doctest: +ELLIPSIS +LINUX
         '.../bin/sh'
+        >>> which('cmd') # doctest: +ELLIPSIS +WINDOWS
+        '...\\cmd.EXE'
     """
     # If name is a path, do not attempt to resolve it.
     if os.path.sep in name:

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -123,7 +123,7 @@ def read(path, count=-1, skip=0):
 
     Examples:
 
-        >>> read('/proc/self/exe')[:4] # doctest: +LINUX
+        >>> read('/proc/self/exe')[:4] # doctest: +LINUX +TODO
         b'\x7fELF'
     """
     path = os.path.expanduser(os.path.expandvars(path))
@@ -163,7 +163,7 @@ def which(name, all = False, path=None):
 
     Example:
 
-        >>> which('sh') # doctest: +ELLIPSIS +LINUX
+        >>> which('sh') # doctest: +ELLIPSIS +POSIX +TODO
         '.../bin/sh'
     """
     # If name is a path, do not attempt to resolve it.

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -165,8 +165,6 @@ def which(name, all = False, path=None):
 
         >>> which('sh') # doctest: +ELLIPSIS +LINUX
         '.../bin/sh'
-        >>> which('cmd') # doctest: +ELLIPSIS +WINDOWS
-        '...\\cmd.EXE'
     """
     # If name is a path, do not attempt to resolve it.
     if os.path.sep in name:

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -990,7 +990,7 @@ def dd(dst, src, count = 0, skip = 0, seek = 0, truncate = False):
         ['H', 'e', 'l', 'l', 'o', b'?']
 
     .. doctest::
-        :options: +LINUX
+        :options: +POSIX +TODO
 
         >>> _ = open('/tmp/foo', 'w').write('A' * 10)
         >>> dd(open('/tmp/foo'), open('/dev/zero'), skip = 3, count = 4).read()

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -988,6 +988,10 @@ def dd(dst, src, count = 0, skip = 0, seek = 0, truncate = False):
         ('H', 'e', 'l', 'l', 'o', b'?')
         >>> dd(list('Hello!'), (63,), skip = 5)
         ['H', 'e', 'l', 'l', 'o', b'?']
+
+    .. doctest::
+        :options: +LINUX
+
         >>> _ = open('/tmp/foo', 'w').write('A' * 10)
         >>> dd(open('/tmp/foo'), open('/dev/zero'), skip = 3, count = 4).read()
         'AAA\\x00\\x00\\x00\\x00AAA'

--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -281,7 +281,7 @@ def test(original):
     r"""Tests the output provided by a shell interpreting a string
 
     .. doctest::
-        :options: +LINUX
+        :options: +POSIX
 
         >>> test(b'foobar')
         >>> test(b'foo bar')

--- a/pwnlib/util/sh_string.py
+++ b/pwnlib/util/sh_string.py
@@ -280,16 +280,19 @@ def test_all():
 def test(original):
     r"""Tests the output provided by a shell interpreting a string
 
-    >>> test(b'foobar')
-    >>> test(b'foo bar')
-    >>> test(b'foo bar\n')
-    >>> test(b"foo'bar")
-    >>> test(b"foo\\\\bar")
-    >>> test(b"foo\\\\'bar")
-    >>> test(b"foo\\x01'bar")
-    >>> test(b'\n')
-    >>> test(b'\xff')
-    >>> test(os.urandom(16 * 1024).replace(b'\x00', b''))
+    .. doctest::
+        :options: +LINUX
+
+        >>> test(b'foobar')
+        >>> test(b'foo bar')
+        >>> test(b'foo bar\n')
+        >>> test(b"foo'bar")
+        >>> test(b"foo\\\\bar")
+        >>> test(b"foo\\\\'bar")
+        >>> test(b"foo\\x01'bar")
+        >>> test(b'\n')
+        >>> test(b'\xff')
+        >>> test(os.urandom(16 * 1024).replace(b'\x00', b''))
     """
     input = sh_string(original)
 


### PR DESCRIPTION
This allows to selectively run tests only on a single platform. We can add `# doctest: +LINUX` comments to tests that cannot work on Windows and the other way around. I've noticed this pattern in the [ctypes docs](https://github.com/python/cpython/blob/b92f101d0f19a1df32050b8502cfcce777b079b2/Doc/library/ctypes.rst#accessing-functions-from-loaded-dlls) but couldn't find where they are evaluated. (Those options appear to have been there since the docs were initially imported into the repo for Python 2, but tests aren't run using doctest anymore for CPython)

To easily skip a lot of tests the `doctest_additional_flags` global variable can be defined in a `testsetup`.

This is achieved by monkey patching sphinx doctest's DocTestBuilder to use our own DocTestRunner which removes examples from the tests that have flags that don't match the platform we're running on. It's only implemented for Sphinx 8 on Python 3.

The goal is to reduce the amount of linux-only tests and add tests for the Windows specific features over time.