### PR TITLE
Fix regression: gdbserver can't handle command-line argument containing whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2602][2602] Allow setting debugger path via context.gdb_binary
 - [#2609][2609] Fix log level of child remotes of `server` tube
 - [#2612][2612] Fix lookup of binutils for `mipsel` architecture
+- [#2624][2624] Fix regression: gdbserver can't handle command-line argument containing whitespace
 
 [2545]: https://github.com/Gallopsled/pwntools/pull/2545
 [2567]: https://github.com/Gallopsled/pwntools/pull/2567
@@ -164,6 +165,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2602]: https://github.com/Gallopsled/pwntools/pull/2602
 [2609]: https://github.com/Gallopsled/pwntools/pull/2609
 [2612]: https://github.com/Gallopsled/pwntools/pull/2612
+[2624]: https://github.com/Gallopsled/pwntools/pull/2624
 
 ## 4.14.1 (`stable`)
 

--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -353,10 +353,6 @@ def _gdbserver_args(pid=None, path=None, port=0, gdbserver_args=None, args=None,
         gdbserver_args += ['--wrapper', python_wrapper_script, '--']
     elif env is not None:
         gdbserver_args += ['--wrapper', which('env'), '-i'] + env_args + ['--']
-    # --no-startup-with-shell is required for forking shells like SHELL=/bin/fish
-    # https://github.com/Gallopsled/pwntools/issues/2377
-    else:
-        gdbserver_args += ['--no-startup-with-shell']
 
     gdbserver_args += ['localhost:%d' % port]
     gdbserver_args += args


### PR DESCRIPTION
The `--no-startup-with-shell` argument was passed in an attempt to fix gdbserver startup with `SHELL=/bin/fish`. (#2377) It caused a regression which disallowed passing arguments containing whitespace to the debuggee in `gdb.debug`.

gdbserver would exit with a message:
"can't handle command-line argument containing whitespace"

There is a 3 second timeout waiting for gdbserver to startup and printing a message with a workaround already suggesting to set `SHELL=/bin/bash` to allow gdbserver to launch. This has to be our best effort to guide users of such shells until we find time to investigate a better solution.

Fixes #2550