### PR TITLE
Fix installation on Python 3.5 and lower on stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,12 @@ The table below shows which release corresponds to each branch, and what date th
 [2476]: https://github.com/Gallopsled/pwntools/pull/2476
 [2364]: https://github.com/Gallopsled/pwntools/pull/2364
 
+## 4.14.1
+
+- [#2533][2533] Fix installation on Python 3.5 and lower
+
+[2533]: https://github.com/Gallopsled/pwntools/pull/2533
+
 ## 4.14.0 (`stable`)
 
 - [#2356][2356] Add local libc database provider for libcdb

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -8,6 +8,7 @@ import os
 import time
 import six
 import tempfile
+import sys
 
 from pwnlib.context import context
 from pwnlib.elf import ELF
@@ -419,7 +420,7 @@ def _extract_tarfile(cache_dir, data_filename, tarball):
 
 def _extract_debfile(cache_dir, package_filename, package):
     # Extract data.tar in the .deb archive.
-    if six.PY2:
+    if sys.version_info < (3, 6):
         if not which('ar'):
             log.error('Missing command line tool "ar" to extract .deb archive. Please install "ar" first.')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "colored_traceback<0.4; python_version < '3'",
     "colored_traceback; python_version >= '3'",
     "pathlib2; python_version < '3.4'",
-    "unix-ar; python_version >= '3'",
+    "unix-ar; python_version >= '3.6'",
     "zstandard",
 ]
 


### PR DESCRIPTION
The unix-ar package requires Python 3.6. Only install it on Python 3.6 then and use the Python 2 fallback for Python <= 3.5 too.

When bumping the supported Python version for Pwntoosl v5, let's keep v4 installable on any earlier Python version.