### PR TITLE
Fix invalid parsing of loader error message in elf.libc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,8 +144,10 @@ The table below shows which release corresponds to each branch, and what date th
 ## 4.14.2
 
 - [#2545][2545] SSH: fix download/upload with -1 exit status
+- [#2567][2567] Fix mistakenly parsing of ld-linux error messages.
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
+[2567]: https://github.com/Gallopsled/pwntools/pull/2567
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -841,6 +841,11 @@ class ELF(ELFFile):
             log.warn_once("Injected /proc/self/maps code did not execute correctly")
             return {}
 
+        # Sometimes the original binary already fail to run, for example, in case glibc mismatches.
+        if 'not found (required by' in data:
+            log.warn_once("Cannot execute `%s` to get /proc/self/maps", self.path)
+            return {}
+
         # Swap in the original ELF name
         data = data.replace(path, self.path)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -842,7 +842,9 @@ class ELF(ELFFile):
             return {}
 
         # Sometimes the original binary already fail to run, for example, in case glibc mismatches.
-        if 'not found (required by' in data:
+        try:
+            int(data.split('-', 1)[0], 16)
+        except ValueError:
             log.warn_once("Cannot execute `%s` to get /proc/self/maps", self.path)
             return {}
 


### PR DESCRIPTION
For example, on my machine:

```
> ./main
./main: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by ./main)
```
