### PR TITLE
doctest: Print duration after each document

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import doctest
 import signal
 import subprocess
 import sys
+from datetime import datetime, timezone
 
 build_dash = tags.has('dash')
 
@@ -118,7 +119,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pwntools'
-copyright = u'2016, Gallopsled et al.'
+copyright = u'2016-2026, Gallopsled et al.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -260,7 +261,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'pwntools.tex', u'pwntools Documentation',
-   u'2016, Gallopsled et al.', 'manual'),
+   u'2016-2026, Gallopsled et al.', 'manual'),
 ]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
@@ -293,7 +294,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'pwntools', u'pwntools Documentation',
-     [u'2016, Gallopsled et al.'], 1)
+     [u'2016-2026, Gallopsled et al.'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -428,15 +429,38 @@ class PlatformDocTestRunner(sphinx.ext.doctest.SphinxDocTestRunner):
         return super(PlatformDocTestRunner, self).run(test, compileflags, out, clear_globs)
 
 class PlatformDocTestBuilder(sphinx.ext.doctest.DocTestBuilder):
-    _test_runner = None
+
+    def __init__(self, *args, **kwargs):
+        super(PlatformDocTestBuilder, self).__init__(*args, **kwargs)
+        self._test_runner = None
+        self._doctree_had_tests = False
 
     @property
     def test_runner(self):
         return self._test_runner
-    
+
     @test_runner.setter
     def test_runner(self, value):
         self._test_runner = PlatformDocTestRunner(value._checker, value._verbose, value.optionflags)
+
+    def test_doc(self, docname, doctree):
+        start = datetime.now(timezone.utc).astimezone()
+        # self._out(f"[{start.isoformat(timespec='milliseconds')}] doctest start: {docname}\n")
+        self._doctree_had_tests = False
+        try:
+            return super(PlatformDocTestBuilder, self).test_doc(docname, doctree)
+        finally:
+            # Only print the timestamp if there were actually tests run.
+            if self._doctree_had_tests:
+                end = datetime.now(timezone.utc).astimezone()
+                duration = (end - start).total_seconds()
+                self._out(f"[{end.isoformat(timespec='milliseconds')} - {duration:.2f}s]\n")
+            self._doctree_had_tests = False
+
+    def test_group(self, group):
+        # Only called when there are tests to run in the current document.
+        self._doctree_had_tests = True
+        return super(PlatformDocTestBuilder, self).test_group(group)
 
 if 'doctest' in sys.argv:
     def setup(app):

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -37,6 +37,8 @@ This exposes a standard interface to talk to processes, sockets, serial ports,
 and all manner of things, along with some nifty helpers for common tasks.
 For example, remote connections via :mod:`pwnlib.tubes.remote`.
 
+::
+
     >>> conn = remote('ftp.ubuntu.com',21)
     >>> conn.recvline() # doctest: +ELLIPSIS
     b'220 ...'


### PR DESCRIPTION
Show time when tests of a document finished and how long they took. This should help identifying long running tests which cause the CI to timeout.

The [`sphinx.ext.duration`](https://www.sphinx-doc.org/en/master/usage/extensions/duration.html) extension just measures the time it took to read a document not how long the doctests ran, which is not interesting to us.

```
====================== slowest reading durations =======================
3.435 shellcraft/amd64
3.428 shellcraft/aarch64
3.413 shellcraft/riscv64
3.324 shellcraft/thumb
3.248 shellcraft/arm
```

This custom mod monkey-patches sphinx to track the test execution time and display it after the results were printed. When upgrading sphinx, we'll have to revisit this, but we already have to due to the `+LINUX` flags.

This shows which document took so long - `intro`?!
```
Document: intro
---------------
1 item passed all tests:
  45 tests in default
45 tests in 1 item.
45 passed.
Test passed.
[2026-02-21T13:45:54.433+00:00 - 270.27s]

Document: libcdb
----------------
1 item passed all tests:
  43 tests in default
43 tests in 1 item.
43 passed.
Test passed.
[2026-02-21T13:47:24.076+00:00 - 89.64s]
```