### PR TITLE
Use unicorn on macOS w/ SIP enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,10 +146,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2545][2545] SSH: fix download/upload with -1 exit status
 - [#2567][2567] Fix mistakenly parsing of ld-linux error messages.
 - [#2576][2576] regsort: respect register aliases
+- [#2593][2593] Use unicorn on macOS w/ SIP enabled
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
 [2576]: https://github.com/Gallopsled/pwntools/pull/2576
+[2593]: https://github.com/Gallopsled/pwntools/pull/2593
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -65,7 +65,7 @@ def __ensure_memory_to_run_unicorn():
         from mmap import mmap, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE
 
         mm = mmap(
-            -1, 1024 * 1024 * 1024, MAP_PRIVATE | MAP_ANON, PROT_WRITE | PROT_READ | PROT_EXEC
+            -1, 1024 * 1024 * 1024, MAP_PRIVATE | MAP_ANON, PROT_WRITE | PROT_READ
         )
         mm.close()
     except OSError:


### PR DESCRIPTION
macOS systems with SIP enabled prohibit `mmap`ing WX memory, so this check will fail.
However, unicorn will work properly because [it uses the `MAP_JIT` protection flag](https://github.com/unicorn-engine/unicorn/blob/803fe5a47770360d1942de72600d3b295b521e31/qemu/accel/tcg/translate-all.c#L1021-L1032) (see [Apple's docs](https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon) for more info).

This patch still checks if 1GB of memory is available, but requests rw instead of rwx memory.

pwndbg, another tool that uses unicorn, [dropped the check](https://github.com/pwndbg/pwndbg/blob/2f6b5bbaea484391f55850a09a16efda161498f2/pwndbg/aglib/disasm/__init__.py#L305-L316) for the same reason listed above.