### PR TITLE
fix: asm() using incorrect assembler for amd64 architecture

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -184,7 +184,7 @@ def which_binutils(util, check_version=False):
         'thumb':  ['arm',    'aarch64'],
         'i386':   ['x86_64', 'amd64'],
         'i686':   ['x86_64', 'amd64'],
-        'amd64':  ['x86_64', 'i386'],
+        'amd64':  ['x86_64', 'amd64'],
         'mips64': ['mips'],
         'powerpc64': ['powerpc'],
         'sparc64': ['sparc'],


### PR DESCRIPTION
I cannot find something like `i386-elf-as`, such as `x86_64-elf-as`, but `amd64` should just use `as` for the default assembler. This could fix [#2509](https://github.com/Gallopsled/pwntools/issues/2509).