### PR TITLE
Fix `log.progress` ignoring `context.log_console`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2542][2542] Decode `_IO_*` flags in `FileStructure` member
 - [#2592][2592] pwnlib.config: Fix customization of `context.timeout`
 - [#2608][2608] Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed
+- [#2610][2610] Fix `log.progress` ignoring `context.log_console`
 
 [2598]: https://github.com/Gallopsled/pwntools/pull/2598
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
@@ -122,6 +123,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2542]: https://github.com/Gallopsled/pwntools/pull/2542
 [2592]: https://github.com/Gallopsled/pwntools/pull/2592
 [2608]: https://github.com/Gallopsled/pwntools/pull/2608
+[2610]: https://github.com/Gallopsled/pwntools/pull/2610
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/log.py
+++ b/pwnlib/log.py
@@ -545,7 +545,8 @@ class Handler(logging.StreamHandler):
 
         # if the record originates from a `Progress` object and term handling
         # is enabled we can have animated spinners! so check that
-        if progress is None or not term.term_mode:
+        # Don't show spinners if the output is being redirected
+        if progress is None or not term.term_mode or not os.path.sameopenfile(context.log_console.fileno(), term.term.fd.fileno()):
             super(Handler, self).emit(record)
             return
 


### PR DESCRIPTION
When setting `context.log_console` to something other than stdout, spinners while using `log.progress` would still be printed to stdout. Redirect them to the stream specified by `context.log_console` and don't animate if it's not a tty.

Fixes #1702

@Arusekk this is your suggested fix from 5 years ago. Was there some gotcha I don't see?