### PR TITLE
Remove "ubuntu" user in base Docker image

### DIFF
--- a/extra/docker/base/Dockerfile
+++ b/extra/docker/base/Dockerfile
@@ -4,11 +4,11 @@
 ############################################################
 
 FROM ubuntu:noble
-MAINTAINER Maintainer Gallopsled et al.
+LABEL maintainer="Maintainer Gallopsled et al."
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -40,6 +40,7 @@ RUN apt-get update \
     && update-locale LANG=en_US.UTF-8 \
     && python3 -m pip install --no-cache-dir --break-system-packages --upgrade pwntools \
     && PWNLIB_NOTERM=1 pwn update \
+    && userdel -r ubuntu \
     && useradd -m pwntools \
     && passwd --delete --unlock pwntools \
     && echo "pwntools ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/pwntools

--- a/travis/docker/Dockerfile
+++ b/travis/docker/Dockerfile
@@ -126,7 +126,7 @@ USER pwntools
 WORKDIR /home/pwntools
 
 # Copy in the Doctest script
-COPY doctest3 tmux.sh /home/pwntools
+COPY doctest3 tmux.sh /home/pwntools/
 
 # Do everything in UTF-8 mode!
 ENV LANG=C.UTF-8

--- a/travis/docker/Dockerfile.travis
+++ b/travis/docker/Dockerfile.travis
@@ -44,7 +44,7 @@ USER pwntools
 WORKDIR /home/pwntools
 
 # Copy in the Doctest script
-COPY doctest3 tmux.sh /home/pwntools
+COPY doctest3 tmux.sh /home/pwntools/
 
 # Do everything in UTF-8 mode!
 ENV LANG=C.UTF-8


### PR DESCRIPTION
The ubuntu/24.04 image contains a default user "ubuntu" with uid 1000. We add our own "pwntools" user which has uid 1001 now causing mismatches with the default host uid of 1000 for the bind-mounts in the develop/testing image.

https://bugs.launchpad.net/cloud-images/+bug/2005129

This allows me to run `make -C travis/docker ANDROID=no` to test locally again.