### PR TITLE
ssh tube: replaced nonexistent key with str(e) in error handling method to get proper error message displayed in stacktrace

### DIFF
--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -450,7 +450,7 @@ class ssh_connecter(sock):
             try:
                 self.sock = parent.transport.open_channel('direct-tcpip', (host, port), ('127.0.0.1', 0))
             except Exception as e:
-                self.exception(e.message)
+                self.exception(str(e))
                 raise
 
             try:


### PR DESCRIPTION
When using gdb.debug with the ssh tube, exception message are not printed correctly, with the change the error message gets printed without triggering a second exception:

Current:
```py
 During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/findus/repos/pwncollege/program_security/shellcode_injection/./level13.py", line 35, in <module>
    p = gdb.debug(["sudo", "-u", "root", "/challenge/babyshell-level-13"], cwd='/', ssh=s)
  File "/usr/lib/python3.13/site-packages/pwnlib/context/__init__.py", line 1582, in setter
    return function(*a, **kw)
  File "/usr/lib/python3.13/site-packages/pwnlib/gdb.py", line 676, in debug
    port = _gdbserver_port(gdbserver, ssh)
  File "/usr/lib/python3.13/site-packages/pwnlib/gdb.py", line 391, in _gdbserver_port
    remote   = ssh.connect_remote('127.0.0.1', port)
  File "/usr/lib/python3.13/site-packages/pwnlib/tubes/ssh.py", line 1147, in connect_remote
    return ssh_connecter(self, host, port, timeout, level=self.level)
  File "/usr/lib/python3.13/site-packages/pwnlib/tubes/ssh.py", line 453, in __init__
    self.exception(e.message)
                   ^^^^^^^^^
AttributeError: 'ChannelException' object has no attribute 'message'

```

With Fix:

```py
[ERROR] ChannelException(1, 'Administratively prohibited')
    Traceback (most recent call last):
      File "/usr/lib/python3.13/site-packages/pwnlib/tubes/ssh.py", line 453, in __init__
        self.sock = parent.transport.open_channel('direct-tcpip', (host, port), ('127.0.0.1', 0))
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/paramiko/transport.py", line 1136, in open_channel
        raise e
    paramiko.ssh_exception.ChannelException: ChannelException(1, 'Administratively prohibited')
Traceback (most recent call last):
  File "/home/findus/repos/pwncollege/program_security/shellcode_injection/./level13.py", line 35, in <module>
    p = gdb.debug(args=["sudo", "-u", "root", "/challenge/babyshell-level-13"], cwd='/', ssh=s)
  File "/usr/lib/python3.13/site-packages/pwnlib/context/__init__.py", line 1582, in setter
    return function(*a, **kw)
  File "/usr/lib/python3.13/site-packages/pwnlib/gdb.py", line 676, in debug
    port = _gdbserver_port(gdbserver, ssh)
  File "/usr/lib/python3.13/site-packages/pwnlib/gdb.py", line 391, in _gdbserver_port
    remote   = ssh.connect_remote('127.0.0.1', port)
  File "/usr/lib/python3.13/site-packages/pwnlib/tubes/ssh.py", line 1150, in connect_remote
    return ssh_connecter(self, host, port, timeout, level=self.level)
  File "/usr/lib/python3.13/site-packages/pwnlib/tubes/ssh.py", line 456, in __init__
    self.exception(str(e))
    ~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.13/site-packages/pwnlib/tubes/ssh.py", line 453, in __init__
    self.sock = parent.transport.open_channel('direct-tcpip', (host, port), ('127.0.0.1', 0))
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/paramiko/transport.py", line 1136, in open_channel
    raise e
paramiko.ssh_exception.ChannelException: ChannelException(1, 'Administratively prohibited')
```

