### PR TITLE
Enable bit-manipulation extensions to RISC-V

### DIFF
--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -274,8 +274,8 @@ def _assembler():
         'ia64':    [gas, '-m%ce' % context.endianness[0]],
 
         # riscv64-unknown-elf-as supports riscv32 as well as riscv64
-        'riscv32': [gas, '-march=rv32gc_zba_zbb_zbc_zbs', '-mabi=ilp32'],
-        'riscv64': [gas, '-march=rv64gc_zba_zbb_zbc_zbs', '-mabi=lp64'],
+        'riscv32': [gas, '-march=rv32gcv_zba_zbb_zbs', '-mabi=ilp32'],
+        'riscv64': [gas, '-march=rv64gcv_zba_zbb_zbs', '-mabi=lp64'],
 
         # loongarch64 supports none of -64, -EB, -EL or -march
         'loongarch64'  : [gas],

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -274,8 +274,8 @@ def _assembler():
         'ia64':    [gas, '-m%ce' % context.endianness[0]],
 
         # riscv64-unknown-elf-as supports riscv32 as well as riscv64
-        'riscv32': [gas, '-march=rv32gc', '-mabi=ilp32'],
-        'riscv64': [gas, '-march=rv64gc', '-mabi=lp64'],
+        'riscv32': [gas, '-march=rv32gc_zba_zbb_zbc_zbs', '-mabi=ilp32'],
+        'riscv64': [gas, '-march=rv64gc_zba_zbb_zbc_zbs', '-mabi=lp64'],
 
         # loongarch64 supports none of -64, -EB, -EL or -march
         'loongarch64'  : [gas],


### PR DESCRIPTION
In reference to #2539, this PR enables certain RISC-V ISA extensions in assembly passed to the `asm` function in pwntools. It simply adds the `zba`, `zbb`, `zbc`, and `zbs` extension strings to CLI arguments passed to the assembler.

There is a long list of other ISA extensions outlined in this doc - https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html, but these 4 were chosen purely because they are general purpose and I happened to have run into them (many of the other ones are related to increasing performance of cryptographic functions or are SIMD-related).

The original issue mentions the possibility of exposing more functionality in the `asm()` function to allow the user to have more control over the assembler/compile process. In this case, as mentioned by @Arusekk in #2539, this is not needed. Currently, examples of where this would be nice don't immediately come to mind.