### PR TITLE
Add automatic detection of statically linked binaries in `detect_missing_binaries` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2502][2502] Fix loading ELF files without valid .dynamic section
 - [#2476][2476] Deprecate 'keepends' argument in favor of 'drop' in `tube.recvline*`
 - [#2364][2364] Deprecate direct commandline scripts invocation and exclude nonsense ones
+- [#2570][2570] Fix `pwn template` to skip Docker library extraction for statically linked binaries
 
 [2508]: https://github.com/Gallopsled/pwntools/pull/2508
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
@@ -140,6 +141,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2502]: https://github.com/Gallopsled/pwntools/pull/2502
 [2476]: https://github.com/Gallopsled/pwntools/pull/2476
 [2364]: https://github.com/Gallopsled/pwntools/pull/2364
+[2570]: https://github.com/Gallopsled/pwntools/pull/2570
 
 ## 4.14.2
 

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -126,25 +126,6 @@ def detect_missing_binaries(args):
         
     Returns:
         tuple: A pair of (executable_path, libc_path) where either may be None if not found.
-    
-    Example:
-        >>> import argparse
-        >>> # Mock args
-        >>> args = argparse.Namespace()
-        >>> args.exe = 'static_binary'
-        >>> args.libc = None
-        >>> # Mock ELF class
-        >>> from pwnlib.elf.elf import ELF
-        >>> orig_init = ELF.__init__
-        >>> def mock_init(self, *args, **kwargs):
-        ...     self.statically_linked = True
-        ...     self.path = args[0]
-        >>> ELF.__init__ = mock_init
-        >>> # For testing purposes, just verify the function exists
-        >>> 'detect_missing_binaries' in globals()
-        True
-        >>> # Restore original ELF.__init__
-        >>> ELF.__init__ = orig_init
     """
     log.info("Automatically detecting challenge binaries...")
     # look for challenge binary, libc, and ld in current directory

--- a/pwnlib/commandline/template.py
+++ b/pwnlib/commandline/template.py
@@ -115,6 +115,37 @@ def get_docker_image_libraries():
     return libc_basename, ld_basename
 
 def detect_missing_binaries(args):
+    """Automatically detects challenge binaries and libraries in the current directory.
+    
+    This function scans the current directory for executable files, libc, and ld libraries.
+    If a Dockerfile is present and no libraries are found, it attempts to extract them from
+    the Docker image, but only if the binary is not statically linked.
+    
+    Args:
+        args: Argument namespace containing exe and libc attributes.
+        
+    Returns:
+        tuple: A pair of (executable_path, libc_path) where either may be None if not found.
+    
+    Example:
+        >>> import argparse
+        >>> # Mock args
+        >>> args = argparse.Namespace()
+        >>> args.exe = 'static_binary'
+        >>> args.libc = None
+        >>> # Mock ELF class
+        >>> from pwnlib.elf.elf import ELF
+        >>> orig_init = ELF.__init__
+        >>> def mock_init(self, *args, **kwargs):
+        ...     self.statically_linked = True
+        ...     self.path = args[0]
+        >>> ELF.__init__ = mock_init
+        >>> # For testing purposes, just verify the function exists
+        >>> 'detect_missing_binaries' in globals()
+        True
+        >>> # Restore original ELF.__init__
+        >>> ELF.__init__ = orig_init
+    """
     log.info("Automatically detecting challenge binaries...")
     # look for challenge binary, libc, and ld in current directory
     exe, libc, ld = args.exe, args.libc, None
@@ -138,7 +169,19 @@ def detect_missing_binaries(args):
         elif len(other_files) > 1:
             log.warning("Failed to find challenge binary. There are multiple binaries in the current directory: %s", other_files)
     
-    if has_dockerfile and exe and not (libc or ld): 
+    # Check if the binary is statically linked before trying to extract libraries from Docker
+    is_statically_linked = False
+    if exe:
+        try:
+            binary = ELF(exe, checksec=False)
+            is_statically_linked = binary.statically_linked
+            if is_statically_linked:
+                log.info("Binary is statically linked, no need for external libraries")
+        except Exception as e:
+            log.warning("Could not check if binary is statically linked: %s", e)
+    
+    # Only extract libraries from Docker if the binary is not statically linked
+    if has_dockerfile and exe and not (libc or ld) and not is_statically_linked: 
         libc, ld = get_docker_image_libraries()
 
     if exe != args.exe:


### PR DESCRIPTION
Fixes #2561 

This change improves the behavior of the pwn template command when working with statically linked binaries that have an accompanying Dockerfile. Previously, when a statically linked binary was present alongside a Dockerfile, pwn template would unnecessarily extract libc and ld libraries from the Docker image. This was redundant and potentially confusing, as statically linked binaries don't require external libraries to run.

The fix adds a check in the `detect_missing_binaries` function to:
1. Detect if the binary is statically linked by examining its ELF properties
2. Skip the Docker library extraction step for statically linked binaries
3. Log an informative message to the user explaining that external libraries aren't needed

## Target Branch
- Dev
