### PR TITLE
Close SSH client connection when authentication failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2669][2669] asm: try native binutils before fallback architectures
 - [#2673][2673] Add libc module for libc-related functions
 - [#2680][2680] Cleanup Python 2 legacy
+- [#2688][2688] Close SSH client connection when authentication failed
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -156,6 +157,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2669]: https://github.com/Gallopsled/pwntools/pull/2669
 [2673]: https://github.com/Gallopsled/pwntools/pull/2673
 [2680]: https://github.com/Gallopsled/pwntools/pull/2680
+[2688]: https://github.com/Gallopsled/pwntools/pull/2688
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -9,7 +9,7 @@ import tempfile
 import threading
 import time
 
-from pwnlib import term
+from pwnlib import atexit, term
 from pwnlib.context import context, LocalContext
 from pwnlib.exception import PwnlibException
 from pwnlib.log import Logger
@@ -716,11 +716,13 @@ class ssh(Timeout, Logger):
                 if user and auth_none and str(e) == "No authentication methods available":
                     self.client.get_transport().auth_none(user)
                 else:
+                    self.close()
                     raise
 
             self.transport = self.client.get_transport()
             self.transport.use_compression(True)
 
+            atexit.register(self.close)
             h.success()
 
         if self.raw:


### PR DESCRIPTION
The TCP connection stayed open after an exception was thrown during authentication, even when a `with`-statement guarding the call. Close the connection before re-raising the exception.

Fixes #2678