### PR TITLE
Ignore a warning with unused args in `asm` on NIX 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 4.15.0 (`dev`)
-
+- [#2508][2508] Ignore a warning when compiling with asm 
 - [#2471][2471] Properly close spawned kitty window
 - [#2358][2358] Cache output of `asm()`
 - [#2457][2457] Catch exception of non-ELF files in checksec.
@@ -90,6 +90,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2476][2476] Deprecate 'keepends' argument in favor of 'drop' in `tube.recvline*`
 - [#2364][2364] Deprecate direct commandline scripts invocation and exclude nonsense ones
 
+[2508]: https://github.com/Gallopsled/pwntools/pull/2508
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
 [2358]: https://github.com/Gallopsled/pwntools/pull/2358
 [2457]: https://github.com/Gallopsled/pwntools/pull/2457

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -471,6 +471,7 @@ def cpp(shellcode):
     code = _include_header() + shellcode
     cmd  = [
         cpp,
+        '-Wno-unused-command-line-argument',
         '-C',
         '-nostdinc',
         '-undef',


### PR DESCRIPTION
# Pwntools Pull Request

This pr ingores the '-Wunused-command-line-argument' warning from the cpp builtin. Since any warning in asm.py makes the process errror out, it makes using something like `asm(shellcraft.sh())` when on nix impossible. See log below
```
✦ ❯ cat log.txt                                                                                                                                                                                                                             
================================================================================                                                                                                                                                            
= Started at 2024-12-23T23:37:31                                               =                                                                                                                                                            
= sys.argv = [                                                                 =                                                                                                                                                            
=   'back_to_shell_sol.py',                                                    =                                                                                                                                                            
= ]                                                                            =                                                                                                                                                            
================================================================================                                                                                                                                                            
================================================================================                                                                                                                                                            
= Started at 2024-12-23T23:37:31                                               =                                                                                                                                                            
= sys.argv = [                                                                 =                                                                                                                                                            
=   'back_to_shell_sol.py',                                                    =                                                                                                                                                            
= ]                                                                            =                                                                                                                                                            
================================================================================                                                                                                                                                            
2024-12-23T23:37:31:INFO:pwnlib.tubes.process.process.140272202976464:Starting local process './back_to_shell' argv=[b'./back_to_shell']                                                                                                    
2024-12-23T23:37:31:INFO:pwnlib.tubes.process.process.140272202976464:Starting local process './back_to_shell' argv=[b'./back_to_shell'] : pid 181737                                                                                       
2024-12-23T23:37:31:DEBUG:pwnlib.tubes.process.process.140272202976464:Received 0xb bytes:                                                                                                                                                  
2024-12-23T23:37:31:DEBUG:pwnlib.tubes.process.process.140272202976464:b'Shellcode: '                                                                                                                                                       
2024-12-23T23:37:32:DEBUG:pwnlib.asm:cpp -C -nostdinc -undef -P -I/nix/store/lbajkkyhz123azc3d5yp0bbhz7bin6gr-python3.11-pwntools-4.12.0/lib/python3.11/site-packages/pwnlib/data/includes /dev/stdin                                       
2024-12-23T23:37:32:ERROR:pwnlib.asm:There was an error running ['cpp', '-C', '-nostdinc', '-undef', '-P', '-I/nix/store/lbajkkyhz123azc3d5yp0bbhz7bin6gr-python3.11-pwntools-4.12.0/lib/python3.11/site-packages/pwnlib/data/includes', '/d
ev/stdin']:                                                                                                                                                                                                                                 
It had this on stdout:                                                                                                                                                                                                                      
cpp: warning: -Wl,-dynamic-linker=/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib/ld-linux-x86-64.so.2: 'linker' input unused in cpp mode [-Wunused-command-line-argument]                                                    
cpp: warning: -Wl,-rpath: 'linker' input unused in cpp mode [-Wunused-command-line-argument]                                                                                                                                                
cpp: warning: -Wl,/var/home/sbancuz/dev/odc/outputs/out/lib: 'linker' input unused in cpp mode [-Wunused-command-line-argument]                                                                                                             
cpp: warning: argument unused during compilation: '-L/nix/store/1x81mi97ycg58d15n0zfz49qhysyh9gd-protobuf-24.4/lib' [-Wunused-command-line-argument]                                                                                        
cpp: warning: argument unused during compilation: '-L/nix/store/55lkzxlbg2qapz6z3nv590fjv5f0p7sh-abseil-cpp-20240116.2/lib' [-Wunused-command-line-argument]                                                                                
cpp: warning: argument unused during compilation: '-L/nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib' [-Wunused-command-line-argument]                                                                                       
cpp: warning: argument unused during compilation: '-L/nix/store/1x81mi97ycg58d15n0zfz49qhysyh9gd-protobuf-24.4/lib' [-Wunused-command-line-argument]                                                                                        
cpp: warning: argument unused during compilation: '-L/nix/store/55lkzxlbg2qapz6z3nv590fjv5f0p7sh-abseil-cpp-20240116.2/lib' [-Wunused-command-line-argument]                                                                                
cpp: warning: argument unused during compilation: '-L/nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib' [-Wunused-command-line-argument]                                                                                       
cpp: warning: argument unused during compilation: '-L/nix/store/1x81mi97ycg58d15n0zfz49qhysyh9gd-protobuf-24.4/lib' [-Wunused-command-line-argument]                                                                                        
cpp: warning: argument unused during compilation: '-L/nix/store/55lkzxlbg2qapz6z3nv590fjv5f0p7sh-abseil-cpp-20240116.2/lib' [-Wunused-command-line-argument]                                                                                
cpp: warning: argument unused during compilation: '-L/nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib' [-Wunused-command-line-argument]                                                                                       
cpp: warning: argument unused during compilation: '-L/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib' [-Wunused-command-line-argument]                                                                                        
cpp: warning: argument unused during compilation: '-L/nix/store/4krab2h0hd4wvxxmscxrw21pl77j4i7j-gcc-13.3.0/lib/gcc/x86_64-unknown-linux-gnu/13.3.0' [-Wunused-command-line-argument]                                                       
cpp: warning: argument unused during compilation: '-L/nix/store/ybjcla5bhj8g1y84998pn4a2drfxybkv-gcc-13.3.0-lib/lib' [-Wunused-command-line-argument]                                                                                       
cpp: warning: argument unused during compilation: '-L/nix/store/4krab2h0hd4wvxxmscxrw21pl77j4i7j-gcc-13.3.0//lib' [-Wunused-command-line-argument]                                                                                          
cpp: warning: argument unused during compilation: '-L/nix/store/j8rzqx7farv0w3isp9z943zy437zk02f-gcc-13.3.0-libgcc/lib' [-Wunused-command-line-argument]                                                                                    
cpp: warning: argument unused during compilation: '-L/nix/store/2j35g928qczhj13kfi7yxm09wg2jiv14-clang-18.1.8-lib/lib' [-Wunused-command-line-argument]                                                                                     
                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                            
================================================================================                                                                                                                                                            
= Started at 2024-12-23T23:37:32                                               =                                                                                                                                                            
= sys.argv = [                                                                 =                                                                                                                                                            
=   'back_to_shell_sol.py',                                                    =                                                                                                                                                            
= ]                                                                            =                                                                                                                                                            
================================================================================                                                                                                                                                            
2024-12-23T23:37:32:INFO:pwnlib.tubes.process.process.140272202976464:Stopped process './back_to_shell' (pid 181737)              
``` 

Since it's not an important warning I thought to just ignore it. This problem could happen on any system that wraps the `cpp` builtin in a weird way.

For now I'm targeting dev since it seems the most appropriate, but please tell me if I need to change it. 