### PR TITLE
Support `context.timeout` in ~/.pwn.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2574][2574] Allow creating an ELF from in-memory bytes
 - [#2575][2575] Detect when Terminator is being used as terminal
 - [#2578][2578] Add gnome-terminal, Alacritty, Ttilix for run_in_new_terminal
+- [#2592][2592] pwnlib.config: Fix customization of `context.timeout`
 
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
 [2551]: https://github.com/Gallopsled/pwntools/pull/2551
@@ -112,6 +113,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2574]: https://github.com/Gallopsled/pwntools/pull/2574
 [2575]: https://github.com/Gallopsled/pwntools/pull/2575
 [2578]: https://github.com/Gallopsled/pwntools/pull/2578
+[2592]: https://github.com/Gallopsled/pwntools/pull/2592
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1757,7 +1757,7 @@ def update_context_defaults(section):
 
         default = ContextType.defaults[key]
 
-        if isinstance(default, (str, int, tuple, list, dict)):
+        if isinstance(default, (str, int, float, tuple, list, dict)):
             value = safeeval.expr(value)
         else:
             log.warn("Unsupported configuration option %r in section %r" % (key, 'context'))


### PR DESCRIPTION
(Tested on 4.14.1, unclear when this regression occurred.)

It appears `context.timeout` cannot be set in ~/.pwn.conf, even though the [docs](https://docs.pwntools.com/en/stable/config.html) indicate that it can.

Example ~/.pwn.conf:

``` toml
[context]
timeout = 10
```

```
$ python3 -c "from pwn import *"
[!] Unsupported configuration option 'timeout' in section 'context'
[!] Wrong value
```

This patch fixes this by adding `float` to the list of types that are allowable to be `safeeval`'d in `update_context_defaults`, which does not seem like it should cause issues (although I am new to the codebase, please correct me if I am mistaken).

Perhaps this has slid under the radar because `timeout` is the only member of context that is affected by this:

``` python
>>> import pwnlib
>>> [k for k,v in pwnlib.context.ContextType.defaults.items() if isinstance(v, float)]
['timeout']
```