### PR TITLE
Add gnome-terminal, Alacritty, Ttilix for run_in_new_terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2538][2538] Add `ssh -L` / `ssh.connect_remote()` workaround when `AllowTcpForwarding` is disabled
 - [#2574][2574] Allow creating an ELF from in-memory bytes
 - [#2575][2575] Detect when Terminator is being used as terminal
-- [#2578][2578] Add gnome-terminal for run_in_new_terminal
+- [#2578][2578] Add gnome-terminal, Alacritty, Ttilix for run_in_new_terminal
 
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
 [2551]: https://github.com/Gallopsled/pwntools/pull/2551

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2538][2538] Add `ssh -L` / `ssh.connect_remote()` workaround when `AllowTcpForwarding` is disabled
 - [#2574][2574] Allow creating an ELF from in-memory bytes
 - [#2575][2575] Detect when Terminator is being used as terminal
+- [#2578][2578] Add gnome-terminal for run_in_new_terminal
 
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
 [2551]: https://github.com/Gallopsled/pwntools/pull/2551
@@ -110,6 +111,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2538]: https://github.com/Gallopsled/pwntools/pull/2538
 [2574]: https://github.com/Gallopsled/pwntools/pull/2574
 [2575]: https://github.com/Gallopsled/pwntools/pull/2575
+[2578]: https://github.com/Gallopsled/pwntools/pull/2578
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -338,7 +338,10 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
                 args = ['-e']
         elif "GNOME_TERMINAL_SCREEN" in os.environ and "GNOME_TERMINAL_SERVICE" in os.environ and which("gnome-terminal"):
             terminal = 'gnome-terminal'
-            args = ['-e']
+            args     = ['-e']
+        elif "ALACRITTY_SOCKET" in os.environ and "ALACRITTY_WINDOW_ID" in os.environ and which("alacritty"):
+            terminal = 'alacritty'
+            args     = ['-e']
         elif 'KONSOLE_VERSION' in os.environ and which('qdbus'):
             qdbus = which('qdbus')
             window_id = os.environ['WINDOWID']

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -336,6 +336,9 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
             else:
                 terminal = 'terminator'
                 args = ['-e']
+        elif os.environ.get("XDG_CURRENT_DESKTOP") == "GNOME" and which("gnome-terminal"):
+            terminal = 'gnome-terminal'
+            args = ['-e']
         elif 'KONSOLE_VERSION' in os.environ and which('qdbus'):
             qdbus = which('qdbus')
             window_id = os.environ['WINDOWID']

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -342,6 +342,9 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
         elif "ALACRITTY_SOCKET" in os.environ and "ALACRITTY_WINDOW_ID" in os.environ and which("alacritty"):
             terminal = 'alacritty'
             args     = ['-e']
+        elif "TILIX_ID" in os.environ and which("tilix"):
+            terminal = "tilix"
+            args     = ['-a', 'session-add-right', '-e']
         elif 'KONSOLE_VERSION' in os.environ and which('qdbus'):
             qdbus = which('qdbus')
             window_id = os.environ['WINDOWID']

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -336,7 +336,7 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
             else:
                 terminal = 'terminator'
                 args = ['-e']
-        elif os.environ.get("XDG_CURRENT_DESKTOP") == "GNOME" and which("gnome-terminal"):
+        elif "GNOME_TERMINAL_SCREEN" in os.environ and "GNOME_TERMINAL_SERVICE" in os.environ and which("gnome-terminal"):
             terminal = 'gnome-terminal'
             args = ['-e']
         elif 'KONSOLE_VERSION' in os.environ and which('qdbus'):


### PR DESCRIPTION
I am using gnome-terminal.
```
➜  ~ gnome-terminal --version
# GNOME Terminal 3.56.0 using VTE 0.80.0 +BIDI +GNUTLS +ICU +SYSTEMD
```
The error log is as follows.
```
(.venv) ➜  pwntools git:(dev) python
Python 3.13.2 (main, Feb  5 2025, 08:05:21) [GCC 14.2.1 20250128] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pwnlib import gdb
... p=gdb.debug('./build/test')
... 
Could not find a terminal binary to use. Set context.terminal to your terminal.
Traceback (most recent call last):
  File "<python-input-0>", line 2, in <module>
    p=gdb.debug('./build/test')
  File "/home/zt/git/pwntools/pwnlib/context/__init__.py", line 1725, in setter
    return function(*a, **kw)
  File "/home/zt/git/pwntools/pwnlib/gdb.py", line 708, in debug
    tmp = attach((host, port), exe=exe, gdbscript=gdbscript, gdb_args=gdb_args, ssh=ssh, sysroot=sysroot, api=api)
  File "/home/zt/git/pwntools/pwnlib/context/__init__.py", line 1725, in setter
    return function(*a, **kw)
  File "/home/zt/git/pwntools/pwnlib/gdb.py", line 1296, in attach
    gdb_pid = misc.run_in_new_terminal(cmd, preexec_fn = preexec_fn)
  File "/home/zt/git/pwntools/pwnlib/util/misc.py", line 394, in run_in_new_terminal
    log.error('Could not find a terminal binary to use. Set context.terminal to your terminal.')
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zt/git/pwntools/pwnlib/log.py", line 438, in error
    raise PwnlibException(message % args)
pwnlib.exception.PwnlibException: Could not find a terminal binary to use. Set context.terminal to your terminal.
```

