### PR TITLE
Allow setting debugger path via `context.gdb_binary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 5.0.0 (`dev`)
-
+- [#2527][2527] Allow setting debugger path via `context.gdb_binary`
 
 ## 4.15.0 (`beta`)
 - [#2508][2508] Ignore a warning when compiling with asm on nix

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -359,6 +359,7 @@ class ContextType(object):
         'encoding': 'auto',
         'endian': 'little',
         'gdbinit': "",
+        'gdb_binary': "",
         'kernel': None,
         'local_libcdb': "/var/lib/libc-database",
         'log_level': logging.INFO,
@@ -1534,6 +1535,20 @@ class ContextType(object):
         the necessary requirements for the gdbinit.
 
         If set to an empty string, GDB will use the default `~/.gdbinit`.
+
+        Default value is ``""``.
+        """
+        return str(value)
+
+    @_validator
+    def gdb_binary(self, value):
+        """Path to the binary that is used when running GDB locally.
+
+        This is useful when you have multiple versions of gdb installed or the gdb binary is
+        called something different.
+
+        If set to an empty string, pwntools will try to search for a reasonable gdb binary from 
+        the path.
 
         Default value is ``""``.
         """

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -750,6 +750,12 @@ def binary():
         >>> gdb.binary() # doctest: +SKIP
         '/usr/bin/gdb'
     """
+    if context.gdb_binary:
+        gdb = misc.which(context.gdb_binary)
+        if not gdb:
+            log.warn_once('Path to gdb binary `{}` not found'.format(context.gdb_binary))
+        return gdb
+
     gdb = misc.which('pwntools-gdb') or misc.which('gdb')
 
     if not context.native:


### PR DESCRIPTION
Allow customization of gdb binary path via `context.gdb_binary`.

Closes https://github.com/Gallopsled/pwntools/issues/2520