### PR TITLE
fix(libcdb-cli): return early if no matched libc found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2615][2615] tube/process: Fix redirecting stderr to stdout on Windows
 - [#2639][2639] ROP: Remove stdout and argv workaround in ROPgadget invocation
 - [#2630][2630] support `preexec_fn` in `debug()`
+- [#2646][2646] fix(libcdb-cli): return early if no matched libc found
 
 [2638]: https://github.com/Gallopsled/pwntools/pull/2638
 [2598]: https://github.com/Gallopsled/pwntools/pull/2598
@@ -134,6 +135,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2615]: https://github.com/Gallopsled/pwntools/pull/2615
 [2639]: https://github.com/Gallopsled/pwntools/pull/2639
 [2630]: https://github.com/Gallopsled/pwntools/pull/2630
+[2646]: https://github.com/Gallopsled/pwntools/pull/2646
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/commandline/libcdb.py
+++ b/pwnlib/commandline/libcdb.py
@@ -240,6 +240,9 @@ def main(args):
         symbols = {pairs[i]:pairs[i+1] for i in range(0, len(pairs), 2)}
         matched_libcs = libcdb.search_by_symbol_offsets(symbols, offline_only=args.offline_only, return_raw=True)
 
+        if not matched_libcs:
+            return
+
         for libc in matched_libcs:
             print_libc_info(libc)
             if args.download_libc:


### PR DESCRIPTION
Before:
<img width="1340" height="329" alt="image" src="https://github.com/user-attachments/assets/9580f4ac-fd44-4166-9f6d-93fa73998a4d" />

When libcdb fails to find matched libc, it triggers an error.

After:
<img width="734" height="63" alt="image" src="https://github.com/user-attachments/assets/ea01fb53-38ed-4247-a1e1-b405f9120acd" />
