### PR TITLE
tube/process: Fix redirecting stderr to stdout on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2608][2608] Abort on `libcdb file libc.so --unstrip` if eu-unstrip is not installed
 - [#2611][2611] Cleanup `pwnlib.lexer` exports and imports
 - [#2610][2610] Fix `log.progress` ignoring `context.log_console`
+- [#2615][2615] tube/process: Fix redirecting stderr to stdout on Windows
 
 [2598]: https://github.com/Gallopsled/pwntools/pull/2598
 [2419]: https://github.com/Gallopsled/pwntools/pull/2419
@@ -126,6 +127,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2608]: https://github.com/Gallopsled/pwntools/pull/2608
 [2611]: https://github.com/Gallopsled/pwntools/pull/2611
 [2610]: https://github.com/Gallopsled/pwntools/pull/2610
+[2615]: https://github.com/Gallopsled/pwntools/pull/2615
 
 ## 4.15.0 (`beta`)
 

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -276,10 +276,6 @@ class process(tube):
         else:
             executable_val, argv_val, env_val = self._validate(cwd, executable, argv, env)
 
-        # Avoid the need to have to deal with the STDOUT magic value.
-        if stderr is STDOUT:
-            stderr = stdout
-
         if IS_WINDOWS:
             self.pty = None
             self.raw = False
@@ -289,6 +285,10 @@ class process(tube):
             self.sgid = self.gid = None
             internal_preexec_fn = None
         else:
+            # Avoid the need to have to deal with the STDOUT magic value.
+            if stderr is STDOUT:
+                stderr = stdout
+
             # Determine which descriptors will be attached to a new PTY
             handles = (stdin, stdout, stderr)
 
@@ -370,6 +370,8 @@ class process(tube):
                                                  creationflags = creationflags)
                     break
                 except OSError as exception:
+                    if sys.platform == 'win32':
+                        raise
                     if exception.errno != errno.ENOEXEC:
                         raise
                     prefixes.append(self.__on_enoexec(exception))


### PR DESCRIPTION
Use the `subprocess` module's built-in redirection capabilities instead of manually redirecting file descriptors, which uses the correct pipes on Windows.

Fixes #2614