### PR TITLE
Poll before reading /proc/maps in `process.libs()` to avoid race condition

### DIFF
--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -1323,7 +1323,7 @@ class process(tube):
         space.
         """
         from pwnlib.util.proc import memory_maps
-        maps_raw = memory_maps(self.pid)
+        maps_raw = self.poll() is not None and memory_maps(self.pid)
 
         if not maps_raw:
             import pwnlib.elf.elf


### PR DESCRIPTION
Try to avoid a race condition in the tests of reading memory maps before libraries are loaded.