### PR TITLE
gdb.py: remove unnecessary check in attach

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -1223,9 +1223,6 @@ def attach(target, gdbscript = '', exe = None, gdb_args = None, ssh = None, sysr
             exe_fn = adb.proc_exe
         exe = exe_fn(pid)
 
-    if not pid and not exe and not ssh:
-        log.error('could not find target process')
-
     gdb_binary = binary()
     cmd = [gdb_binary]
 


### PR DESCRIPTION
This PR removes a check which will fail when debugging a binary inside a Docker container using `gdbserver` without having the executable locally, even though debugging still works, since GDB can fetch the binary from the remote system.



