### PR TITLE
Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2496][2496] Add linux ko file search support
 - [#2542][2542] Decode `_IO_*` flags in `FileStructure` member
 - [#2592][2592] pwnlib.config: Fix customization of `context.timeout`
+- [#2608][2608] Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed
 
 [2598]: https://github.com/Gallopsled/pwntools/pull/2598
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
@@ -122,6 +123,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2496]: https://github.com/Gallopsled/pwntools/pull/2496
 [2542]: https://github.com/Gallopsled/pwntools/pull/2542
 [2592]: https://github.com/Gallopsled/pwntools/pull/2592
+[2608]: https://github.com/Gallopsled/pwntools/pull/2608
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/commandline/libcdb.py
+++ b/pwnlib/commandline/libcdb.py
@@ -267,7 +267,9 @@ def main(args):
                 continue
 
             if args.unstrip:
-                libcdb.unstrip_libc(file)
+                if not libcdb.unstrip_libc(file):
+                    log.failure('Failed to unstrip libc binary %s', file)
+                    continue
 
             print_libc_elf(ELF(file, checksec=False))
 


### PR DESCRIPTION
When asking to unstrip a local file, abort if that didn't work instead of only warning about it.

Fixes #2586