### PR TITLE
SSH: fix download/upload with -1 exit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2545][2545] SSH: fix download/upload with -1 exit status
 - [#2551][2551] Detect when kitty is being used as terminal
 - [#2519][2519] Drop Python 2.7 support / Require Python 3.10
 - [#2507][2507] Add `+LINUX` and `+WINDOWS` doctest options and start proper testing on Windows

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1359,7 +1359,11 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             update(len(data), total)
 
         result = c.wait()
-        if result != 0:
+
+        if result == -1:
+            self.warn_once("Could not verify success of file download %r, no error code" % (remote))
+
+        if result != 0 and result != -1:
             h.failure('Could not download file %r (%r)' % (remote, result))
             return
 
@@ -1539,7 +1543,11 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             s.shutdown('send')
             data   = s.recvall()
             result = s.wait()
-            if result != 0:
+
+            if result == -1:
+                self.warn_once("Could not verify success of file upload %r, no error code" % (remote))
+
+            if result != 0 and result != -1:
                 self.error("Could not upload file %r (%r)\n%s" % (remote, result, data))
 
     def upload_file(self, filename, remote = None):


### PR DESCRIPTION
# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.

The `paramiko` `recv_exit_status` function returns -1 is no return code is received, this can happen because the ssh server did not send an `exit-status` request.
The [RFC 4254](https://datatracker.ietf.org/doc/html/rfc4254#section-6.10) states this request is recommended but not required, so an SSH Server would be working correctly but the upload and download functions of pwntools would fail. 

I'm not sure if you consider this a bug and against which branch you want this targeted.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
