### PR TITLE
Remove leftover `six` references

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 import os
 import doctest
 import signal
-import six
 import subprocess
 import sys
 
@@ -71,7 +70,6 @@ doctest_global_setup = '''
 import sys, os
 os.environ['PWNLIB_NOTERM'] = '1'
 os.environ['PWNLIB_RANDOMIZE'] = '0'
-import six
 import pwnlib.update
 import pwnlib.util.fiddling
 import logging
@@ -362,7 +360,7 @@ def linkcode_resolve(domain, info):
         if isinstance(val, property):
             val = val.fget
 
-        if isinstance(val, (types.ModuleType, types.MethodType, types.FunctionType, types.TracebackType, types.FrameType, types.CodeType) + six.class_types):
+        if isinstance(val, (types.ModuleType, types.MethodType, types.FunctionType, types.TracebackType, types.FrameType, types.CodeType, type)):
             try:
                 lines, first = inspect.getsourcelines(val)
                 filename += '#L%d-L%d' % (first, first + len(lines) - 1)

--- a/docs/source/filesystem.rst
+++ b/docs/source/filesystem.rst
@@ -1,7 +1,6 @@
 .. testsetup:: *
 
     import time
-    import six
     from pwnlib.context import context
     from pwnlib.tubes.ssh import ssh
     from pwnlib.filesystem import *

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -73,8 +73,8 @@ from pwnlib.util.web import *
 
 # Promote these modules, so that "from pwn import *" will let you access them
 
-from six.moves import cPickle as pickle, cStringIO as StringIO
-from six import BytesIO
+import pickle
+from io import BytesIO, StringIO
 
 log = getLogger("pwnlib.exploit")
 error   = log.error

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -380,7 +380,7 @@ def unstrip_libc(filename):
 
     # Deferred import because it's slow
     import requests
-    from six.moves import urllib
+    import urllib.parse
 
     hex_encoded_id = enhex(libc.buildid)
 


### PR DESCRIPTION
Some `six` usage sneaked by in #2547.