### PR TITLE
Remove "pip" as explicit dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@ intervaltree
 isort
 mako>=1.0.0
 paramiko>=1.15.2
-pip>=6.0.8
 pyelftools>=0.32
 pygments>=2.0
 pypandoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "ropgadget>=5.3",
     "pyserial>=2.7",
     "requests>=2.0",
-    "pip>=6.0.8",
     "pygments>=2.0",
     "pysocks",
     "python-dateutil",


### PR DESCRIPTION
It looks like this was done to work around a bug in an old pip version years ago. It caused problems when freezing dependencies which unnecessarily forced pip to the version used at freeze time when installing again.

Fixes #2625