### PR TITLE
Default to `checksec=False` on ELF class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2549][2549] `checksec` argument of `ELF` class now defaults to `False`.
 - [#2519][2519] Drop Python 2.7 support / Require Python 3.10
 - [#2507][2507] Add `+LINUX` and `+WINDOWS` doctest options and start proper testing on Windows
 - [#2522][2522] Support starting a kitty debugging window with the 'kitten' command
@@ -86,6 +87,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2506][2506] ROP: fix `ROP(ELF(exe)).leave` is `None` in some ELF
 - [#2504][2504] doc: add example case for `tuple` (host, port pair) in `gdb.attach`
 
+[2549]: https://github.com/Gallopsled/pwntools/pull/2549
 [2519]: https://github.com/Gallopsled/pwntools/pull/2519
 [2507]: https://github.com/Gallopsled/pwntools/pull/2507
 [2522]: https://github.com/Gallopsled/pwntools/pull/2522

--- a/pwnlib/commandline/checksec.py
+++ b/pwnlib/commandline/checksec.py
@@ -34,7 +34,7 @@ def main(args):
 
     for f in files:
         try:
-            e = ELF(f)
+            e = ELF(f, checksec=True)
         except Exception as e:
             print("{name}: {error}".format(name=f, error=e))
 

--- a/pwnlib/commandline/debug.py
+++ b/pwnlib/commandline/debug.py
@@ -61,7 +61,7 @@ def main(args):
 
     if args.executable:
         if os.path.exists(args.executable):
-            context.binary = ELF(args.executable)
+            context.binary = ELF(args.executable) # ???
             target = context.binary.path
 
         # This path does nothing, but avoids the "print_usage()"

--- a/pwnlib/commandline/disablenx.py
+++ b/pwnlib/commandline/disablenx.py
@@ -19,9 +19,9 @@ parser.add_argument(
 
 def main(args):
     for f in args.elf:
-        e = ELF(f.name)
+        e = ELF(f.name, checksec=True)
         e.disable_nx()
-        ELF(e.path)
+        ELF(e.path, checksec=True)
 
 if __name__ == '__main__':
     pwnlib.commandline.common.main(__file__, main)

--- a/pwnlib/commandline/elfpatch.py
+++ b/pwnlib/commandline/elfpatch.py
@@ -27,9 +27,7 @@ def main(a):
     offset = int(a.offset, 16)
     bytes  = unhex(a.bytes)
 
-    with context.silent:
-        elf    = ELF(a.elf)
-
+    elf    = ELF(a.elf, checksec=False)
     elf.write(offset, bytes)
     getattr(sys.stdout, 'buffer', sys.stdout).write(elf.get_data())
 

--- a/pwnlib/commandline/pwnstrip.py
+++ b/pwnlib/commandline/pwnstrip.py
@@ -27,7 +27,7 @@ def main(args):
         sys.stderr.write(p.format_usage())
         sys.exit(0)
 
-    elf = ELF(args.file.name)
+    elf = ELF(args.file.name, checksec=True)
     context.clear(arch=elf.arch)
 
     if args.build_id:

--- a/pwnlib/dynelf.py
+++ b/pwnlib/dynelf.py
@@ -173,6 +173,7 @@ class DynELF(object):
                 path = elf.path
 
             # Load a fresh copy of the ELF
+            # why suppress log ?
             with context.local(log_level='error'):
                 w = self.waitfor("Loading from %r" % path)
                 self.elf = ELF(path)
@@ -573,6 +574,7 @@ class DynELF(object):
                 log.info("Trying lookup based on Build ID: %s", build_id)
                 path = libcdb.search_by_build_id(build_id)
                 if path:
+                    # why suppress log ?
                     with context.local(log_level='error'):
                         e = ELF(path)
                         e.address = dynlib.libbase

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -212,7 +212,7 @@ class ELF(ELFFile):
     _fill_gaps = True
 
 
-    def __init__(self, path, checksec=True):
+    def __init__(self, path, checksec=False):
         # elftools uses the backing file for all reads and writes
         # in order to permit writing without being able to write to disk,
         # mmap() the file.

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -476,10 +476,8 @@ class process(tube):
         binfmt helpers installed for QEMU.
         """
         # Get the ELF binary for the target executable
-        with context.quiet:
-            # XXX: Cyclic imports :(
-            from pwnlib.elf import ELF
-            binary = ELF(self.executable)
+        from pwnlib.elf import ELF
+        binary = ELF(self.executable)
 
         # If we're on macOS, this will never work.  Bail now.
         # if platform.mac_ver()[0]:
@@ -892,7 +890,7 @@ class process(tube):
         """maps() -> [mapping]
 
         Returns a list of process mappings.
-        
+
         A mapping object has the following fields:
             addr, address (addr alias), start (addr alias), end, size, perms, path, rss, pss, shared_clean, shared_dirty, private_clean, private_dirty, referenced, anonymous, swap
 
@@ -900,7 +898,7 @@ class process(tube):
             read, write, execute, private, shared, string
 
         Example:
-      
+
             >>> p = process(['cat'])
             >>> p.sendline(b"meow")
             >>> p.recvline()
@@ -937,8 +935,8 @@ class process(tube):
             pmmap_ext = namedtuple(
                 'pmmap_ext', 'addr perms ' + ' '.join(pmmap_grouped._fields))
 
-            
-        Here is an example of a pmmap_ext entry: 
+
+        Here is an example of a pmmap_ext entry:
 
         .. code-block:: python
 
@@ -946,7 +944,7 @@ class process(tube):
         """
 
         permissions = namedtuple("permissions", "read write execute private shared string")
-        mapping = namedtuple("mapping", 
+        mapping = namedtuple("mapping",
             "addr address start end size perms path rss pss shared_clean shared_dirty private_clean private_dirty referenced anonymous swap")
         # addr = address (alias) = start (alias)
 
@@ -976,11 +974,11 @@ class process(tube):
             single(bool=True): Whether to only return the first
                 mapping matched, or all of them.
 
-        Returns found mapping(s) in process memory according to 
+        Returns found mapping(s) in process memory according to
         path_value.
 
         Example:
-            
+
             >>> p = process(['cat'])
             >>> mapping = p.get_mapping('[stack]')
             >>> mapping.path == '[stack]'
@@ -1039,7 +1037,7 @@ class process(tube):
 
         """
         return self.get_mapping('[stack]', single)
-    
+
     def heap_mapping(self, single=True):
         """heap_mapping(single=True) -> mapping
         heap_mapping(False) -> [mapping]
@@ -1071,7 +1069,7 @@ class process(tube):
 
         """
         return self.get_mapping('[heap]', single)
-    
+
     def vdso_mapping(self, single=True):
         """vdso_mapping(single=True) -> mapping
         vdso_mapping(False) -> [mapping]
@@ -1100,7 +1098,7 @@ class process(tube):
 
         """
         return self.get_mapping('[vdso]', single)
-    
+
     def vvar_mapping(self, single=True):
         """vvar_mapping(single=True) -> mapping
         vvar_mapping(False) -> [mapping]
@@ -1129,7 +1127,7 @@ class process(tube):
 
         """
         return self.get_mapping('[vvar]', single)
-    
+
     def libc_mapping(self, single=True):
         """libc_mapping(single=True) -> mapping
         libc_mapping(False) -> [mapping]
@@ -1139,7 +1137,7 @@ class process(tube):
                 mapping matched, or all of them.
 
         Returns either the first libc mapping found in process memory,
-        or all libc mappings, depending on "single". 
+        or all libc mappings, depending on "single".
 
         Example:
 
@@ -1183,7 +1181,7 @@ class process(tube):
             if 'libc.so' in lib_basename or ('libc-' in lib_basename and '.so' in lib_basename):
                 l_mappings.append(mapping)
         return l_mappings
-    
+
     def musl_mapping(self, single=True):
         """musl_mapping(single=True) -> mapping
         musl_mapping(False) -> [mapping]
@@ -1193,7 +1191,7 @@ class process(tube):
                 mapping matched, or all of them.
 
         Returns either the first musl mapping found in process memory,
-        or all musl mappings, depending on "single". 
+        or all musl mappings, depending on "single".
         """
         all_maps = self.maps()
 
@@ -1203,14 +1201,14 @@ class process(tube):
                 if 'musl.so' in lib_basename or ('musl-' in lib_basename and '.so' in lib_basename):
                     return mapping
             return None
-        
+
         m_mappings = []
         for mapping in all_maps:
             lib_basename = os.path.basename(mapping.path)
             if 'musl.so' in lib_basename or ('musl-' in lib_basename and '.so' in lib_basename):
                 m_mappings.append(mapping)
         return m_mappings
-    
+
     def elf_mapping(self, single=True):
         """elf_mapping(single=True) -> mapping
         elf_mapping(False) -> [mapping]
@@ -1274,10 +1272,10 @@ class process(tube):
 
         # Expecting this to be sorted
         lib_mappings = self.get_mapping(path_value, single=False)
-        
+
         if len(lib_mappings) == 0:
             return 0
-    
+
         is_contiguous = True
         total_size = lib_mappings[0].size
         for i in range(1, len(lib_mappings)):
@@ -1293,7 +1291,7 @@ class process(tube):
 
     def address_mapping(self, address):
         """address_mapping(address) -> mapping
-        
+
         Returns the mapping at the specified address.
 
         Example:
@@ -1333,10 +1331,8 @@ class process(tube):
         maps_raw = self.poll() is not None and memory_maps(self.pid)
 
         if not maps_raw:
-            import pwnlib.elf.elf
-
-            with context.quiet:
-                return pwnlib.elf.elf.ELF(self.executable).maps
+            from pwnlib.elf import ELF
+            return ELF(self.executable, checksec=False).maps
 
         # Enumerate all of the libraries actually loaded right now.
         maps = {}
@@ -1358,7 +1354,7 @@ class process(tube):
         return maps
 
     @property
-    def libc(self):
+    def libc(self, checksec=False):
         """libc() -> ELF
 
         Returns an ELF for the libc for the current process.
@@ -1378,7 +1374,7 @@ class process(tube):
         for lib, address in self.libs().items():
             lib_basename = os.path.basename(lib)
             if 'libc.so' in lib_basename or ('libc-' in lib_basename and '.so' in lib_basename):
-                e = ELF(lib)
+                e = ELF(lib, checksec)
                 e.address = address
                 return e
 
@@ -1388,8 +1384,8 @@ class process(tube):
 
         Returns an ELF file for the executable that launched the process.
         """
-        import pwnlib.elf.elf
-        return pwnlib.elf.elf.ELF(self.executable)
+        from pwnlib.elf import ELF
+        return ELF(self.executable)
 
     @property
     def corefile(self):
@@ -1479,7 +1475,7 @@ class process(tube):
             data(bytes): Data to write to the address
 
         Example:
-        
+
             Let's write data to  the beginning of the mapped memory of the  ELF.
 
             >>> context.clear(arch='i386')

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -350,7 +350,7 @@ class ssh_process(ssh_channel):
 
         for lib, address in self.libs().items():
             if 'libc.so' in lib:
-                e = ELF(lib)
+                e = ELF(lib, checksec=True)
                 e.address = address
                 return e
 
@@ -360,14 +360,14 @@ class ssh_process(ssh_channel):
 
         Returns an ELF file for the executable that launched the process.
         """
-        import pwnlib.elf.elf
+        from pwnlib.elf import ELF
 
         libs = self.parent.libs(self.executable)
 
         for lib in libs:
             # Cannot just check "executable in lib", see issue #1047
             if lib.endswith(self.executable):
-                return pwnlib.elf.elf.ELF(lib)
+                return ELF(lib, checksec=True)
 
 
     @property


### PR DESCRIPTION
There is no need to print checksec details every time. Most usecases only need to view checksec once in a while.
~~Even the [default template][1] uses `checksec=False` which might reflect the expected default value of that argument.~~
Edit: I misread the code.

[1]: https://github.com/Gallopsled/pwntools/blob/f6f278be1788cfda7caa430e69084cc5ba9d61b4/pwnlib/data/templates/pwnup.mako

Here is the `checksec=False` set in callsites before this patch:

```
> rg '\sELF\(' | rg checksec
pwnlib/libcdb.py:    local_libc = ELF(shell_path, checksec=False).libc
pwnlib/libcdb.py:    libc = ELF(filename, checksec=False)
pwnlib/libcdb.py:        >>> libc_path = ELF(which('ls'), checksec=False).libc.path
pwnlib/libcdb.py:    libc = ELF(libc_path, checksec=False)
pwnlib/elf/elf.py:                return ELF(lib, self._print_checksec)
pwnlib/elf/elf.py:        return ELF(exepath, checksec=False)
pwnlib/elf/elf.py:        return ELF(exepath, checksec=False)
pwnlib/commandline/libcdb.py:            exe = ELF(path, checksec=False)
pwnlib/commandline/checksec.py:            e = ELF(f)
pwnlib/data/templates/pwnup.mako:       ctx.binary = ELF(binary, checksec=False)
```

## Testing

Lines end with `# ???` or `# XXX` are the ones I'm not sure about. Please take a careful review.