### PR TITLE
Fix log level of child remotes of `server` tube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2596][2596] Ignore `colored_traceback` error when TERM envvar is unset
 - [#2579][2579] Fix poll error in `process.libs()` and clean up maps parsing
 - [#2602][2602] Allow setting debugger path via context.gdb_binary
+- [#2609][2609] Fix log level of child remotes of `server` tube
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
@@ -160,6 +161,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2596]: https://github.com/Gallopsled/pwntools/pull/2596
 [2579]: https://github.com/Gallopsled/pwntools/pull/2579
 [2602]: https://github.com/Gallopsled/pwntools/pull/2602
+[2609]: https://github.com/Gallopsled/pwntools/pull/2609
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/tubes/server.py
+++ b/pwnlib/tubes/server.py
@@ -127,7 +127,7 @@ class server(sock):
                         return
 
                 self.rhost, self.rport = rhost[:2]
-                r = remote(self.rhost, self.rport, sock = sock)
+                r = remote(self.rhost, self.rport, sock = sock, level = self.level)
                 h.success('Got connection from %s on port %d' % (self.rhost, self.rport))
                 if callback:
                     if not blocking:


### PR DESCRIPTION
The log level of the `server` tube wasn't passed on to the `remote` wrappers created upon receiving a new child connection. This caused the connection closed message to be logged even when the server object was created with `level='error'`.