### PR TITLE
Add (un)pack shorthands for 40-56 bit numbers `u48()`/`p48()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2669][2669] asm: try native binutils before fallback architectures
 - [#2673][2673] Add libc module for libc-related functions
 - [#2680][2680] Cleanup Python 2 legacy
-- [#2687][268] Add (un)pack shorthands for 40-56 bit numbers `u48()`/`p48()`
+- [#2687][2687] Add (un)pack shorthands for 40-56 bit numbers `u48()`/`p48()`
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2669][2669] asm: try native binutils before fallback architectures
 - [#2673][2673] Add libc module for libc-related functions
 - [#2680][2680] Cleanup Python 2 legacy
+- [#2687][268] Add (un)pack shorthands for 40-56 bit numbers `u48()`/`p48()`
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -156,6 +157,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2669]: https://github.com/Gallopsled/pwntools/pull/2669
 [2673]: https://github.com/Gallopsled/pwntools/pull/2673
 [2680]: https://github.com/Gallopsled/pwntools/pull/2680
+[2687]: https://github.com/Gallopsled/pwntools/pull/2687
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/elf/elf.py
+++ b/pwnlib/elf/elf.py
@@ -2329,6 +2329,21 @@ class ELF(ELFFile):
         self._update_args(kw)
         return self.write(address, packing.p64(data, *a, **kw))
 
+    def p56(self,  address, data, *a, **kw):
+        """Writes a 56-bit integer ``data`` to the specified ``address``"""
+        self._update_args(kw)
+        return self.write(address, packing.p56(data, *a, **kw))
+
+    def p48(self,  address, data, *a, **kw):
+        """Writes a 48-bit integer ``data`` to the specified ``address``"""
+        self._update_args(kw)
+        return self.write(address, packing.p48(data, *a, **kw))
+
+    def p40(self,  address, data, *a, **kw):
+        """Writes a 40-bit integer ``data`` to the specified ``address``"""
+        self._update_args(kw)
+        return self.write(address, packing.p40(data, *a, **kw))
+
     def p32(self,  address, data, *a, **kw):
         """Writes a 32-bit integer ``data`` to the specified ``address``"""
         self._update_args(kw)
@@ -2353,6 +2368,21 @@ class ELF(ELFFile):
         """Unpacks an integer from the specified ``address``."""
         self._update_args(kw)
         return packing.u64(self.read(address, 8), *a, **kw)
+
+    def u56(self,    address, *a, **kw):
+        """Unpacks an integer from the specified ``address``."""
+        self._update_args(kw)
+        return packing.u56(self.read(address, 7), *a, **kw)
+
+    def u48(self,    address, *a, **kw):
+        """Unpacks an integer from the specified ``address``."""
+        self._update_args(kw)
+        return packing.u48(self.read(address, 6), *a, **kw)
+
+    def u40(self,    address, *a, **kw):
+        """Unpacks an integer from the specified ``address``."""
+        self._update_args(kw)
+        return packing.u40(self.read(address, 5), *a, **kw)
 
     def u32(self,    address, *a, **kw):
         """Unpacks an integer from the specified ``address``."""

--- a/pwnlib/tubes/tube.py
+++ b/pwnlib/tubes/tube.py
@@ -1650,12 +1650,18 @@ class tube(Timeout, Logger):
 
 
     def p64(self, *a, **kw):        return self.send(packing.p64(*a, **kw))
+    def p56(self, *a, **kw):        return self.send(packing.p56(*a, **kw))
+    def p48(self, *a, **kw):        return self.send(packing.p48(*a, **kw))
+    def p40(self, *a, **kw):        return self.send(packing.p40(*a, **kw))
     def p32(self, *a, **kw):        return self.send(packing.p32(*a, **kw))
     def p16(self, *a, **kw):        return self.send(packing.p16(*a, **kw))
     def p8(self, *a, **kw):         return self.send(packing.p8(*a, **kw))
     def pack(self, *a, **kw):       return self.send(packing.pack(*a, **kw))
 
     def u64(self, *a, **kw):        return packing.u64(self.recvn(8), *a, **kw)
+    def u56(self, *a, **kw):        return packing.u56(self.recvn(7), *a, **kw)
+    def u48(self, *a, **kw):        return packing.u48(self.recvn(6), *a, **kw)
+    def u40(self, *a, **kw):        return packing.u40(self.recvn(5), *a, **kw)
     def u32(self, *a, **kw):        return packing.u32(self.recvn(4), *a, **kw)
     def u16(self, *a, **kw):        return packing.u16(self.recvn(2), *a, **kw)
     def u8(self, *a, **kw):         return packing.u8(self.recvn(1), *a, **kw)

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -288,7 +288,7 @@ def unpack_many(data, word_size = None):
 # Make individual packers, e.g. _p8lu
 #
 ops   = ['p','u']
-sizes = {8:'b', 16:'h', 32:'i', 64:'q'}
+sizes = {8:'b', 16:'h', 32:'i', 40: '', 48: '', 56: '', 64:'q'}
 ends  = ['b','l']
 signs = ['s','u']
 
@@ -298,6 +298,20 @@ op_verbs         = {'p': 'pack', 'u': 'unpack'}
 def make_single(op,size,end,sign):
     name = '_%s%s%s%s' % (op, size, end, sign)
     fmt  = sizes[size]
+
+    # Handle non-standard sizes without the struct module.
+    if fmt == '':
+        endianess = 'big' if end == 'b' else 'little'
+        if op == 'u':
+            def routine(data, stacklevel=1):
+                data = _need_bytes(data, stacklevel)
+                return unpack(data, size, endianness=endianess, sign=sign == 's')
+        else:
+            def routine(data, stacklevel=None):
+                return pack(data, size, endianness=endianess, sign=sign == 's')
+        routine.__name__ = routine.__qualname__ = name
+        return name, routine            
+
     end = '>' if end == 'b' else '<'
 
     if sign == 'u':
@@ -411,6 +425,81 @@ def p32(number, endianness = None, **kwargs):
     return _do_packing('p', 32, number, endianness)
 
 @LocalNoarchContext
+def p40(number, endianness = None, **kwargs):
+    """p40(number, endianness, sign, ...) -> bytes
+
+    Packs an 40-bit integer
+
+    Arguments:
+        number (int): Number to convert
+        endianness (str): Endianness of the converted integer ("little"/"big")
+        sign (str): Signedness of the converted integer ("unsigned"/"signed")
+        kwargs (dict): Arguments passed to context.local(), such as
+            ``endian`` or ``signed``.
+
+    Returns:
+        The packed number as a byte string
+
+    Examples:
+
+        >>> p40(0x4142434445, 'big')
+        b'ABCDE'
+        >>> p40(0x4142434445, endianness='big')
+        b'ABCDE'
+    """
+    return _do_packing('p', 40, number, endianness)
+
+@LocalNoarchContext
+def p48(number, endianness = None, **kwargs):
+    """p48(number, endianness, sign, ...) -> bytes
+
+    Packs an 48-bit integer
+
+    Arguments:
+        number (int): Number to convert
+        endianness (str): Endianness of the converted integer ("little"/"big")
+        sign (str): Signedness of the converted integer ("unsigned"/"signed")
+        kwargs (dict): Arguments passed to context.local(), such as
+            ``endian`` or ``signed``.
+
+    Returns:
+        The packed number as a byte string
+
+    Examples:
+
+        >>> p48(0x414243444546, 'big')
+        b'ABCDEF'
+        >>> p48(0x414243444546, endianness='big')
+        b'ABCDEF'
+    """
+    return _do_packing('p', 48, number, endianness)
+
+@LocalNoarchContext
+def p56(number, endianness = None, **kwargs):
+    """p56(number, endianness, sign, ...) -> bytes
+
+    Packs an 56-bit integer
+
+    Arguments:
+        number (int): Number to convert
+        endianness (str): Endianness of the converted integer ("little"/"big")
+        sign (str): Signedness of the converted integer ("unsigned"/"signed")
+        kwargs (dict): Arguments passed to context.local(), such as
+            ``endian`` or ``signed``.
+
+    Returns:
+        The packed number as a byte string
+
+    Examples:
+
+        >>> p56(0x41424344454647, 'big')
+        b'ABCDEFG'
+        >>> p56(0x41424344454647, endianness='big')
+        b'ABCDEFG'
+    """
+    return _do_packing('p', 56, number, endianness)
+
+@LocalNoarchContext
 def p64(number, endianness = None, **kwargs):
     """p64(number, endianness, sign, ...) -> bytes
 
@@ -488,6 +577,60 @@ def u32(data, endianness = None, **kwargs):
         The unpacked number
     """
     return _do_packing('u', 32, data, endianness)
+
+@LocalNoarchContext
+def u40(data, endianness = None, **kwargs):
+    """u40(data, endianness, sign, ...) -> int
+
+    Unpacks an 40-bit integer
+
+    Arguments:
+        data (bytes): Byte string to convert
+        endianness (str): Endianness of the converted integer ("little"/"big")
+        sign (str): Signedness of the converted integer ("unsigned"/"signed")
+        kwargs (dict): Arguments passed to context.local(), such as
+            ``endian`` or ``signed``.
+
+    Returns:
+        The unpacked number
+    """
+    return _do_packing('u', 40, data, endianness)
+
+@LocalNoarchContext
+def u48(data, endianness = None, **kwargs):
+    """u48(data, endianness, sign, ...) -> int
+
+    Unpacks an 48-bit integer
+
+    Arguments:
+        data (bytes): Byte string to convert
+        endianness (str): Endianness of the converted integer ("little"/"big")
+        sign (str): Signedness of the converted integer ("unsigned"/"signed")
+        kwargs (dict): Arguments passed to context.local(), such as
+            ``endian`` or ``signed``.
+
+    Returns:
+        The unpacked number
+    """
+    return _do_packing('u', 48, data, endianness)
+
+@LocalNoarchContext
+def u56(data, endianness = None, **kwargs):
+    """u56(data, endianness, sign, ...) -> int
+
+    Unpacks an 56-bit integer
+
+    Arguments:
+        data (bytes): Byte string to convert
+        endianness (str): Endianness of the converted integer ("little"/"big")
+        sign (str): Signedness of the converted integer ("unsigned"/"signed")
+        kwargs (dict): Arguments passed to context.local(), such as
+            ``endian`` or ``signed``.
+
+    Returns:
+        The unpacked number
+    """
+    return _do_packing('u', 56, data, endianness)
 
 @LocalNoarchContext
 def u64(data, endianness = None, **kwargs):


### PR DESCRIPTION
`u40`/`p40`, `u48`/`p48`, and `u56`/`p56` can be used to quickly unpack shorter integers.

`u48` can be used to unpack addresses leaked using a c-string function which stops at the first null-byte. Instead of doing `u64(data.ljust(8, b'\x00"))` you can now just do `u48(data)`.

I'm not sure `u56` is that useful, those could be removed again 🤷 

Refs #2447
