### PR TITLE
Fix args for kitty launch

### DIFF
--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -328,7 +328,7 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
             args     = ['-e']
         elif 'KITTY_PID' in os.environ and which('kitty') and which('kitten'):
             terminal = 'kitten'
-            args = ['@', 'launch']
+            args = ['@', 'launch', '--copy-env', '--cwd', 'current']
         elif 'TERMINATOR_UUID' in os.environ and which('terminator'):
             if which('remotinator'):
                 terminal = 'remotinator'

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -423,7 +423,7 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
             # Likely the average user just wanted to tell pwntools to use kitty, rather than
             # thinking about how the terminal will actually be invoked.
             terminal = "kitten"
-            args = ["@", "launch"]
+            args = ['@', 'launch', '--copy-env', '--cwd', 'current']
         else:
             # Allowing this would make our life much harder (because we don't get the window id from
             # running `kitty`, but we do from `kitten @ launch`) and it's an easy fix for the user.


### PR DESCRIPTION
For gdb to work correctly it needs to get the same cwd cuze it's where the bin is located, if --cwd isn't specified gdb doesn't find the binary being debugged and show an error

<img width="695" height="189" alt="image" src="https://github.com/user-attachments/assets/c11e1561-3169-4c72-889f-a3c6555ddadd" />