### PR TITLE
Support longer function names in Windows `getexport` shellcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,10 +146,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2545][2545] SSH: fix download/upload with -1 exit status
 - [#2567][2567] Fix mistakenly parsing of ld-linux error messages.
 - [#2576][2576] regsort: respect register aliases
+- [#2587][2587] Support longer function names in Windows `getexport` shellcode
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
 [2576]: https://github.com/Gallopsled/pwntools/pull/2576
+[2587]: https://github.com/Gallopsled/pwntools/pull/2587
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/shellcraft/templates/amd64/windows/getexport.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/getexport.asm
@@ -1,24 +1,30 @@
 <%
-    from pwnlib.shellcraft import amd64, pretty
+    from pwnlib.shellcraft import amd64, common, pretty
     from pwnlib.util.packing import u64, _need_bytes
 %>
 <%docstring>Find the address of an exported function in a dll
 by manually iterating through the PE export table.
 
+The dll must be `b'kernel32.dll'` or `b'ntdll.dll'` at the moment.
+Behavior is undefined if the function is not found.
+
 Args:
-    function_name (str): The name of the function to find.
-    dll(str): The name of the DLL to find the function in.
+    function_name (bytes): The name of the function to find.
+    dll(bytes): The name of the DLL to find the function in.
     dest (str): The register to load the function address into.
 </%docstring>
-<%page args="function_name,dll='kernel32.dll',dest='rax'"/>
+<%page args="function_name,dll=b'kernel32.dll',dest='rax'"/>
 <%
 function_name = _need_bytes(function_name)
 dll = _need_bytes(dll)
-if len(function_name) > 8:
-    raise ValueError('function_name must be <= 8 bytes')
-assert dll == b'kernel32.dll'
+assert dll in (b'kernel32.dll', b'ntdll.dll')
+find_function_loop = common.label('find_function').strip()
 %>
+% if dll == b'kernel32.dll':
     ${amd64.windows.kernel32base('rbx')} /* rbx = kernel32.dll PE base */
+% elif dll == b'ntdll.dll':
+    ${amd64.windows.ntdllbase('rbx')} /* rbx = ntdll.dll PE base */
+% endif
     mov r8d, [rbx + 0x3c]
     mov rdx, r8
     add rdx, rbx
@@ -26,25 +32,42 @@ assert dll == b'kernel32.dll'
     add rdx, r9
     mov r8d, [rdx]
     add r8, rbx /* r8 = export table */
-    mov esi, [r8 + 0x20]
-    add rsi, rbx /* rsi = names table */
-    xor rcx, rcx
+    mov edx, [r8 + 0x20]
+    add rdx, rbx /* rdx = names table */
 % if len(function_name) <= 8:
     mov r9, ${pretty(u64(function_name.ljust(8, b'\x00')))}
 % else:
     ${amd64.pushstr(function_name)}
     mov r9, rsp
 % endif
+    push r8
+    xor r8, r8
 
     /* Loop through the names table */
-    FindFunction:
-        inc rcx
-        mov eax, [rsi + rcx * 4]
+    ${find_function_loop}:
+        inc r8
+        mov eax, [rdx + r8 * 4]
         add rax, rbx
-        ## TODO: implement strcmp properly for function names > 8 bytes
+        ## strcmp
+        % if len(function_name) <= 8:
         cmp qword ptr [rax], r9
-        jnz FindFunction
+        % else:
+        ${amd64.setregs({
+            'rdi': 'rax',
+            'rsi': 'r9',
+            'rcx': len(function_name),
+        })}
+        repe cmpsb
+        movzx rax, byte ptr [rsi-1]
+        movzx rcx, byte ptr [rdi-1]
+        sub rax, rcx
+        % endif
+        jnz ${find_function_loop}
 
+    ## Assume we find the function, we'll crash walking past the
+    ## end of the names table otherwise.
+    mov rcx, r8
+    pop r8
     mov esi, [r8 + 0x24]
     add rsi, rbx /* rsi = ordinals table */
     mov cx, [rsi + rcx * 2]
@@ -52,4 +75,4 @@ assert dll == b'kernel32.dll'
     add rsi, rbx /* rsi = address table */
     mov eax, [rsi + rcx * 4]
     add rax, rbx /* rax = function address */
-    mov ${dest}, rax
+    ${amd64.mov(dest, 'rax')}

--- a/pwnlib/shellcraft/templates/amd64/windows/getprocaddress.asm
+++ b/pwnlib/shellcraft/templates/amd64/windows/getprocaddress.asm
@@ -11,7 +11,7 @@ Args:
     dll(str): The name of the DLL to find the function in.
     dest (str): The register to load the function address into.
 </%docstring>
-<%page args="function_name,dll='kernel32.dll',dest='rax'"/>
+<%page args="function_name,dll=b'kernel32.dll',dest='rax'"/>
 <%
 function_name = _need_bytes(function_name)
 dll = _need_bytes(dll)
@@ -25,4 +25,4 @@ assert dll == b'kernel32.dll'
     sub rsp, 0x30
     call rdi
     add rsp, ${pretty(0x30+align(8, len(function_name)))}
-    mov ${dest}, rax
+    ${amd64.mov(dest, 'rax')}


### PR DESCRIPTION
Previously, an arbitrary name length limit of 8 characters was in place due to the lack of a proper strcmp loop. Implement a cheap strcmp for longer function names. This trashes a bunch of registers and we might be able to optimize it further to reduce the damage.

Use a unique label too to avoid redefinition when using the shellcraft template twice in the same shellcode. Use the mov shellcraft template for the destination register to avoid an instruction if the result is already in the desired register.