### PR TITLE
modify pyelftools version to >=0.32 in requirement.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ isort
 mako>=1.0.0
 paramiko>=1.15.2
 pip>=6.0.8
-pyelftools>=0.29
+pyelftools>=0.32
 pygments>=2.0
 pypandoc
 pyserial>=2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.6"
 dependencies = [
     "paramiko>=1.15.2",
     "mako>=1.0.0",
-    "pyelftools>=0.29",
+    "pyelftools>=0.32",
     "capstone>=4.0.0",
     "ropgadget>=5.3",
     "pyserial>=2.7",


### PR DESCRIPTION
    pyelftools 0.29 results a fail in checksec, makes the script can't execute

    * modify pyelftools version

[reflink](https://github.com/Gallopsled/pwntools/issues/2600)
