### PR TITLE
Fix `server.close()` not closing the listen socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2647][2647] packing: Add `overlap` to overlap structures easily
 - [#2669][2669] asm: try native binutils before fallback architectures
 - [#2680][2680] Cleanup Python 2 legacy
+- [#2682][2682] Fix `server.close()` not closing the listen socket
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -154,6 +155,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2647]: https://github.com/Gallopsled/pwntools/pull/2647
 [2669]: https://github.com/Gallopsled/pwntools/pull/2669
 [2680]: https://github.com/Gallopsled/pwntools/pull/2680
+[2682]: https://github.com/Gallopsled/pwntools/pull/2682
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -32,12 +32,14 @@ class listen(sock):
         >>> l.sendline(b'Hello')
         >>> r.recvline()
         b'Hello\n'
+        >>> l.close()
+        >>> r.close()
 
         .. doctest::
             :options: +POSIX +TODO
             
             >>> # It works with ipv4 by default
-            >>> l = listen()
+            >>> l = listen(1234)
             >>> l.spawn_process('/bin/sh')
             >>> r = remote('127.0.0.1', l.lport)
             >>> r.sendline(b'echo Goodbye')
@@ -106,9 +108,12 @@ class listen(sock):
                 except (socket.error, AttributeError):
                     self.warn("could not set socket to accept also IPV4")
             listen_sock.bind(self.sockaddr)
+            # Set a timeout so `accept()` doesn't block indefinitely.
+            listen_sock.settimeout(0.5)
             self.lhost, self.lport = listen_sock.getsockname()[:2]
             if self.type == socket.SOCK_STREAM:
                 listen_sock.listen(1)
+            self._listen_sock = listen_sock
             break
         else:
             h.failure()
@@ -131,7 +136,16 @@ class listen(sock):
                         self.unrecv(data)
                     self.settimeout(self.timeout)
                     break
+                # If the timeout is reached, just try again.
+                # This allows us to check if the listen socket has been closed in the meantime.
+                except socket.timeout:
+                    continue
                 except socket.error as e:
+                    # EBADF means the listen socket was closed,
+                    # so we should stop trying to accept connections and just exit the thread.
+                    if e.errno == errno.EBADF:
+                        h.failure("Listen socket was closed")
+                        return
                     if e.errno == errno.EINTR:
                         continue
                     h.failure()
@@ -176,8 +190,5 @@ class listen(sock):
         self.__dict__['sock'] = s
 
     def close(self):
-        # since `close` is scheduled to run on exit we must check that we got
-        # a connection or the program will hang in the `join` call above
-        if self._accepter and self._accepter.is_alive():
-            return
+        self._listen_sock.close()
         super(listen, self).close()

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -143,7 +143,8 @@ class listen(sock):
                 except socket.error as e:
                     # EBADF means the listen socket was closed,
                     # so we should stop trying to accept connections and just exit the thread.
-                    if e.errno == errno.EBADF:
+                    # ENOTSOCK is raised on Windows when accepting on a closed socket.
+                    if e.errno in (errno.EBADF, errno.ENOTSOCK):
                         h.failure("Listen socket was closed")
                         return
                     if e.errno == errno.EINTR:

--- a/pwnlib/tubes/server.py
+++ b/pwnlib/tubes/server.py
@@ -14,6 +14,9 @@ class server(sock):
     r"""Creates an TCP or UDP-server to listen for connections. It supports
     both IPv4 and IPv6.
 
+    It can be used in two ways: either by calling :meth:`next_connection()` to get a tube for each incoming connection, or by providing a callback that is called with the tube for each incoming connection.
+    When providing a callback, the accepter thread can either block while the callback is running or start the callback in a new thread. The :meth:`next_connection()` method only works when no callback is provided.
+
     Arguments:
         port(int): The port to connect to.
             Defaults to a port auto-selected by the operating system.
@@ -22,6 +25,7 @@ class server(sock):
         fam: The string "any", "ipv4" or "ipv6" or an integer to pass to :func:`socket.getaddrinfo`.
         typ: The string "tcp" or "udp" or an integer to pass to :func:`socket.getaddrinfo`.
         callback: A function to be started on incoming connections. It should take a :class:`pwnlib.tubes.remote` as its only argument.
+        blocking(bool): Whether to block the accepter thread while the callback is running. The callback is executed in another thread when ``False``. Only relevant if a callback is provided. Defaults to ``False``.
 
     Examples:
 
@@ -31,15 +35,20 @@ class server(sock):
         >>> client_conn.sendline(b'Hello')
         >>> server_conn.recvline()
         b'Hello\n'
+        >>> client_conn.close()
+        >>> s.close()
+
         >>> def cb(r):
         ...     client_input = r.readline()
         ...     r.send(client_input[::-1])
         ...
-        >>> t = server(8889, callback=cb)
+        >>> t = server(8888, callback=cb)
         >>> client_conn = remote('localhost', t.lport)
         >>> client_conn.sendline(b'callback')
         >>> client_conn.recv()
         b'\nkcabllac'
+        >>> client_conn.close()
+        >>> t.close()
     """
 
     #: Local port
@@ -89,6 +98,8 @@ class server(sock):
             listen_sock = socket.socket(self.family, self.type, self.proto)
             listen_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             listen_sock.bind(self.sockaddr)
+            # Set a timeout so `accept()` doesn't block indefinitely.
+            listen_sock.settimeout(0.5)
             self.lhost, self.lport = listen_sock.getsockname()[:2]
             if self.type == socket.SOCK_STREAM:
                 listen_sock.listen(1)
@@ -113,9 +124,17 @@ class server(sock):
                             listen_sock.connect(rhost)
                             sock = listen_sock
                             self.unrecv(data)
-                        sock.settimeout(self.timeout)
                         break
+                    # If the timeout is reached, just try again.
+                    # This allows us to check if the server socket has been closed in the meantime.
+                    except socket.timeout:
+                        continue
                     except socket.error as e:
+                        # EBADF means the server socket was closed,
+                        # so we should stop trying to accept connections and just exit the thread.
+                        if e.errno == errno.EBADF:
+                            h.failure("Server socket was closed")
+                            return
                         if e.errno == errno.EINTR:
                             continue
                         h.failure()
@@ -141,11 +160,14 @@ class server(sock):
         self._accepter.start()
 
     def next_connection(self):
+        """next_connection() -> tubes.remote
+        Returns the next connection to the server if no callback was provided.
+        """
         return self.connections.get()
 
     def close(self):
-        # since `close` is scheduled to run on exit we must check that we got
-        # a connection or the program will hang in the `join` call above
-        if self._accepter and self._accepter.is_alive():
-            return
+        """close() -> None
+        Closes the listening socket and waits for the accepter thread to finish.
+        """
         super(server, self).close()
+        self._accepter.join(timeout=self.timeout)

--- a/pwnlib/tubes/server.py
+++ b/pwnlib/tubes/server.py
@@ -144,7 +144,7 @@ class server(sock):
                         return
 
                 self.rhost, self.rport = rhost[:2]
-                r = remote(self.rhost, self.rport, sock = sock, level = self.level)
+                r = remote(self.rhost, self.rport, sock = sock, timeout = self.timeout, level = self.level)
                 h.success('Got connection from %s on port %d' % (self.rhost, self.rport))
                 if callback:
                     if not blocking:

--- a/pwnlib/tubes/server.py
+++ b/pwnlib/tubes/server.py
@@ -132,7 +132,8 @@ class server(sock):
                     except socket.error as e:
                         # EBADF means the server socket was closed,
                         # so we should stop trying to accept connections and just exit the thread.
-                        if e.errno == errno.EBADF:
+                        # ENOTSOCK is raised on Windows when accepting on a closed socket.
+                        if e.errno in (errno.EBADF, errno.ENOTSOCK):
                             h.failure("Server socket was closed")
                             return
                         if e.errno == errno.EINTR:


### PR DESCRIPTION
It would block on `accept` forever, not freeing the listening port. Break out of `accept()` regularly to check if the socket was closed in the meantime and stop the thread. The previous check in `close()` seems to have been copied from the `listen` tube, but it doesn't apply here.

```python
for _ in range(2):
    with server(1337) as s:
        r = remote('localhost', 1337)
        l = s.next_connection()
        r.sendline(b'Hello, world!')
        print(l.recvline())
        l.close()
        r.close()
```

would crash on the second loop because the port was already in use.

```[+] Trying to bind to :: on port 1337: Done
[+] Waiting for connections on :::1337: Got connection from ::ffff:127.0.0.1 on port 38640
[+] Opening connection to localhost on port 1337: Done
[◢] Waiting for connections on :::1337
b'Hello, world!\n'
[*] Closed connection to ::ffff:127.0.0.1 port 38640
[*] Closed connection to localhost port 1337
[q] Trying to bind to :: on port 1337: Trying ::
Traceback (most recent call last):
  File "server_test.py", line 4, in <module>
    with server(1337) as s:
         ^^^^^^^^^^^^
  File "/home/pwn/pwntools/pwnlib/tubes/server.py", line 91, in __init__
    listen_sock.bind(self.sockaddr)
OSError: [Errno 98] Address already in use
```