### PR TITLE
Make setting the context.terminal to kitty more user friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2652][2652] Make setting the context.terminal to kitty more user friendly
 - [#2638][2638] feat: add disable_corefiles context option
 - [#2627][2627] remove pwnlib.util.iters.lookahead (broken anyway)
 - [#2598][2598] aarch64: Fix ABI definition
@@ -106,6 +107,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2639][2639] ROP: Remove stdout and argv workaround in ROPgadget invocation
 - [#2630][2630] support `preexec_fn` in `debug()`
 
+[2652]: https://github.com/Gallopsled/pwntools/pull/2652
 [2638]: https://github.com/Gallopsled/pwntools/pull/2638
 [2627]: https://github.com/Gallopsled/pwntools/pull/2627
 [2598]: https://github.com/Gallopsled/pwntools/pull/2598

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -413,6 +413,18 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
     if terminal == 'tmux':
         args += ['-F' '#{pane_pid}', '-P']
 
+    if terminal == "kitty":
+        if not args:
+            # Likely the average user just wanted to tell pwntools to use kitty, rather than
+            # thinking about how the terminal will actually be invoked.
+            terminal = "kitten"
+            args = ["@", "launch"]
+        else:
+            # Allowing this would make our life much harder (because we don't get the window id from
+            # running `kitty`, but we do from `kitten @ launch`) and it's an easy fix for the user.
+            log.error(
+                f"Invalid kitty invocation {context.terminal}, please use `kitten @ launch`.")
+            
     argv = [which(terminal)] + args
 
     if isinstance(command, str):
@@ -469,8 +481,10 @@ end tell
     log.debug("Launching a new terminal: %r" % argv)
 
     stdin = stdout = stderr = open(os.devnull, 'r+b')
-    if terminal == 'tmux' or terminal in ('kitty', 'kitten'):
+    if terminal == 'tmux' or terminal == 'kitten':
         stdout = subprocess.PIPE
+    if terminal == 'kitten':
+        stderr = subprocess.PIPE
 
     p = subprocess.Popen(argv, stdin=stdin, stdout=stdout, stderr=stderr, preexec_fn=preexec_fn)
 
@@ -486,15 +500,20 @@ end tell
         with subprocess.Popen((qdbus, konsole_dbus_service, '/Sessions/{}'.format(last_konsole_session),
                                'org.kde.konsole.Session.processId'), stdout=subprocess.PIPE) as proc:
             pid = int(proc.communicate()[0].decode())
-    elif terminal in ('kitty', 'kitten'):
+    elif terminal == "kitten":
         pid = None
-        out, _ = p.communicate()
+        out, err = p.communicate()
+
+        # Catch the most common user error
+        if b"Remote control is disabled" in err:
+            log.error("Kitty remote control is disabled. Add `allow_remote_control yes` to your ~/.config/kitty/kitty.conf .")
+
         try:
             kittyid = int(out)
         except ValueError:
             kittyid = None
         if kittyid is None:
-            log.error("Could not parse kitty window ID from output (%r)", out)
+            log.error("Could not parse kitty window ID from output (%r) (stderr: %r)", out, err)
         else:
             lsout, _ = subprocess.Popen(["kitten", "@", "ls", "--match", "id:%d" % kittyid], stdin=stdin, stdout=stdout, stderr=stderr).communicate()
             try:


### PR DESCRIPTION
`context.terminal = "kitty"` is the most "obvious" thing although actually running that doesn't really work for us.

Catch the most common error of not allowing remote control.

I guess it would be possible to allow doing it without allowing remote control and with `context.terminal = "kitty"` by finding the correct pid by name or something, but that would be flaky. And we do really want to support `kitten` invocation because that allows pane manipulation (vertical/horizontal/new tab/new os window/bias etc.).