### PR TITLE
Fix poll error in `process.libs()` and clean up maps parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,10 +146,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2545][2545] SSH: fix download/upload with -1 exit status
 - [#2567][2567] Fix mistakenly parsing of ld-linux error messages.
 - [#2576][2576] regsort: respect register aliases
+- [#2579][2579] Fix poll error in `process.libs()` and clean up maps parsing
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
 [2576]: https://github.com/Gallopsled/pwntools/pull/2576
+[2579]: https://github.com/Gallopsled/pwntools/pull/2579
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -1322,8 +1322,7 @@ class process(tube):
         by the process to the address it is loaded at in the process' address
         space.
         """
-        from pwnlib.util.proc import memory_maps
-        maps_raw = self.poll() is not None and memory_maps(self.pid)
+        maps_raw = self.poll() is None and self.maps()
 
         if not maps_raw:
             import pwnlib.elf.elf
@@ -1332,23 +1331,15 @@ class process(tube):
                 return pwnlib.elf.elf.ELF(self.executable).maps
 
         # Enumerate all of the libraries actually loaded right now.
-        maps = {}
+        libs = {}
         for mapping in maps_raw:
             path = mapping.path
             if os.sep not in path: continue
             path = os.path.realpath(path)
-            if path not in maps:
-                maps[path]=0
+            if path not in libs:
+                libs[path] = mapping.addr
 
-        for lib in maps:
-            path = os.path.realpath(lib)
-            for mapping in maps_raw:
-                if mapping.path == path:
-                    address = mapping.addr.split('-')[0]
-                    maps[lib] = int(address, 16)
-                    break
-
-        return maps
+        return libs
 
     @property
     def libc(self):


### PR DESCRIPTION
- Fix `poll()` error : deleting the `not` because the function returns None if the process is running
- Clean up maps parsing : replace `memory_maps()` by `maps()` and remove useless code