### PR TITLE
Fix typo in error message for UDP sockets

### DIFF
--- a/pwnlib/tubes/sock.py
+++ b/pwnlib/tubes/sock.py
@@ -25,7 +25,7 @@ class sock(tube):
         """
 
         if getattr(self, 'type', None) == socket.SOCK_DGRAM:
-            self.error("UDP sockets does not supports recvall")
+            self.error("UDP sockets do not support recvall")
         else:
             return super(sock, self).recvall(timeout)
 


### PR DESCRIPTION
This PR fixes a typo in an error message that indicates UDP sockets don't support recvall().