### PR TITLE
Support starting a kitty debugging window with the 'kitten' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,9 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 5.0.0 (`dev`)
+- [#2522][2522] Support starting a kitty debugging window with the 'kitten' command
 
+[2522]: https://github.com/Gallopsled/pwntools/pull/2522
 
 ## 4.15.0 (`beta`)
 - [#2508][2508] Ignore a warning when compiling with asm on nix

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -450,12 +450,10 @@ end tell
     log.debug("Launching a new terminal: %r" % argv)
 
     stdin = stdout = stderr = open(os.devnull, 'r+b')
-    if terminal == 'tmux' or terminal == 'kitty':
+    if terminal == 'tmux' or terminal in ('kitty', 'kitten'):
         stdout = subprocess.PIPE
 
     p = subprocess.Popen(argv, stdin=stdin, stdout=stdout, stderr=stderr, preexec_fn=preexec_fn)
-
-    kittyid = None
 
     if terminal == 'tmux':
         out, _ = p.communicate()
@@ -469,7 +467,7 @@ end tell
         with subprocess.Popen((qdbus, konsole_dbus_service, '/Sessions/{}'.format(last_konsole_session),
                                'org.kde.konsole.Session.processId'), stdout=subprocess.PIPE) as proc:
             pid = int(proc.communicate()[0].decode())
-    elif terminal == 'kitty':
+    elif terminal in ('kitty', 'kitten'):
         pid = p.pid
         
         out, _ = p.communicate()
@@ -503,7 +501,7 @@ end tell
             try:
                 if terminal == 'qdbus':
                     os.kill(pid, signal.SIGHUP)
-                elif terminal == 'kitty':
+                elif terminal in ('kitty', 'kitten'):
                     subprocess.Popen(["kitten", "@", "close-window", "--match", "id:{}".format(kittyid)], stderr=stderr)
                 else:
                     os.kill(pid, signal.SIGTERM)


### PR DESCRIPTION
Support starting a kitty debugging window with the 'kitten' command. Essentially while doing this works:
```python
context.terminal = "kitty @ launch --location=before --cwd=current --bias=65".split()
```
it is deprecated, and one should do this:
```python
context.terminal = "kitten @ launch --location=before --cwd=current --bias=65".split()
```

P.S. I'm no longer encountering this issue: https://github.com/Gallopsled/pwntools/pull/2471#issuecomment-2377396539