### PR TITLE
Add support for finding corefiles under WSL2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2574][2574] Allow creating an ELF from in-memory bytes
 - [#2575][2575] Detect when Terminator is being used as terminal
 - [#2578][2578] Add gnome-terminal, Alacritty, Ttilix for run_in_new_terminal
+- [#2590][2590] Add support for finding corefiles under WSL2
 
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
 [2551]: https://github.com/Gallopsled/pwntools/pull/2551
@@ -112,6 +113,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2574]: https://github.com/Gallopsled/pwntools/pull/2574
 [2575]: https://github.com/Gallopsled/pwntools/pull/2575
 [2578]: https://github.com/Gallopsled/pwntools/pull/2578
+[2590]: https://github.com/Gallopsled/pwntools/pull/2590
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -92,6 +92,7 @@ from pwnlib.util.fiddling import b64d
 from pwnlib.util.fiddling import enhex
 from pwnlib.util.fiddling import unhex
 from pwnlib.util.misc import read
+from pwnlib.util.misc import which
 from pwnlib.util.misc import write
 from pwnlib.util.packing import pack
 from pwnlib.util.packing import unpack_many
@@ -1367,6 +1368,38 @@ class CorefileFinder(object):
         except subprocess.CalledProcessError as e:
             log.debug("coredumpctl failed with status: %d" % e.returncode)
 
+    def wsl_capture_crash_corefile(self):
+        # Get the temp directory of the current user on Windows.
+        with context.local(os="windows", log_level="error"):
+            with process([which("cmd.exe"), "/U", "/c", "echo %TEMP%"]) as p:
+                windows_temp = p.recvall().decode("utf-16le").strip().split(context.newline.decode())
+            if not windows_temp:
+                log.error("Could not determine Windows temp directory")
+                return None
+            # Convert the C:\... Windows path to a WSL path.
+            with process([which("wslpath"), "-a", "-u", windows_temp[-1]]) as p:
+                windows_temp_path = p.recvallS().strip()
+
+        # The /wsl-capture-crash tool stores the core files in %TEMP%\wsl-crashes
+        wsl_crashes = os.path.join(windows_temp_path, "wsl-crashes")
+        if not os.path.isdir(wsl_crashes):
+            log.debug("WSL crashes directory does not exist: %r", wsl_crashes)
+            return None
+
+        # Format the name
+        corefile_name = 'wsl-crash-*-{pid}-*{basename}*.dmp'
+        corefile_name = corefile_name.format(pid=self.pid, basename=self.basename)
+
+        # Get the full path
+        corefile_path = os.path.join(wsl_crashes, corefile_name)
+
+        log.debug("Trying corefile_path: %r", corefile_path)
+
+        # Glob all of them, return the *most recent* based on numeric sort order.
+        for corefile in sorted(glob.glob(corefile_path), reverse=True):
+            return corefile
+        return None
+
     def native_corefile(self):
         """Find the corefile for a native crash.
 
@@ -1415,6 +1448,9 @@ class CorefileFinder(object):
         elif b'systemd-coredump' in self.kernel_core_pattern:
             log.debug("Found systemd-coredump in core_pattern")
             return self.systemd_coredump_corefile()
+        elif b'/wsl-capture-crash' in self.kernel_core_pattern:
+            log.debug("Found WSL core_pattern")
+            return self.wsl_capture_crash_corefile()
         else:
             log.warn_once("Unsupported core_pattern: %r", self.kernel_core_pattern)
             return None


### PR DESCRIPTION
The `wsl-capture-crash` tool stores the crash dumps in the Windows filesystem under `%TEMP%\wsl-crashes`. Look in that directory.

This allows to use the `process.corefile` infrastructure when debugging locally under WSL2.

```
$ python
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pwn import *
>>> context.log_level='debug'
>>> io = ELF.from_assembly(shellcraft.trap()).process()
[DEBUG] cpp -Wno-unused-command-line-argument -C -nostdinc -undef -P -I/home/peace/dev/pwntools/pwnlib/data/includes
[DEBUG] Assembling
    .section .shellcode,"awx"
    .global _start
    .global __start
    _start:
    __start:
    .intel_syntax noprefix
    .p2align 0
        int3
[DEBUG] Using cached assembly output from '/home/peace/.cache/.pwntools-cache-3.12/asm-cache/42b04c41a1a82cf206abae07bf280e1eee3c75e1'
[DEBUG] '/tmp/pwn-asm-86be57_f/step3' is statically linked, skipping GOT/PLT symbols
[*] '/tmp/pwn-asm-86be57_f/step3'
    Arch:       i386-32-little
    RELRO:      No RELRO
    Stack:      No canary found
    NX:         NX enabled on new kernels
    PIE:        No PIE (0xffff000)
    Stack:      Executable
    RWX:        Has RWX segments
    Stripped:   No
[x] Starting local process '/tmp/pwn-asm-86be57_f/step3'
[+] Starting local process '/tmp/pwn-asm-86be57_f/step3': pid 8745
>>> core = io.corefile
[*] Process '/tmp/pwn-asm-86be57_f/step3' stopped with exit code -5 (SIGTRAP) (pid 8745)
[DEBUG] core_pattern: b'|/wsl-capture-crash %t %E %p %s'
[DEBUG] core_uses_pid: False
[DEBUG] interpreter: ''
[DEBUG] Looking for QEMU corefile
[DEBUG] Trying corefile_path: '/home/peace/dev/pwntools/qemu_step3_*_8745.core'
[DEBUG] Looking for native corefile
[DEBUG] Checking for corefile (piped)
[DEBUG] Found WSL core_pattern
[DEBUG] Trying corefile_path: '/mnt/c/Users/Jannik/AppData/Local/Temp/wsl-crashes/wsl-crash-*-8745-*step3*.dmp'
[x] Parsing corefile...
[*] '/tmp/tmp33fi_ge_'
    Arch:      i386-32-little
    EIP:       0x10000001
    ESP:       0xffa80b80
    Exe:       '/tmp/pwn-asm-86be57_f/step3' (0xffff000)
[+] Parsing corefile...: Done
[x] Parsing corefile...
[*] '/home/peace/dev/pwntools/core.8745'
    Arch:      i386-32-little
    EIP:       0x10000001
    ESP:       0xffa80b80
    Exe:       '/tmp/pwn-asm-86be57_f/step3' (0xffff000)
[+] Parsing corefile...: Done
>>>
```