### PR TITLE
Docker: Don't upgrade pip anymore and --break-system-packages

### DIFF
--- a/extra/docker/base/Dockerfile
+++ b/extra/docker/base/Dockerfile
@@ -38,8 +38,7 @@ RUN apt-get update \
         patchelf \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
-    && python3 -m pip install --no-cache-dir --upgrade pip \
-    && python3 -m pip install --no-cache-dir --upgrade pwntools \
+    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade pwntools \
     && PWNLIB_NOTERM=1 pwn update \
     && useradd -m pwntools \
     && passwd --delete --unlock pwntools \

--- a/extra/docker/beta/Dockerfile
+++ b/extra/docker/beta/Dockerfile
@@ -1,6 +1,6 @@
 FROM pwntools/pwntools:stable
 
 USER root
-RUN python3 -m pip install --no-cache-dir --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@beta
+RUN python3 -m pip uninstall --break-system-packages -q -y pwntools && python3 -m pip install --no-cache-dir --break-system-packages --upgrade git+https://github.com/Gallopsled/pwntools@beta
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/extra/docker/dev/Dockerfile
+++ b/extra/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM pwntools/pwntools:stable
 
 USER root
-RUN python3 -m pip install --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@dev
+RUN python3 -m pip uninstall --break-system-packages -q -y pwntools && python3 -m pip install --no-cache-dir --break-system-packages --upgrade git+https://github.com/Gallopsled/pwntools@dev
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/extra/docker/develop/Dockerfile
+++ b/extra/docker/develop/Dockerfile
@@ -5,7 +5,7 @@ ENV HISTFILE=/home/pwntools/.history
 
 # Uninstall existing versions of pwntools
 USER root
-RUN python3 -m pip uninstall -q -y pwntools
+RUN python3 -m pip uninstall --break-system-packages -q -y pwntools
 
 # Switch back to the pwntools user from here forward
 USER pwntools
@@ -17,14 +17,14 @@ ENV PATH="/home/pwntools/.local/bin:${PATH}"
 
 # Install Pwntools to the home directory, make it an editable install
 RUN git clone https://github.com/Gallopsled/pwntools \
- && python3 -m pip install --upgrade --editable pwntools \
+ && python3 -m pip install --break-system-packages --upgrade --editable pwntools \
  && PWNLIB_NOTERM=1 pwn version
 
 # Requirements for running the tests
-RUN python3 -m pip install --upgrade --requirement pwntools/docs/requirements.txt
+RUN python3 -m pip install --break-system-packages --upgrade --requirement pwntools/docs/requirements.txt
 
 # Python niceties for debugging
-RUN python3 -m pip install -U ipython ipdb
+RUN python3 -m pip install --break-system-packages -U ipython ipdb
 
 # Dependencies from .travis.yml addons -> apt -> packages
 ARG DEBIAN_FRONTEND=noninteractive

--- a/extra/docker/stable/Dockerfile
+++ b/extra/docker/stable/Dockerfile
@@ -1,6 +1,6 @@
 FROM pwntools/pwntools:base
 
 USER root
-RUN python3 -m pip install --no-cache-dir --force-reinstall --upgrade git+https://github.com/Gallopsled/pwntools@stable
+RUN python3 -m pip uninstall --break-system-packages -q -y pwntools && python3 -m pip install --no-cache-dir --break-system-packages --upgrade git+https://github.com/Gallopsled/pwntools@stable
 RUN PWNLIB_NOTERM=1 pwn update
 USER pwntools

--- a/travis/docker/Dockerfile
+++ b/travis/docker/Dockerfile
@@ -5,7 +5,7 @@ ENV HISTFILE=/home/pwntools/.history
 
 # Uninstall existing versions of pwntools
 USER root
-RUN python3 -m pip uninstall -q -y pwntools
+RUN python3 -m pip uninstall --break-system-packages -q -y pwntools
 
 # Switch back to the pwntools user from here forward
 USER pwntools
@@ -17,14 +17,14 @@ ENV PATH="/home/pwntools/.local/bin:${PATH}"
 
 # Install Pwntools to the home directory, make it an editable install
 RUN git clone https://github.com/Gallopsled/pwntools \
- && python3 -m pip install --upgrade --editable pwntools \
+ && python3 -m pip install --break-system-packages --upgrade --editable pwntools \
  && PWNLIB_NOTERM=1 pwn version
 
 # Requirements for running the tests
-RUN python3 -m pip install --upgrade --requirement pwntools/docs/requirements.txt
+RUN python3 -m pip install --break-system-packages --upgrade --requirement pwntools/docs/requirements.txt
 
 # Python niceties for debugging
-RUN python3 -m pip install -U ipython ipdb
+RUN python3 -m pip install --break-system-packages -U ipython ipdb
 
 # Dependencies from .travis.yml addons -> apt -> packages
 ARG DEBIAN_FRONTEND=noninteractive
@@ -80,10 +80,6 @@ ADD ipython_config.py  /home/pwntools/.ipython/profile_default
 
 # Do not require password for sudo
 RUN echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/travis
-
-# Some additional debugging tools that are useful
-RUN python3 -m pip install --no-cache-dir ipdb
-
 # Install debugging utilities
 USER root
 RUN apt-get -y install gdb gdbserver tmux gdb-multiarch

--- a/travis/docker/Dockerfile.travis
+++ b/travis/docker/Dockerfile.travis
@@ -1,7 +1,3 @@
-
-# Some additional debugging tools that are useful
-RUN python3 -m pip install --no-cache-dir ipdb
-
 # Install debugging utilities
 USER root
 RUN apt-get -y install gdb gdbserver tmux gdb-multiarch


### PR DESCRIPTION
The Docker images don't build anymore after switching to ubuntu 24.04 as a base image in #2529.
Pip doesn't have a RECORD file anymore and fails to uninstall / upgrade on latest Ubuntu now. pip --force-reinstall on pwntools causes pip to upgrade too since it's in our dependencies, which fails too. As a workaround uninstall pwntools manually before upgrading.

Should we switch to a venv in the docker file? It might become annoying when having to remember to activate it, but maybe we can add it to the PATH so new processes always use the venv too?