### PR TITLE
Enhance CI script to check for core file generation and improve logging in corefile extraction process.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,21 @@ jobs:
         ulimit -c unlimited
         cat /proc/sys/kernel/core_pattern
         cat /proc/sys/kernel/core_uses_pid
-        ( cd $(mktemp -d); sh -c 'kill -11 $$' || true; ls -la ./*core* /var/crash/*.crash /var/lib/apport/coredump/core*) || true
+        # Create a temporary directory for the test
+        TEST_DIR=$(mktemp -d)
+        cd $TEST_DIR
+        
+        # Run a command that will generate a segfault
+        sh -c 'kill -11 $$' || true
+        
+        # Check for core files in various locations
+        echo "Looking for core files in various locations:"
+        if ls -la ./*core* /var/crash/*.crash /var/lib/apport/coredump/core* 2>/dev/null; then
+          echo "SUCCESS: Core file found"
+        else
+          echo "ERROR: No core file found"
+          exit 1
+        fi
 
     - name: Set up SSH
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2504][2504] doc: add example case for `tuple` (host, port pair) in `gdb.attach`
 - [#2546][2546] ssh: Allow passing disabled_algorithms keyword argument from ssh to paramiko
 - [#2538][2538] Add `ssh -L` / `ssh.connect_remote()` workaround when `AllowTcpForwarding` is disabled
+- [#2571][2571] Improve CI test for core file generation to fail if no core file is found
+- [#2571][2571] Add better logging for systemd-coredump extraction in CorefileFinder
 
 [2551]: https://github.com/Gallopsled/pwntools/pull/2551
 [2519]: https://github.com/Gallopsled/pwntools/pull/2519
@@ -104,6 +106,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2504]: https://github.com/Gallopsled/pwntools/pull/2504
 [2546]: https://github.com/Gallopsled/pwntools/pull/2546
 [2538]: https://github.com/Gallopsled/pwntools/pull/2538
+[2571]: https://github.com/Gallopsled/pwntools/pull/2571
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -1351,6 +1351,7 @@ class CorefileFinder(object):
         """
         filename = "core.%s.%i.coredumpctl" % (self.basename, self.pid)
         try:
+            log.debug("Attempting to extract core dump with coredumpctl for PID %d" % self.pid)
             subprocess.check_call(
                 [
                     "coredumpctl",
@@ -1363,9 +1364,12 @@ class CorefileFinder(object):
                 stderr=subprocess.STDOUT,
                 shell=False,
             )
+            log.debug("Successfully extracted core dump to %s" % filename)
             return filename
         except subprocess.CalledProcessError as e:
             log.debug("coredumpctl failed with status: %d" % e.returncode)
+        except Exception as e:
+            log.debug("coredumpctl failed with exception: %s" % e)
 
     def native_corefile(self):
         """Find the corefile for a native crash.


### PR DESCRIPTION
This pull request enhances the core file testing in the CI workflow to properly validate that pwntools can handle core dumps. It addresses two key issues:

- CI Test Improvement: The original test would run regardless of whether a core file was actually generated. The updated test now fails explicitly if no core file is found in any of the expected locations. This ensures that the CI properly validates the core file handling functionality.
- Better Debugging: Added more detailed logging to the `systemd_coredump_corefile` method in `corefile.py` to provide better diagnostics when core file extraction fails. This will make it easier to troubleshoot issues with core file handling in different environments.
These changes will help ensure that the core file handling functionality in `pwntools` (including the `systemd-coredump` support added in PR #1181) works correctly and is properly tested in the CI pipeline.

## Target Branch
- Dev