### PR TITLE
Cleanup `pwnlib.lexer` exports and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2542][2542] Decode `_IO_*` flags in `FileStructure` member
 - [#2592][2592] pwnlib.config: Fix customization of `context.timeout`
 - [#2608][2608] Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed
+- [#2611][2611] Cleanup `pwnlib.lexer` exports and imports
 
 [2598]: https://github.com/Gallopsled/pwntools/pull/2598
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
@@ -122,6 +123,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2542]: https://github.com/Gallopsled/pwntools/pull/2542
 [2592]: https://github.com/Gallopsled/pwntools/pull/2592
 [2608]: https://github.com/Gallopsled/pwntools/pull/2608
+[2611]: https://github.com/Gallopsled/pwntools/pull/2611
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/lexer.py
+++ b/pwnlib/lexer.py
@@ -2,27 +2,15 @@ from __future__ import division
 
 import re
 
-from pygments.lexer import DelegatingLexer
 from pygments.lexer import RegexLexer
 from pygments.lexer import bygroups
 from pygments.lexer import include
-from pygments.lexer import using
-from pygments.lexers.c_cpp import CLexer
-from pygments.lexers.c_cpp import CppLexer
-from pygments.lexers.d import DLexer
 from pygments.token import Comment
-from pygments.token import Keyword
 from pygments.token import Name
 from pygments.token import Number
-from pygments.token import Operator
-from pygments.token import Other
 from pygments.token import Punctuation
 from pygments.token import String
 from pygments.token import Text
-
-__all__ = ['GasLexer', 'ObjdumpLexer', 'DObjdumpLexer', 'CppObjdumpLexer',
-           'CObjdumpLexer', 'LlvmLexer', 'NasmLexer', 'NasmObjdumpLexer',
-           'Ca65Lexer']
 
 
 class PwntoolsLexer(RegexLexer):
@@ -108,3 +96,14 @@ class PwntoolsLexer(RegexLexer):
             return True
         elif re.match(r'^\.\w+', text, re.M):
             return 0.1
+
+# Aliases for convenience
+GasLexer = PwntoolsLexer
+ObjdumpLexer = PwntoolsLexer
+DObjdumpLexer = PwntoolsLexer
+CppObjdumpLexer = PwntoolsLexer
+CObjdumpLexer = PwntoolsLexer
+LlvmLexer = PwntoolsLexer
+NasmLexer = PwntoolsLexer
+NasmObjdumpLexer = PwntoolsLexer
+Ca65Lexer = PwntoolsLexer


### PR DESCRIPTION
The exported lexers don't really exist. It has been this way since this code was first included in the repo, so I'd assume the intention was to have aliases for the same lexer since the disassembly looks similar between all those tools.

Many imports are unused too, so remove them.

Fixes #1309