### PR TITLE
Add Ubuntu and Debian debuginfod servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,10 +146,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2545][2545] SSH: fix download/upload with -1 exit status
 - [#2567][2567] Fix mistakenly parsing of ld-linux error messages.
 - [#2576][2576] regsort: respect register aliases
+- [#2595][2595] libcdb: Add Ubuntu and Debian debuginfod servers to default list
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
 [2576]: https://github.com/Gallopsled/pwntools/pull/2576
+[2595]: https://github.com/Gallopsled/pwntools/pull/2595
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -31,6 +31,8 @@ HASHES = {
     'md5': md5filehex,
 }
 DEBUGINFOD_SERVERS = [
+    'https://debuginfod.ubuntu.com/',
+    'https://debuginfod.debian.net/',
     'https://debuginfod.elfutils.org/',
 ]
 


### PR DESCRIPTION
Most CTF challenges are hosted on Ubuntu or Debian [citation needed], so check their debuginfod servers before trying the federating one as a fallback.

This is required since the elfutils.org server seems down for maintenance occasionally.
https://sourceware.org/elfutils/Debuginfod.html

(the stable branch doesn't have the libcdb cache yet, so this fixes CI hopefully)