### PR TITLE
Add aarch64_be qemu mapping

### DIFF
--- a/pwnlib/qemu.py
+++ b/pwnlib/qemu.py
@@ -105,6 +105,7 @@ def archname():
         ('powerpc64', 'little'): 'ppc64le',
         ('thumb', 'little'):     'arm',
         ('thumb', 'big'):        'armeb',
+        ('aarch64', 'big'):      'aarch64_be',
     }.get((context.arch, context.endian), context.arch)
 
 @LocalContext


### PR DESCRIPTION
For big-endian aarch64, the qemu arch name is `aarch64_be`. This adds a mapping so the correct qemu program is used when invoking gdb.debug or starting a process.