### PR TITLE
Run vermin targetting at most Python 3.10 in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,8 @@ jobs:
         flake8 pwnlib setup.py docs travis --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         flake8 examples --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore='F403,F405'
         flake8 pwn --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore='F401,F403,F405'
+
+    - name: Minimum Python version check
+      run: |
+        pip install vermin
+        vermin -vvv --no-tips -t=3.10- --violations  ./pwnlib ./pwn

--- a/pwnlib/constants/constant.py
+++ b/pwnlib/constants/constant.py
@@ -1,9 +1,4 @@
-try:
-    base = long  # workaround for py2
-except NameError:
-    base = int
-
-class Constant(base):
+class Constant(int):
     def __new__(cls, s, i):
         obj = super(Constant, cls).__new__(cls, i)
         obj.s = s

--- a/pwnlib/util/getdents.py
+++ b/pwnlib/util/getdents.py
@@ -21,40 +21,42 @@ class linux_dirent:
     """
     Represent struct linux_dirent
 
-    struct linux_dirent
-    {
-      unsigned long d_ino;
-      unsigned long d_off;
-      unsigned short d_reclen;
-      char d_name[];
-    };
-    // https://elixir.bootlin.com/linux/v6.14.4/source/fs/readdir.c#L244
-    // the 32version of linux_dirent stores d_type after d_name
+    .. code-block:: c
 
-    struct linux_dirent64 {
-        u64		d_ino;
-        s64		d_off;
-        unsigned short	d_reclen;
-        unsigned char	d_type;
-        char		d_name[];
-    };
-    // https://elixir.bootlin.com/linux/v6.14.4/source/include/linux/dirent.h#L5
+        struct linux_dirent
+        {
+            unsigned long d_ino;
+            unsigned long d_off;
+            unsigned short d_reclen;
+            char d_name[];
+        };
+        // https://elixir.bootlin.com/linux/v6.14.4/source/fs/readdir.c#L244
+        // the 32version of linux_dirent stores d_type after d_name
 
-    enum
-    {
-        DT_UNKNOWN = 0,
-        DT_FIFO = 1,
-        DT_CHR = 2,
-        DT_DIR = 4,
-        DT_BLK = 6,
-        DT_REG = 8,
-        DT_LNK = 10,
-        DT_SOCK = 12,
-        DT_WHT = 14,
-        DT_SUBVOL = 16
-    };
-    // https://elixir.bootlin.com/linux/v6.14.4/source/include/linux/fs_types.h#L42
-    // https://elixir.bootlin.com/linux/v6.14.4/source/fs/bcachefs/dirent_format.h#L37
+        struct linux_dirent64 {
+            u64		d_ino;
+            s64		d_off;
+            unsigned short	d_reclen;
+            unsigned char	d_type;
+            char		d_name[];
+        };
+        // https://elixir.bootlin.com/linux/v6.14.4/source/include/linux/dirent.h#L5
+
+        enum
+        {
+            DT_UNKNOWN = 0,
+            DT_FIFO = 1,
+            DT_CHR = 2,
+            DT_DIR = 4,
+            DT_BLK = 6,
+            DT_REG = 8,
+            DT_LNK = 10,
+            DT_SOCK = 12,
+            DT_WHT = 14,
+            DT_SUBVOL = 16
+        };
+        // https://elixir.bootlin.com/linux/v6.14.4/source/include/linux/fs_types.h#L42
+        // https://elixir.bootlin.com/linux/v6.14.4/source/fs/bcachefs/dirent_format.h#L37
     """
 
     d_ino: int


### PR DESCRIPTION
Run https://github.com/netromdk/vermin to verify we don't use any Python features of newer versions than what we want to support.

This will help us adopt type hints more confidently. At least I hope it does.