### PR TITLE
Fix double exception in `tube.remote` when getaddrinfo raise gaierror

### DIFF
--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -427,7 +427,7 @@ class Logger(object):
         """Alias for :meth:`warning`."""
         return self.warning(*args, **kwargs)
 
-    def error(self, message, *args, **kwargs):
+    def error(self, message, *args, original_exc=None, **kwargs):
         """error(message, *args, **kwargs)
 
         To be called outside an exception handler.
@@ -435,7 +435,7 @@ class Logger(object):
         Logs an error message, then raises a ``PwnlibException``.
         """
         self._log(logging.ERROR, message, args, kwargs, 'error')
-        raise PwnlibException(message % args)
+        raise PwnlibException(message % args) from original_exc
 
     def exception(self, message, *args, **kwargs):
         """exception(message, *args, **kwargs)

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -86,7 +86,7 @@ class remote(sock):
             except socket.gaierror as e:
                 if e.errno != socket.EAI_NONAME:
                     raise
-                self.error('Could not resolve hostname: %r', host)
+                self.exception('Could not resolve hostname: %r', host)
         if self.sock:
             self.settimeout(self.timeout)
             self.lhost, self.lport = self.sock.getsockname()[:2]


### PR DESCRIPTION
Before:
```python
[-] Opening connection to pwn.ctf.umasscybersec.org on port 9000: Failed
[ERROR] Could not resolve hostname: 'pwn.ctf.umasscybersec.org'
Traceback (most recent call last):
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 85, in __init__
    self.sock   = self._connect(fam, typ)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 113, in _connect
    for res in socket.getaddrinfo(self.rhost, self.rport, fam, typ, 0, socket.AI_PASSIVE):
  File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/ctfs/2025/umass/pwn/calc/run.py", line 76, in <module>
    r = conn()
  File "/home/user/ctfs/2025/umass/pwn/calc/run.py", line 50, in conn
    r = remote(host, int(port), ssl=args.SSL)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 89, in __init__
    self.error('Could not resolve hostname: %r', host)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/log.py", line 438, in error
    raise PwnlibException(message % args)
pwnlib.exception.PwnlibException: Could not resolve hostname: 'pwn.ctf.umasscybersec.org'
```

After:
```python
[-] Opening connection to pwn.ctf.umasscybersec.org on port 9000: Failed
[ERROR] Could not resolve hostname: 'pwn.ctf.umasscybersec.org'
Traceback (most recent call last):
  File "/home/user/ctfs/2025/umass/pwn/calc/run.py", line 76, in <module>
    r = conn()
  File "/home/user/ctfs/2025/umass/pwn/calc/run.py", line 50, in conn
    r = remote(host, int(port), ssl=args.SSL)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 89, in __init__
    self.error('Could not resolve hostname: %r', host)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/log.py", line 438, in error
    raise PwnlibException(message % args) from original_exc
pwnlib.exception.PwnlibException: Could not resolve hostname: 'pwn.ctf.umasscybersec.org'
```

If using `log.exception` inside except block:
```py
[-] Opening connection to pwn.ctf.umasscybersec.org on port 9000: Failed
[ERROR] Could not resolve hostname: 'pwn.ctf.umasscybersec.org'
    Traceback (most recent call last):
      File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 85, in __init__
        self.sock   = self._connect(fam, typ)
      File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 113, in _connect
        for res in socket.getaddrinfo(self.rhost, self.rport, fam, typ, 0, socket.AI_PASSIVE):
      File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
        for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
    socket.gaierror: [Errno -2] Name or service not known
Traceback (most recent call last):
  File "/home/user/ctfs/2025/umass/pwn/calc/run.py", line 76, in <module>
    r = conn()
  File "/home/user/ctfs/2025/umass/pwn/calc/run.py", line 50, in conn
    r = remote(host, int(port), ssl=args.SSL)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 89, in __init__
    self.exception('Could not resolve hostname: %r', host)
  File "/home/user/venv/lib/python3.10/site-packages/pwnlib/tubes/remote.py", line 85, in __init__
    self.sock   = self._connect(fam, typ)
socket.gaierror: [Errno -2] Name or service not known
```
