### PR TITLE
fix: update apport coredump path handling for CorefileFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,8 +115,10 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.14.1
 
 - [#2533][2533] Fix installation on Python 3.5 and lower
+- [#2518][2518] fix: update apport coredump path handling for CorefileFinder
 
 [2533]: https://github.com/Gallopsled/pwntools/pull/2533
+[2518]: https://github.com/Gallopsled/pwntools/pull/2518
 
 ## 4.14.0 (`stable`)
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1512,7 +1512,15 @@ class CorefileFinder(object):
         boot_id = read('/proc/sys/kernel/random/boot_id').strip().decode()
 
         # Use the absolute path of the executable
-        # Apport uses the executable's pathname in the core filename
+        # Apport uses the executable's path to determine the core dump filename
+        #
+        # Reference source:
+        # https://github.com/canonical/apport/blob/4bbb179b8f92989bf7c1ee3692074f35d70ef3e8/data/apport#L110
+        # https://github.com/canonical/apport/blob/4bbb179b8f92989bf7c1ee3692074f35d70ef3e8/apport/fileutils.py#L599
+        #
+        # Apport calls `get_core_path` with `options.executable_path`, which corresponds to
+        # the executable's pathname, as specified by the `%E` placeholder
+        # in the core pattern (see `man core` and `apport --help`).
         path = os.path.abspath(self.exe).replace('/', '_').replace('.', '_')
 
         # Format the name

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1510,7 +1510,10 @@ class CorefileFinder(object):
         # should be unique enough that we can just glob.
 
         boot_id = read('/proc/sys/kernel/random/boot_id').strip().decode()
-        path = self.exe.replace('/', '_')
+
+        # Use the absolute path of the executable
+        # Apport uses the executable's pathname in the core filename
+        path = os.path.abspath(self.exe).replace('/', '_').replace('.', '_')
 
         # Format the name
         corefile_name = 'core.{path}.{uid}.{boot_id}.{pid}.*'.format(


### PR DESCRIPTION
Apport uses the executable's pathname in the core filename. This update modifies the implementation to use the absolute path of the executable and replace both `/` and `.` with `_` in the pathname to match apport's implementation.

Reference source:
https://github.com/canonical/apport/blob/4bbb179b8f92989bf7c1ee3692074f35d70ef3e8/data/apport#L110
https://github.com/canonical/apport/blob/4bbb179b8f92989bf7c1ee3692074f35d70ef3e8/apport/fileutils.py#L599

Apport calls `get_core_path` with `options.executable_path`, which corresponds to the executable's pathname, as specified by the `%E` placeholder in the core pattern (see `man core` and `apport --help`).

