### PR TITLE
feat: add libc `__exit_funcs` utility class

### DIFF
--- a/pwnlib/exit_funcs.py
+++ b/pwnlib/exit_funcs.py
@@ -1,0 +1,51 @@
+from pwnlib.util.fiddling import rol
+from pwnlib.util.packing import *
+
+__all__ = ["encode_ptr", "CxaFunc", "AtFunc", "OnFunc"]
+
+
+def encode_ptr(ptr, ptr_guard, width=Nonte):
+    """
+    Encodes a function pointer using glibc's pointer-mangling scheme.
+    """
+    if width is None:
+        width = context.bits
+
+    if width == 64:
+        return rol(ptr ^ ptr_guard, 0x11, 64) & ((1 << 64) - 1)
+    elif width == 32:
+        return rol(ptr ^ ptr_guard, 0x9, 32) & ((1 << 32) - 1)
+    else:
+        raise ValueError(f"Unsupported architecture for pointer encoding: {context.arch}")
+
+
+class CxaFunc:
+    def __init__(self, fp, arg, width=None):
+        self.fp = fp
+        self.arg = arg
+        self.width = width
+
+    def encode(ptr_guard) -> bytes:
+        # ef_cxa == 4 | encoded function pointer | argument | dso handle set to NULL
+        return flat(4, encode_ptr(self.fp, ptr_guard, self.width), self.arg, 0)
+
+
+class AtFunc:
+    def __init__(self, fp, width=None):
+        self.fp = fp
+        self.width = width
+
+    def encode(ptr_guard) -> bytes:
+        # ef_at == 3 | encoded function pointer
+        return flat(3, encode_ptr(self.fp, ptr_guard, self.width))
+
+
+class OnFunc:
+    def __init__(self, fp, arg, width=None):
+        self.fp = fp
+        self.arg = arg
+        self.width = width
+
+    def encode(ptr_guard) -> bytes:
+        # ef_at == 2 | encoded function pointer | argument
+        return flat(2, encode_ptr(self.fp, ptr_guard, self.width), self.arg)


### PR DESCRIPTION
closes #2633 
# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.
> WIP!

Adding a utility class for glibc's __exit_funcs. This can be helpful when promoting an arbitrary write and read to RCE.

See [this]() resource for more info. A lot of exploits just use the CxaFunc and ExitHandler class shown here, so it would make sense to have the functionality in pwntools as well.

## TODO
- [ ] documentation
- [ ] compliance with older glibc versions  
- [ ] exit handler class

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.com/blog/2224-change-the-base-branch-of-a-pull-request

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
