### PR TITLE
Fix lookup of binutils for `mipsel` architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           binutils-aarch64-linux-gnu \
           binutils-arm-linux-gnueabihf \
           binutils-mips-linux-gnu \
+          binutils-mipsel-linux-gnu \
           binutils-msp430 \
           binutils-powerpc-linux-gnu \
           binutils-s390x-linux-gnu \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2579][2579] Fix poll error in `process.libs()` and clean up maps parsing
 - [#2602][2602] Allow setting debugger path via context.gdb_binary
 - [#2609][2609] Fix log level of child remotes of `server` tube
+- [#2612][2612] Fix lookup of binutils for `mipsel` architecture
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
@@ -162,6 +163,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2579]: https://github.com/Gallopsled/pwntools/pull/2579
 [2602]: https://github.com/Gallopsled/pwntools/pull/2602
 [2609]: https://github.com/Gallopsled/pwntools/pull/2609
+[2612]: https://github.com/Gallopsled/pwntools/pull/2612
 
 ## 4.14.1 (`stable`)
 

--- a/extra/docker/base/Dockerfile
+++ b/extra/docker/base/Dockerfile
@@ -32,8 +32,10 @@ RUN apt-get update \
         binutils-aarch64-linux-gnu \
         binutils-mips-linux-gnu \
         binutils-mipsel-linux-gnu \
+        binutils-msp430 \
         binutils-powerpc-linux-gnu \
         binutils-powerpc64-linux-gnu \
+        binutils-s390x-linux-gnu \
         binutils-sparc64-linux-gnu \
         binutils-riscv64-linux-gnu \
         tmux \

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -190,12 +190,14 @@ def which_binutils(util, check_version=False):
         'i386':   ['x86_64', 'amd64'],
         'i686':   ['x86_64', 'amd64'],
         'amd64':  ['x86_64', 'i386'],
-        'mips64': ['mips'],
-        'mips64el': ['mipsel'],
+        'mips': ['mipsel'],
+        'mipsel': ['mips'],
+        'mips64': ['mips', 'mipsel'],
+        'mips64el': ['mipsel', 'mips'],
         'powerpc64': ['powerpc'],
         'sparc64': ['sparc'],
-        'riscv32': ['riscv32', 'riscv64', 'riscv'],
-        'riscv64': ['riscv64', 'riscv32', 'riscv'],
+        'riscv32': ['riscv64', 'riscv'],
+        'riscv64': ['riscv32', 'riscv'],
     }.get(arch, [])
 
     # If one of the candidate architectures matches the native

--- a/pwnlib/asm.py
+++ b/pwnlib/asm.py
@@ -167,6 +167,8 @@ def which_binutils(util, check_version=False):
         '.../bin/arm-...-as'
         >>> which_binutils('as', arch='powerpc') #doctest: +ELLIPSIS
         '.../bin/powerpc...-as'
+        >>> which_binutils('as', arch='mips', endianness='little') #doctest: +ELLIPSIS
+        '.../bin/mipsel...-as'
         >>> which_binutils('as', arch='msp430') #doctest: +SKIP
         ...
         Traceback (most recent call last):
@@ -174,6 +176,12 @@ def which_binutils(util, check_version=False):
         Exception: Could not find 'as' installed for ContextType(arch = 'msp430')
     """
     arch = context.arch
+
+    # Handle endianness-specific naming for mips/mips64
+    arch = {
+        ('mips', 'little'): 'mipsel',
+        ('mips64', 'little'): 'mips64el',
+    }.get((arch, context.endianness), arch)
 
     # Fix up pwntools vs Debian triplet naming, and account
     # for 'thumb' being its own pwntools architecture.
@@ -183,6 +191,7 @@ def which_binutils(util, check_version=False):
         'i686':   ['x86_64', 'amd64'],
         'amd64':  ['x86_64', 'i386'],
         'mips64': ['mips'],
+        'mips64el': ['mipsel'],
         'powerpc64': ['powerpc'],
         'sparc64': ['sparc'],
         'riscv32': ['riscv32', 'riscv64', 'riscv'],


### PR DESCRIPTION
The endianness is encoded in the architecture name for mips targets which wasn't respected while looking for the correct binutils binary.

Sync the CI and Dockerfile binutils packages while we're at it.

Fixes #2591