### PR TITLE
ssh: Allow passing `disabled_algorithms` keyword argument from `ssh` to paramiko

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2529][2529] Add LoongArch64 support
 - [#2506][2506] ROP: fix `ROP(ELF(exe)).leave` is `None` in some ELF
 - [#2504][2504] doc: add example case for `tuple` (host, port pair) in `gdb.attach`
+- [#2546][2546] ssh: Allow passing disabled_algorithms keyword argument from ssh to paramiko
 
 [2519]: https://github.com/Gallopsled/pwntools/pull/2519
 [2507]: https://github.com/Gallopsled/pwntools/pull/2507
@@ -97,6 +98,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2529]: https://github.com/Gallopsled/pwntools/pull/2529
 [2506]: https://github.com/Gallopsled/pwntools/pull/2506
 [2504]: https://github.com/Gallopsled/pwntools/pull/2504
+[2546]: https://github.com/Gallopsled/pwntools/pull/2546
 
 ## 4.15.0 (`beta`)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,7 +266,7 @@ latex_documents = [
 ]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
-                       'paramiko': ('https://docs.paramiko.org/en/2.1/', None)}
+                       'paramiko': ('https://docs.paramiko.org/en/stable/', None)}
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -574,7 +574,7 @@ class ssh(Timeout, Logger):
     def __init__(self, user=None, host=None, port=22, password=None, key=None,
                  keyfile=None, proxy_command=None, proxy_sock=None, level=None,
                  cache=True, ssh_agent=False, ignore_config=False, raw=False, 
-                 auth_none=False, *a, **kw):
+                 auth_none=False, disabled_algorithms=None, *a, **kw):
         """Creates a new ssh connection.
 
         Arguments:
@@ -593,6 +593,7 @@ class ssh(Timeout, Logger):
             ignore_config(bool): If :const:`True`, disable usage of ~/.ssh/config and ~/.ssh/authorized_keys
             raw(bool): If :const:`True`, assume a non-standard shell and don't probe the environment
             auth_none(bool): If :const:`True`, try to authenticate with no authentication methods
+            disabled_algorithms(dict): Mapping of algorithm type and list of algorithms identifier to disable. Passed directly to paramiko.
 
         NOTE: The proxy_command and proxy_sock arguments is only available if a
         fairly new version of paramiko is used.
@@ -682,7 +683,7 @@ class ssh(Timeout, Logger):
                 proxy_sock = None
 
             try:
-                self.client.connect(host, port, user, password, key, keyfiles, self.timeout, allow_agent=ssh_agent, compress=True, sock=proxy_sock, look_for_keys=not ignore_config)
+                self.client.connect(host, port, user, password, key, keyfiles, self.timeout, allow_agent=ssh_agent, compress=True, sock=proxy_sock, look_for_keys=not ignore_config, disabled_algorithms=disabled_algorithms)
             except paramiko.BadHostKeyException as e:
                 self.error("Remote host %(host)s is using a different key than stated in known_hosts\n"
                            "    To remove the existing entry from your known_hosts and trust the new key, run the following commands:\n"

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -593,7 +593,9 @@ class ssh(Timeout, Logger):
             ignore_config(bool): If :const:`True`, disable usage of ~/.ssh/config and ~/.ssh/authorized_keys
             raw(bool): If :const:`True`, assume a non-standard shell and don't probe the environment
             auth_none(bool): If :const:`True`, try to authenticate with no authentication methods
-            disabled_algorithms(dict): Mapping of algorithm type and list of algorithms identifier to disable. Passed directly to paramiko.
+            disabled_algorithms(dict):
+                Mapping of algorithm type and list of algorithm identifiers to disable.
+                See :class:`paramiko.transport.Transport` for more information.
 
         NOTE: The proxy_command and proxy_sock arguments is only available if a
         fairly new version of paramiko is used.


### PR DESCRIPTION
in order to connect to older/non standard ssh servers using newer versions of paramiko, we need to disable newer algorithms.

```
    s = ssh(
        ...
        disabled_algorithms={"pubkeys": ["rsa-sha2-512", "rsa-sha2-256"]}
    )
```

see https://www.paramiko.org/changelog.html#2.9.0