### PR TITLE
Add glibc safe-linking `reveal_ptr_same_page`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2669][2669] asm: try native binutils before fallback architectures
 - [#2673][2673] Add libc module for libc-related functions
 - [#2680][2680] Cleanup Python 2 legacy
+- [#2686][2686] Add glibc safe-linking `glibc.reveal_ptr_same_page`
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -156,6 +157,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2669]: https://github.com/Gallopsled/pwntools/pull/2669
 [2673]: https://github.com/Gallopsled/pwntools/pull/2673
 [2680]: https://github.com/Gallopsled/pwntools/pull/2680
+[2686]: https://github.com/Gallopsled/pwntools/pull/2686
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/libc/glibc.py
+++ b/pwnlib/libc/glibc.py
@@ -56,7 +56,8 @@ def ptr_demangle(guard: int, mangled: int) -> int:
 
 def protect_ptr(word_addr: int, value: int) -> int:
     """
-    Perform ``PROTECT_PTR`` in glibc heap macros to protect pointers.
+    Perform ` ``PROTECT_PTR`` <https://elixir.bootlin.com/glibc/glibc-2.42/source/malloc/malloc.c#L331>`__ 
+    in glibc heap macros to protect pointers.
     ``REVEAL_PTR`` is basically ``PROTECT_PTR``, and since we don't know
     the address of the word, so use ``protect_ptr`` instead.
 
@@ -70,5 +71,39 @@ def protect_ptr(word_addr: int, value: int) -> int:
     Examples:
         >>> hex(glibc.protect_ptr(0x5e5555556700, 0))
         '0x5e5555556'
+        >>> ptr_addr = 0x555555559200
+        >>> ptr_value = 0x7ffff7f96058
+        >>> glibc.protect_ptr(ptr_addr, glibc.protect_ptr(ptr_addr, ptr_value)) == ptr_value
+        True
     """
     return (word_addr >> 12) ^ value
+
+def reveal_ptr_same_page(ptr_value: int) -> int:
+    """
+    Reveal a pointer that was mangled by protect_ptr without knowing where the pointer is stored.
+    Only works if the leaked pointer itself is stored on the same page as its value.
+
+    Arguments:
+        ptr_value(int): The mangled pointer.
+
+    Returns:
+        int: The original pointer.
+    
+    Example:
+
+        >>> context.clear(arch='amd64')
+        >>> ptr_addr = 0x555555559200
+        >>> ptr_value = 0x555555559380
+        >>> glibc.reveal_ptr_same_page(glibc.protect_ptr(ptr_addr, ptr_value)) == ptr_value
+        True
+        >>> ptr_addr = 0x555555559200
+        >>> ptr_value = 0x55555556a380
+        >>> glibc.reveal_ptr_same_page(glibc.protect_ptr(ptr_addr, ptr_value)) == ptr_value
+        False
+    """
+    mask = 0xfff << (context.bits - 12)
+    while mask:
+        key = ptr_value & mask
+        ptr_value ^= key >> 12
+        mask >>= 12
+    return ptr_value


### PR DESCRIPTION
Reveals a pointer mangled using PROTECT_PTR without knowing where it is stored. Only works when the pointer points to the same page as it is stored on, which happens regularly in normal tcache forward-ptrs.

Refs #2447