### PR TITLE
Improve error of `process.maps()` after the process exited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The table below shows which release corresponds to each branch, and what date th
 | Version          | Branch   | Release Date           |
 | ---------------- | -------- | ---------------------- |
 | [5.0.0](#500-dev)  | `dev`    |
-| [4.15.0](#4150-stable)  | `stable` | Oct 12, 2025
+| [4.15.0](#4150-stable) | `stable` | Oct 12, 2025
 | [4.14.1](#4141)  |          | Mar 24, 2025
 | [4.14.0](#4140)  |          | Jan 15, 2025
 | [4.13.1](#4131)  |          | Sep 29, 2024
@@ -102,6 +102,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2496][2496] Add linux ko file search support
 - [#2542][2542] Decode `_IO_*` flags in `FileStructure` member
 - [#2592][2592] pwnlib.config: Fix customization of `context.timeout`
+- [#2606][2606] Fix `process.maps()`
 - [#2608][2608] Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed
 - [#2611][2611] Cleanup `pwnlib.lexer` exports and imports
 - [#2610][2610] Fix `log.progress` ignoring `context.log_console`
@@ -146,6 +147,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2496]: https://github.com/Gallopsled/pwntools/pull/2496
 [2542]: https://github.com/Gallopsled/pwntools/pull/2542
 [2592]: https://github.com/Gallopsled/pwntools/pull/2592
+[2606]: https://github.com/Gallopsled/pwntools/pull/2606
 [2608]: https://github.com/Gallopsled/pwntools/pull/2608
 [2611]: https://github.com/Gallopsled/pwntools/pull/2611
 [2610]: https://github.com/Gallopsled/pwntools/pull/2610
@@ -227,7 +229,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2612]: https://github.com/Gallopsled/pwntools/pull/2612
 [2624]: https://github.com/Gallopsled/pwntools/pull/2624
 
-## 4.14.1 (`stable`)
+## 4.14.1
 
 - [#2451][2451] Show symbols defined to value 0 (start of file)
 - [#2533][2533] Fix installation on Python 3.5 and lower
@@ -678,7 +680,7 @@ In memoriam — [Zach Riggle][zach] — long time contributor and maintainer of 
 [fecf9f]: http://github.com/Gallopsled/pwntools/commit/fecf9f
 [1454]: https://github.com/Gallopsled/pwntools/pull/1454
 
-## 4.1.7 (`stable`)
+## 4.1.7
 
 - [#1615][1615] Fix aarch64 pushstr and pushstr_array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2496][2496] Add linux ko file search support
 - [#2542][2542] Decode `_IO_*` flags in `FileStructure` member
 - [#2592][2592] pwnlib.config: Fix customization of `context.timeout`
-- [#2606][2606] Fix `process.maps()`
+- [#2606][2606] Improve error of `process.maps()` after the process exited
 - [#2608][2608] Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed
 - [#2611][2611] Cleanup `pwnlib.lexer` exports and imports
 - [#2610][2610] Fix `log.progress` ignoring `context.log_console`

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -996,7 +996,10 @@ class process(tube):
         # addr = address (alias) = start (alias)
 
         from pwnlib.util.proc import memory_maps
-        raw_maps = memory_maps(self.pid)
+        raw_maps = self.poll() is None and memory_maps(self.pid)
+
+        if not raw_maps:
+            raise RuntimeError("Could not read maps, process %s has finished" % self.pid)
 
         maps = []
         # raw_mapping
@@ -1377,17 +1380,11 @@ class process(tube):
         by the process to the address it is loaded at in the process' address
         space.
         """
-        maps_raw = self.poll() is None and self.maps()
-
-        if not maps_raw:
-            import pwnlib.elf.elf
-
-            with context.quiet:
-                return pwnlib.elf.elf.ELF(self.executable).maps
+        all_maps = self.maps()
 
         # Enumerate all of the libraries actually loaded right now.
         libs = {}
-        for mapping in maps_raw:
+        for mapping in all_maps:
             path = mapping.path
             if os.sep not in path: continue
             path = os.path.realpath(path)

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -999,7 +999,7 @@ class process(tube):
         raw_maps = self.poll() is None and memory_maps(self.pid)
 
         if not raw_maps:
-            raise RuntimeError("Could not read maps, process %s has finished" % self.pid)
+            self.error("Could not read maps, process %d has finished", self.pid)
 
         maps = []
         # raw_mapping


### PR DESCRIPTION
- Move the changes of #2516 from libs() to maps() because maps() is called in others functions than libs() as stated in #2579
- Return an error instead of sending the elf maps to avoid sending incorrect values