### PR TITLE
Allow setting debugger path via context.gdb_binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,6 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2524][2524] Raise EOFError during `process.recv` when stdout closes on Windows
 - [#2526][2526] Properly make use of extra arguments in `packing` utilities. `sign` parameter requires keyword syntax to specify it.
 - [#2517][2517] Allow to passthru kwargs on `ssh.__getattr__` convenience function to fix SSH motd problems
-- [#2527][2527] Allow setting debugger path via `context.gdb_binary`
 - [#2530][2530] Do NOT error when passing directory arguments in `checksec` commandline tool.
 - [#2529][2529] Add LoongArch64 support
 - [#2506][2506] ROP: fix `ROP(ELF(exe)).leave` is `None` in some ELF
@@ -96,7 +95,6 @@ The table below shows which release corresponds to each branch, and what date th
 [2524]: https://github.com/Gallopsled/pwntools/pull/2524
 [2526]: https://github.com/Gallopsled/pwntools/pull/2526
 [2517]: https://github.com/Gallopsled/pwntools/pull/2517
-[2527]: https://github.com/Gallopsled/pwntools/pull/2527
 [2530]: https://github.com/Gallopsled/pwntools/pull/2530
 [2529]: https://github.com/Gallopsled/pwntools/pull/2529
 [2506]: https://github.com/Gallopsled/pwntools/pull/2506
@@ -151,6 +149,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2587][2587] Support longer function names in Windows `getexport` shellcode
 - [#2596][2596] Ignore `colored_traceback` error when TERM envvar is unset
 - [#2579][2579] Fix poll error in `process.libs()` and clean up maps parsing
+- [#2602][2602] Allow setting debugger path via context.gdb_binary
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
@@ -160,6 +159,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2587]: https://github.com/Gallopsled/pwntools/pull/2587
 [2596]: https://github.com/Gallopsled/pwntools/pull/2596
 [2579]: https://github.com/Gallopsled/pwntools/pull/2579
+[2602]: https://github.com/Gallopsled/pwntools/pull/2602
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -359,6 +359,7 @@ class ContextType(object):
         'encoding': 'auto',
         'endian': 'little',
         'gdbinit': "",
+        'gdb_binary': "",
         'kernel': None,
         'local_libcdb': "/var/lib/libc-database",
         'log_level': logging.INFO,
@@ -1523,6 +1524,20 @@ class ContextType(object):
         the necessary requirements for the gdbinit.
 
         If set to an empty string, GDB will use the default `~/.gdbinit`.
+
+        Default value is ``""``.
+        """
+        return str(value)
+
+    @_validator
+    def gdb_binary(self, value):
+        """Path to the binary that is used when running GDB locally.
+
+        This is useful when you have multiple versions of gdb installed or the gdb binary is
+        called something different.
+
+        If set to an empty string, pwntools will try to search for a reasonable gdb binary from 
+        the path.
 
         Default value is ``""``.
         """

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -750,6 +750,12 @@ def binary():
         >>> gdb.binary() # doctest: +SKIP
         '/usr/bin/gdb'
     """
+    if context.gdb_binary:
+        gdb = misc.which(context.gdb_binary)
+        if not gdb:
+            log.warn_once('Path to gdb binary `{}` not found'.format(context.gdb_binary))
+        return gdb
+
     gdb = misc.which('pwntools-gdb') or misc.which('gdb')
 
     if not context.native:


### PR DESCRIPTION
Backport of e51bc74e2585fff5eebba150cbe45f2167c265b1 to stable

Allow customization of gdb binary path via context.gdb_binary.

Closes https://github.com/Gallopsled/pwntools/issues/2520