### PR TITLE
Fix syntax highlighting of multiline comments in ASM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,10 +117,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2533][2533] Fix installation on Python 3.5 and lower
 - [#2518][2518] fix: update apport coredump path handling for CorefileFinder
 - [#2559][2559] Fix parsing corefile with missing auxv
+- [#2562][2562] Fix syntax highlighting of multiline comments in ASM
 
 [2533]: https://github.com/Gallopsled/pwntools/pull/2533
 [2518]: https://github.com/Gallopsled/pwntools/pull/2518
 [2559]: https://github.com/Gallopsled/pwntools/pull/2559
+[2562]: https://github.com/Gallopsled/pwntools/pull/2562
 
 ## 4.14.0
 

--- a/pwnlib/lexer.py
+++ b/pwnlib/lexer.py
@@ -95,7 +95,7 @@ class PwntoolsLexer(RegexLexer):
         'whitespace': [
             (r'\n', Text),
             (r'\s+', Text),
-            (r'/\*.*?\*/', Comment),
+            (r'(?ms)/\*.*?\*/', Comment),
             (r';.*$', Comment)
         ],
         'punctuation': [


### PR DESCRIPTION
Enable DOT_ALL next to the default MULTILINE regex flags to match newlines too with the `.*?`.
```
/* this works */
/*
this is not highlighted as a comment
*/
```

![grafik](https://github.com/user-attachments/assets/268492b9-906a-4505-a962-67669376594f)
