### PR TITLE
Detect when kitty is being used as terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2551][2551] Detect when kitty is being used as terminal
 - [#2519][2519] Drop Python 2.7 support / Require Python 3.10
 - [#2507][2507] Add `+LINUX` and `+WINDOWS` doctest options and start proper testing on Windows
 - [#2522][2522] Support starting a kitty debugging window with the 'kitten' command
@@ -86,6 +87,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2506][2506] ROP: fix `ROP(ELF(exe)).leave` is `None` in some ELF
 - [#2504][2504] doc: add example case for `tuple` (host, port pair) in `gdb.attach`
 
+[2551]: https://github.com/Gallopsled/pwntools/pull/2551
 [2519]: https://github.com/Gallopsled/pwntools/pull/2519
 [2507]: https://github.com/Gallopsled/pwntools/pull/2507
 [2522]: https://github.com/Gallopsled/pwntools/pull/2522

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -327,6 +327,9 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
         elif 'DISPLAY' in os.environ and which('x-terminal-emulator'):
             terminal = 'x-terminal-emulator'
             args     = ['-e']
+        elif 'KITTY_PID' in os.environ and which('kitty') and which('kitten'):
+            terminal = 'kitten'
+            args = ['@', 'launch']
         elif 'KONSOLE_VERSION' in os.environ and which('qdbus'):
             qdbus = which('qdbus')
             window_id = os.environ['WINDOWID']


### PR DESCRIPTION
Not having to specify `context.terminal` leads to more portable exploit scripts :D