### PR TITLE
Refactor zsh completion script and deprecate `-e` in `pwn asm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,9 +125,9 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2686][2686] Add glibc safe-linking `glibc.reveal_ptr_same_page`
 - [#2704][2704] ssh: Fix distro lookup on Ubuntu 24.04
 - [#2655][2655] Add `context.debugger` to select which debugger to use
+- [#2689][2689] Refactor zsh completion script and deprecate `-e` in `pwn asm`
 - [#2713][2713] Remove python-dateutil dependency
 
-[2677]: https://github.com/Gallopsled/pwntools/pull/2677
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
 [2638]: https://github.com/Gallopsled/pwntools/pull/2638
@@ -177,6 +177,8 @@ The table below shows which release corresponds to each branch, and what date th
 [2686]: https://github.com/Gallopsled/pwntools/pull/2686
 [2704]: https://github.com/Gallopsled/pwntools/pull/2704
 [2655]: https://github.com/Gallopsled/pwntools/pull/2655
+[2677]: https://github.com/Gallopsled/pwntools/pull/2677
+[2689]: https://github.com/Gallopsled/pwntools/pull/2689
 [2713]: https://github.com/Gallopsled/pwntools/pull/2713
 
 ## 4.15.1

--- a/extra/zsh_completion/_pwn
+++ b/extra/zsh_completion/_pwn
@@ -49,11 +49,11 @@ _pwn() {
       case $words[1] in
         asm)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-f --format)'{-f,--format}'=[Output format (defaults to hex for ttys, otherwise raw)]:-f :(raw hex string elf)' \
-            '(-o --output)'{-o,--output}'=[Output file (defaults to stdout)]:' \
-            '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
-            '(-v --avoid)'{-v,--avoid}'=[Encode the shellcode to avoid the listed bytes (provided as hex)]:' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-f --format)'{-f,--format}'[Output format]:FORMAT:(raw hex string elf)' \
+            '(-o --output)'{-o,--output}'[Output file (defaults to stdout)]:_files' \
+            '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes (provided as hex)]:HEXBYTES: ' \
             '(-n --newline)'{-n,--newline}'[Encode the shellcode to avoid newlines]' \
             '(-z --zero)'{-z,--zero}'[Encode the shellcode to avoid NULL bytes]' \
             '(-d --debug)'{-d,--debug}'[Debug the shellcode with GDB]' \
@@ -65,8 +65,8 @@ _pwn() {
         checksec)
             _arguments \
               '(-h --help)'{-h,--help}'[show help message and exit]' \
-              '--file[File to check]:ELF:_files' \
-              '*:ELF:_files'
+              '--file[File to check]:ELF file:_files' \
+              '*:ELF file:_files'
             ;;
         constgrep)
           _arguments \
@@ -74,31 +74,57 @@ _pwn() {
             '(-e --exact)'{-e,--exact}'[Do an exact match for a constant instead of searching for a regex]' \
             '(-i --case-insensitive)'{-i,--case-insensitive}'[Search case insensitive]' \
             '(-m --mask-mode)'{-m,--mask-mode}'[Instead of searching for a specific constant value, search for values not containing strictly less bits that the given value.]' \
-            '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '1:REGEX: ' \
+            '2:CONST: ' \
+            '*: :'
             ;;
         cyclic)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-a --alphabet)'{-a,--alphabet}'=[The alphabet to use in the cyclic pattern (defaults to all lower case letters)]:' \
-            '(-n --length)'{-n,--length}'=[Size of the unique subsequences (defaults to 4).]:' \
-            '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
-            '(-l -o --offset --lookup)'{-l,-o,--offset,--lookup}'=[Do a lookup instead printing the alphabet]:' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-a --alphabet)'{-a,--alphabet}'[The alphabet to use in the cyclic pattern (defaults to all lower case letters)]:ALPHABETS: ' \
+            '(-n --length)'{-n,--length}'[Size of the unique subsequences (defaults to 4)]:LENGTH: ' \
+            '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '(-l -o --offset --lookup)'{-l,-o,--offset,--lookup}'[Do a lookup instead printing the alphabet]:LOOKUP: ' \
+            '1:COUNT: ' \
+            '*: :'
             ;;
         debug)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '-x=[Execute GDB commands from this file.]:' \
-            '--pid=[PID to attach to]:' \
-            '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
-            '--exec=[File to debug]:' \
-            '--process=[Name of the process to attach to (e.g. "bash")]:' \
-            '--sysroot=[GDB sysroot path]:' \
-            ;;
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '-x[Execute GDB commands from this file]:GDBSCRIPT:_files' \
+            '--pid[PID to attach to]:PID:->pid' \
+            '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '--exec[File to debug]:EXE:_files' \
+            '--process[Name of the process to attach to (e.g. "bash")]:NAME:->procs' \
+            '--sysroot[GDB sysroot path]:PATH:_files -/'
+          if [[ $state == 'pid' ]] {
+                local line pids lines
+                pids=()
+                # extract command output line by line
+                lines=("${(@f)$(ps --ppid 2 -p 2 -N -o pid=,tty=,user=,comm=)}")
+                for line ($lines) {
+                    pids+=${line[(w)1]} # extract first word (pid)
+                }
+                _wanted nonk-pids expl 'non-kernel process ID' \
+                    compadd -o nosort -ld lines -a pids
+          } elif [[ $state == 'procs' ]] {
+                local line names lines
+                names=()
+                # extract command output line by line
+                lines=("${(@f)$(ps --ppid 2 -p 2 -N -o comm=,pid=,tty=,user=)}")
+                for line ($lines) {
+                    names+=${line[(w)1]} # extract first word (pid)
+                }
+                _wanted nonk-comm expl 'non-kernel process names' \
+                    compadd -o nosort -ld lines -a names
+          }
+          ;;
         disasm)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
-            '(-a --address)'{-a,--address}'=[Base address]:' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '(-a --address)'{-a,--address}'[Base address]:ADDR: ' \
             '--color[Color output]' \
             '--no-color[Disable color output]' \
             '*:HEX: '
@@ -126,18 +152,15 @@ _pwn() {
         errno)
           _arguments \
             '(-h --help)'{-h,--help}'[show help message and exit]' \
-            '1:ERROR: ' \
+            '2:ERROR: ' \
             '*: :'
             ;;
         hex)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-p --prefix)'{-p,--prefix}'=[Insert a prefix before each byte]:' \
-            '(-s --separator)'{-s,--separator}'=[Add a separator between each byte]:' \
-            ;;
-        libcdb)
-          _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-p --prefix)'{-p,--prefix}'[Insert a prefix before each byte]:PREFIX: ' \
+            '(-s --separator)'{-s,--separator}'[Add a separator between each byte]:SEPARATOR: ' \
+            '*:DATA: '
             ;;
         libcdb)
           local -a libc_cmds=(
@@ -202,17 +225,38 @@ _pwn() {
             ;;
         pwnstrip)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
             '(-b --build-id)'{-b,--build-id}'[Strip build ID]' \
-            '(-p --patch)'{-p,--patch}'=[Patch function]:' \
-            '(-o --output)'{-o,--output}'=[None]:' \
-            ;;
+            '(-p --patch)'{-p,--patch}'[Patch function]:FUNCTION:->funcs' \
+            '(-o --output)'{-o,--output}'[Output file]:OUTPUT:_files' \
+            '1:FILE:_files' \
+            '*: :'
+          if [[ $state == 'funcs' ]] {
+            _message "FUNCTION"
+            if [[ $#line -ne 0 ]] {
+              filename=$~line[1]
+            } elif [[ -f $~words[-1] ]] {
+              filename=$~words[-1]
+            } else {
+                return
+            }
+            local names
+            output=$(readelf -Ws $filename 2>/dev/null)
+            if [[ $? -ne 0 ]] {
+                return
+            }
+            names=("${(f)$(awk '$4=="FUNC" && $7!="UND" {print $8}' <(echo "$output"))}")
+            if [[ $#names -gt 0 ]] {
+              _values "FUNCTIONS" $names
+            }
+          }
+          ;;
         scramble)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-f --format)'{-f,--format}'=[Output format (defaults to hex for ttys, otherwise raw)]:-f :(raw hex string elf)' \
-            '(-o --output)'{-o,--output}'=[Output file (defaults to stdout)]:' \
-            '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-f --format)'{-f,--format}'[Output format (defaults to hex for ttys, otherwise raw)]:FORMAT:(raw hex string elf)' \
+            '(-o --output)'{-o,--output}'[Output file (defaults to stdout)]:OUTPUT:_files' \
+            '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
             '(-p --alphanumeric)'{-p,--alphanumeric}'[Encode the shellcode with an alphanumeric encoder]' \
             '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes]:AVOID: ' \
             '(-n --newline)'{-n,--newline}'[Encode the shellcode to avoid newlines]' \
@@ -226,7 +270,7 @@ _pwn() {
             '(-o --out)'{-o,--out}'[Output file (default: stdout)]:OUTPUT:_files' \
             '(-f --format)'{-f,--format}'[Output format (default: hex)]:FORMAT:(e r s c h i a p d)' \
             '(-d --debug)'{-d,--debug}'[Debug the shellcode with GDB]' \
-            '--delim=[Set the delimiter between multiple shellcodes]:' \
+            '--delim[Set the delimiter between multilple shellcodes]:DELIM: ' \
             '(-b --before)'{-b,--before}'[Insert a debug trap before the code]' \
             '(-a --after)'{-a,--after}'[Insert a debug trap after the code]' \
             '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes]:AVOID: ' \
@@ -243,17 +287,19 @@ _pwn() {
             ;;
         template)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '--host=[Remote host / SSH server]:' \
-            '--port=[Remote port / SSH port]:' \
-            '--user=[SSH Username]:' \
-            '(--pass --password)'{--pass,--password}'=[SSH Password]:' \
-            '--libc=[Path to libc binary to use. If not given, the current directory is searched for a libc binary.]:' \
-            '--path=[Remote path of file on SSH server]:' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '--host[Remote host / SSH server]:HOST:_ssh_hosts ' \
+            '--port[Remote port / SSH port]:PORT: ' \
+            '--user[SSH Username]:USER:_ssh_users' \
+            '(--pass --password)'{--pass,--password}'[SSH Password]:PASSWORD: ' \
+            '--libc[Path to libc binary to use. If not given, the current directory is searched for a libc binary]:LIBC_PATH:_files' \
+            '--path[Remote path of file on SSH server]:PATH:_files' \
             '--quiet[Less verbose template comments]' \
-            '--color=[Print the output in color]:--color :(never always auto)' \
-            '--template=[Path to a custom template. Tries to use "~/.config/pwntools/templates/pwnup.mako", if it exists. Check "/pwntools/pwnlib/data/templates/pwnup.mako" for the default template shipped with pwntools.]:' \
+            '--color[Print the output in color]:COLOR:(never always auto)' \
+            '--template[Path to a custom template]:TEMPLATE_PATH:_files' \
             '--no-auto[Do not automatically detect missing binaries]' \
+            '1:EXE:_files' \
+            '*: :'
             ;;
         unhex)
           _arguments \

--- a/extra/zsh_completion/_pwn
+++ b/extra/zsh_completion/_pwn
@@ -269,7 +269,7 @@ _pwn() {
             '(-o --out)'{-o,--out}'[Output file (default: stdout)]:OUTPUT:_files' \
             '(-f --format)'{-f,--format}'[Output format (default: hex)]:FORMAT:(e r s c h i a p d)' \
             '(-d --debug)'{-d,--debug}'[Debug the shellcode with GDB]' \
-            '--delim[Set the delimiter between multilple shellcodes]:DELIM: ' \
+            '--delim[Set the delimiter between multiple shellcodes]:DELIM: ' \
             '(-b --before)'{-b,--before}'[Insert a debug trap before the code]' \
             '(-a --after)'{-a,--after}'[Insert a debug trap after the code]' \
             '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes]:AVOID: ' \

--- a/extra/zsh_completion/_pwn
+++ b/extra/zsh_completion/_pwn
@@ -8,6 +8,52 @@
 # NOTE: Don't use Zargparse any more as it may bring known errors!
 # ----------------------------------------------------------------------------------------
 
+_comp_pid() {
+    if [[ $1 == 'pid' ]] {
+        local line pids lines
+        pids=()
+        # extract command output line by line
+        lines=("${(@f)$(ps --ppid 2 -p 2 -N -o pid=,tty=,user=,comm=)}")
+        for line ($lines) {
+            pids+=${line[(w)1]} # extract first word (pid)
+        }
+        _wanted nonk-pids expl 'non-kernel process ID' \
+            compadd -o nosort -ld lines -a pids
+    } elif [[ $1 == 'procs' ]] {
+        local line names lines
+        names=()
+        # extract command output line by line
+        lines=("${(@f)$(ps --ppid 2 -p 2 -N -o comm=,pid=,tty=,user=)}")
+        for line ($lines) {
+            names+=${line[(w)1]} # extract first word (pid)
+        }
+        _wanted nonk-comm expl 'non-kernel process names' \
+            compadd -o nosort -ld lines -a names
+    }
+}
+
+_comp_funcs() {
+    local names
+    output=$(readelf -Ws $1 2>/dev/null)
+    if [[ $? -ne 0 ]] {
+        return
+    }
+    names=("${(f)$(awk '$4=="FUNC" && $7!="UND" {print $8}' <(echo "$output"))}")
+    if [[ $#names -gt 0 ]] {
+      _values "FUNCTIONS" $names
+    }
+}
+
+_comp_error() {
+    local -a names
+    which errno > /dev/null
+    if [[ $? -ne 0 ]] {
+        return
+    }
+    names=("${(f)$(LC_ALL=C errno -l | awk '{printf "%s:(%d) %s\n", $1, $2, substr($0, length($1 $2)+3)}')}")
+    _describe "ERRORS" names
+}
+
 typeset -A opt_args
 
 _pwn() {
@@ -94,32 +140,11 @@ _pwn() {
           _arguments \
             '(-h --help)'{-h,--help}'[show help message and exit]' \
             '-x[Execute GDB commands from this file]:GDBSCRIPT:_files' \
-            '--pid[PID to attach to]:PID:->pid' \
+            '--pid[PID to attach to]:PID: _comp_pid pid' \
             '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
             '--exec[File to debug]:EXE:_files' \
-            '--process[Name of the process to attach to (e.g. "bash")]:NAME:->procs' \
+            '--process[Name of the process to attach to (e.g. "bash")]:NAME: _comp_pid procs' \
             '--sysroot[GDB sysroot path]:PATH:_files -/'
-          if [[ $state == 'pid' ]] {
-                local line pids lines
-                pids=()
-                # extract command output line by line
-                lines=("${(@f)$(ps --ppid 2 -p 2 -N -o pid=,tty=,user=,comm=)}")
-                for line ($lines) {
-                    pids+=${line[(w)1]} # extract first word (pid)
-                }
-                _wanted nonk-pids expl 'non-kernel process ID' \
-                    compadd -o nosort -ld lines -a pids
-          } elif [[ $state == 'procs' ]] {
-                local line names lines
-                names=()
-                # extract command output line by line
-                lines=("${(@f)$(ps --ppid 2 -p 2 -N -o comm=,pid=,tty=,user=)}")
-                for line ($lines) {
-                    names+=${line[(w)1]} # extract first word (pid)
-                }
-                _wanted nonk-comm expl 'non-kernel process names' \
-                    compadd -o nosort -ld lines -a names
-          }
           ;;
         disasm)
           _arguments \
@@ -153,7 +178,7 @@ _pwn() {
         errno)
           _arguments \
             '(-h --help)'{-h,--help}'[show help message and exit]' \
-            '2:ERROR: ' \
+            '1:ERROR:_comp_error' \
             '*: :'
             ;;
         hex)
@@ -201,13 +226,13 @@ _pwn() {
                 '(-s --symbols)'{-s,--symbols}'[List of symbol offsets to dump in addition to the common ones]:SYMBOLS: ' \
                 '(-o --offset)'{-o,--offset}'[Display all offsets relative to this symbol]:OFFSET: ' \
                 '--unstrip[Attempt to unstrip the libc binary inplace with debug symbols from a debuginfod server]' \
-                '*:FILE: '
+                '*:FILE:_files'
               ;;
             (fetch)
               _arguments \
                 '(-h --help)'{-h,--help}'[show help message and exit]' \
                 '(-u --update)'{-u,--update}'[Fetch the desired libc categories]:UPDATE: ' \
-                '1:PATH: ' \
+                '1:PATH:_files' \
                 '*: :'
               ;;
           }
@@ -241,15 +266,7 @@ _pwn() {
             } else {
                 return
             }
-            local names
-            output=$(readelf -Ws $filename 2>/dev/null)
-            if [[ $? -ne 0 ]] {
-                return
-            }
-            names=("${(f)$(awk '$4=="FUNC" && $7!="UND" {print $8}' <(echo "$output"))}")
-            if [[ $#names -gt 0 ]] {
-              _values "FUNCTIONS" $names
-            }
+            _comp_funcs $filename
           }
           ;;
         scramble)

--- a/extra/zsh_completion/_pwn
+++ b/extra/zsh_completion/_pwn
@@ -5,6 +5,7 @@
 # Pwntools Command-line Interface
 #
 # This file was generated with help from Zargparse (https://github.com/ctil/zargparse)
+# NOTE: Don't use Zargparse any more as it may bring known errors!
 # ----------------------------------------------------------------------------------------
 
 typeset -A opt_args
@@ -38,8 +39,8 @@ _pwn() {
 
   # Global flags (i.e. ones not associated with a subcommand)
   _arguments \
-    "1: :{_describe 'command' commands}" \
-    '(-h --help)'{-h,--help}'[show this help message and exit]' \
+    "1:COMMAND: _describe 'command' commands" \
+    '(-h --help)'{-h,--help}'[show help message and exit]' \
     '*:: :->args'
 
   # Flags for each subcommand
@@ -56,19 +57,20 @@ _pwn() {
             '(-n --newline)'{-n,--newline}'[Encode the shellcode to avoid newlines]' \
             '(-z --zero)'{-z,--zero}'[Encode the shellcode to avoid NULL bytes]' \
             '(-d --debug)'{-d,--debug}'[Debug the shellcode with GDB]' \
-            '(-e --encoder)'{-e,--encoder}'=[Specific encoder to use]:' \
-            '(-i --infile)'{-i,--infile}'=[Specify input file]:' \
+            '(-i --infile)'{-i,--infile}'[Specify input file]:INPUT:_files' \
             '(-r --run)'{-r,--run}'[Run output]' \
+            '*:LINE: '
+            return 0
             ;;
         checksec)
             _arguments \
-              '(-h --help)'{-h,--help}'[show this help message and exit]' \
-              '--file=[File to check (for compatibility with checksec.sh)]:ELF file:_path_files -g "*(-.)"' \
-              '*:ELF file:_path_files -g "*(-.)"' \
+              '(-h --help)'{-h,--help}'[show help message and exit]' \
+              '--file[File to check]:ELF:_files' \
+              '*:ELF:_files'
             ;;
         constgrep)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
             '(-e --exact)'{-e,--exact}'[Do an exact match for a constant instead of searching for a regex]' \
             '(-i --case-insensitive)'{-i,--case-insensitive}'[Search case insensitive]' \
             '(-m --mask-mode)'{-m,--mask-mode}'[Instead of searching for a specific constant value, search for values not containing strictly less bits that the given value.]' \
@@ -99,22 +101,33 @@ _pwn() {
             '(-a --address)'{-a,--address}'=[Base address]:' \
             '--color[Color output]' \
             '--no-color[Disable color output]' \
+            '*:HEX: '
             ;;
         disablenx)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '*:ELF:_files'
             ;;
         elfdiff)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '1:ELF_A:_files' \
+            '2:ELF_B:_files' \
+            '*: :'
             ;;
         elfpatch)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '1:ELF:_files' \
+            '2:OFFSET: ' \
+            '3:PATCH: ' \
+            '*: :'
             ;;
         errno)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '1:ERROR: ' \
+            '*: :'
             ;;
         hex)
           _arguments \
@@ -126,15 +139,66 @@ _pwn() {
           _arguments \
             '(-h --help)'{-h,--help}'[show this help message and exit]' \
             ;;
+        libcdb)
+          local -a libc_cmds=(
+            'lookup:Lookup a libc version by function offsets'
+            'hash:Display information of a libc version given an unique hash'
+            'file:Dump information about a libc binary'
+            'fetch:Fetch libc database'
+          )
+          _arguments \
+            "1:LIBC_COMMAND: _describe 'libc command' libc_cmds" \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '*:: :->args'
+          if [[ $state != 'args' ]] {
+              return
+          }
+          case $words[1] {
+            (lookup)
+              _arguments \
+                '(-h --help)'{-h,--help}'[show help message and exit]' \
+                '(-d --download-libc)'{-d,--download-libc}'[Attempt to download the matching libc.so]' \
+                '--no-unstrip[Do NOT attempt to unstrip the libc binary with debug symbols from a debuginfod server]' \
+                '--offline-only[Attempt to searching with offline only mode]' \
+                '*:SYMBOL_OFFSET_PAIRS: _message -r "SYMBOL_OFFSET_PAIRS Hint: read 3e0 write 520"'
+              ;;
+            (hash)
+              _arguments \
+                '(-h --help)'{-h,--help}'[show help message and exit]' \
+                '(-t --hash_type)'{-t,--hash_type}'[The type of the provided hash value]:HASH TYPE:(id buildid md5 sha1 sha256)' \
+                '(-d --download-libc)'{-d,--download-libc}'[Attempt to download the matching libc.so]' \
+                '--no-unstrip[Do NOT attempt to unstrip the libc binary with debug symbols from a debuginfod server]' \
+                '--offline-only[Attempt to searching with offline only mode]' \
+                '*:HASH VALUE: '
+              ;;
+            (file)
+              _arguments \
+                '(-h --help)'{-h,--help}'[show help message and exit]' \
+                '(-s --symbols)'{-s,--symbols}'[List of symbol offsets to dump in addition to the common ones]:SYMBOLS: ' \
+                '(-o --offset)'{-o,--offset}'[Display all offsets relative to this symbol]:OFFSET: ' \
+                '--unstrip[Attempt to unstrip the libc binary inplace with debug symbols from a debuginfod server]' \
+                '*:FILE: '
+              ;;
+            (fetch)
+              _arguments \
+                '(-h --help)'{-h,--help}'[show help message and exit]' \
+                '(-u --update)'{-u,--update}'[Fetch the desired libc categories]:UPDATE: ' \
+                '1:PATH: ' \
+                '*: :'
+              ;;
+          }
+          ;;
         phd)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-w --width)'{-w,--width}'=[Number of bytes per line.]:' \
-            '(-l --highlight)'{-l,--highlight}'=[Byte to highlight.]:' \
-            '(-s --skip)'{-s,--skip}'=[Skip this many initial bytes.]:' \
-            '(-c --count)'{-c,--count}'=[Only show this many bytes.]:' \
-            '(-o --offset)'{-o,--offset}'=[Addresses in left hand column starts at this address.]:' \
-            '--color=[Colorize the output.  When "auto" output is colorized exactly when stdout is a TTY.  Default is "auto".]:--color :(always never auto)' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-w --width)'{-w,--width}'[Number of bytes per line]:WIDTH INT: ' \
+            '(-l --highlight)'{-l,--highlight}'[Byte to highlight]:HIGHLIGHTS INT: ' \
+            '(-s --skip)'{-s,--skip}'[Skip this many initial bytes]:SKIP INT: ' \
+            '(-c --count)'{-c,--count}'[Only show this many bytes]:COUNT INT: ' \
+            '(-o --offset)'{-o,--offset}'[Addresses in left hand column starts at this address]:OFFSET INT: ' \
+            '--color[Colorize the output.  When "auto" output is colorized exactly when stdout is a TTY; default is auto]:COLOR:(always never auto)' \
+            '1:FILE:_files' \
+            '*: :'
             ;;
         pwnstrip)
           _arguments \
@@ -150,31 +214,32 @@ _pwn() {
             '(-o --output)'{-o,--output}'=[Output file (defaults to stdout)]:' \
             '(-c --context)'{-c,--context}'=[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386), choose from: \["16", "32", "64", "baremetal", "freebsd", "windows", "android", "darwin", "linux", "cgc", "loongarch64", "powerpc64", "aarch64", "powerpc", "riscv32", "riscv64", "sparc64", "mips64", "msp430", "alpha", "amd64", "sparc", "thumb", "cris", "i386", "ia64", "m68k", "mips", "s390", "none", "avr", "arm", "vax", "little", "big", "be", "eb", "le", "el"\]]:-c :(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
             '(-p --alphanumeric)'{-p,--alphanumeric}'[Encode the shellcode with an alphanumeric encoder]' \
-            '(-v --avoid)'{-v,--avoid}'=[Encode the shellcode to avoid the listed bytes]:' \
+            '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes]:AVOID: ' \
             '(-n --newline)'{-n,--newline}'[Encode the shellcode to avoid newlines]' \
             '(-z --zero)'{-z,--zero}'[Encode the shellcode to avoid NULL bytes]' \
             '(-d --debug)'{-d,--debug}'[Debug the shellcode with GDB]' \
             ;;
         shellcraft)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '(-? --show)'{-?,--show}'[Show shellcode documentation]' \
-            '(-o --out)'{-o,--out}'=[Output file (default: stdout)]:' \
-            '(-f --format)'{-f,--format}'=[Output format (default: hex), choose from {e}lf, {r}aw, {s}tring, {c}-style array, {h}ex string, hex{i}i, {a}ssembly code, {p}reprocssed code, escape{d} hex string]:-f :(r raw s str string c h hex a asm assembly p i hexii e elf d escaped default)' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '(-? --show)'{-\?,--show}'[Show shellcode documentation]' \
+            '(-o --out)'{-o,--out}'[Output file (default: stdout)]:OUTPUT:_files' \
+            '(-f --format)'{-f,--format}'[Output format (default: hex)]:FORMAT:(e r s c h i a p d)' \
             '(-d --debug)'{-d,--debug}'[Debug the shellcode with GDB]' \
             '--delim=[Set the delimiter between multiple shellcodes]:' \
             '(-b --before)'{-b,--before}'[Insert a debug trap before the code]' \
             '(-a --after)'{-a,--after}'[Insert a debug trap after the code]' \
-            '(-v --avoid)'{-v,--avoid}'=[Encode the shellcode to avoid the listed bytes]:' \
+            '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes]:AVOID: ' \
             '(-n --newline)'{-n,--newline}'[Encode the shellcode to avoid newlines]' \
             '(-z --zero)'{-z,--zero}'[Encode the shellcode to avoid NULL bytes]' \
             '(-r --run)'{-r,--run}'[Run output]' \
             '--color[Color output]' \
             '--no-color[Disable color output]' \
             '--syscalls[List syscalls]' \
-            '--address=[Load address]:' \
+            '--address[Load address]:ADDRESS: ' \
             '(-l --list)'{-l,--list}'[List available shellcodes, optionally provide a filter]' \
             '(-s --shared)'{-s,--shared}'[Generated ELF is a shared library]' \
+            '*:SHELLCODE: '
             ;;
         template)
           _arguments \
@@ -192,17 +257,18 @@ _pwn() {
             ;;
         unhex)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '*:HEX: '
             ;;
         update)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
-            '--install[Install the update automatically.]' \
-            '--pre[Check for pre-releases.]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
+            '--install[Install the update automatically]' \
+            '--pre[Check for pre-releases]' \
             ;;
         version)
           _arguments \
-            '(-h --help)'{-h,--help}'[show this help message and exit]' \
+            '(-h --help)'{-h,--help}'[show help message and exit]' \
             ;;
       esac
       ;;

--- a/extra/zsh_completion/_pwn
+++ b/extra/zsh_completion/_pwn
@@ -51,7 +51,7 @@ _pwn() {
           _arguments \
             '(-h --help)'{-h,--help}'[show help message and exit]' \
             '(-f --format)'{-f,--format}'[Output format]:FORMAT:(raw hex string elf)' \
-            '(-o --output)'{-o,--output}'[Output file (defaults to stdout)]:_files' \
+            '(-o --output)'{-o,--output}'[Output file (defaults to stdout)]:OUTPUT:_files' \
             '(-c --context)'{-c,--context}'[The os/architecture/endianness/bits the shellcode will run in (default: linux/i386)]:CONTEXT:(16 32 64 baremetal freebsd windows android darwin linux cgc loongarch64 powerpc64 aarch64 powerpc riscv32 riscv64 sparc64 mips64 msp430 alpha amd64 sparc thumb cris i386 ia64 m68k mips s390 none avr arm vax little big be eb le el)' \
             '(-v --avoid)'{-v,--avoid}'[Encode the shellcode to avoid the listed bytes (provided as hex)]:HEXBYTES: ' \
             '(-n --newline)'{-n,--newline}'[Encode the shellcode to avoid newlines]' \
@@ -60,13 +60,12 @@ _pwn() {
             '(-i --infile)'{-i,--infile}'[Specify input file]:INPUT:_files' \
             '(-r --run)'{-r,--run}'[Run output]' \
             '*:LINE: '
-            return 0
             ;;
         checksec)
             _arguments \
               '(-h --help)'{-h,--help}'[show help message and exit]' \
-              '--file[File to check]:ELF file:_files' \
-              '*:ELF file:_files'
+              '--file[File to check]:ELF:_files' \
+              '*:ELF:_files'
             ;;
         constgrep)
           _arguments \

--- a/extra/zsh_completion/_pwn
+++ b/extra/zsh_completion/_pwn
@@ -11,6 +11,8 @@
 typeset -A opt_args
 
 _pwn() {
+  setopt localoptions
+  setopt extendedglob
   # Define the subcommands
   local -a commands
   
@@ -214,7 +216,7 @@ _pwn() {
           _arguments \
             '(-h --help)'{-h,--help}'[show help message and exit]' \
             '(-w --width)'{-w,--width}'[Number of bytes per line]:WIDTH INT: ' \
-            '(-l --highlight)'{-l,--highlight}'[Byte to highlight]:HIGHLIGHTS INT: ' \
+            '(-l --highlight)'{-l,--highlight}'[Byte to highlight]:*^<->:HIGHLIGHTS INT: ' \
             '(-s --skip)'{-s,--skip}'[Skip this many initial bytes]:SKIP INT: ' \
             '(-c --count)'{-c,--count}'[Only show this many bytes]:COUNT INT: ' \
             '(-o --offset)'{-o,--offset}'[Addresses in left hand column starts at this address]:OFFSET INT: ' \

--- a/pwnlib/commandline/asm.py
+++ b/pwnlib/commandline/asm.py
@@ -76,7 +76,8 @@ parser.add_argument(
 parser.add_argument(
     '-e',
     '--encoder',
-    help="Specific encoder to use"
+    metavar='X',
+    help="Compatibility flag, ignored"
 )
 
 parser.add_argument(

--- a/pwnlib/commandline/pwnstrip.py
+++ b/pwnlib/commandline/pwnstrip.py
@@ -15,7 +15,7 @@ p = common.parser_commands.add_parser(
 g = p.add_argument_group("actions")
 g.add_argument('-b', '--build-id', help="Strip build ID", action='store_true')
 g.add_argument('-p', '--patch', metavar='FUNCTION', help="Patch function", action='append')
-p.add_argument('-o', '--output', type=argparse.FileType('wb'), default=getattr(sys.stdout, 'buffer', sys.stdout))
+p.add_argument('-o', '--output', type=argparse.FileType('wb'), default=getattr(sys.stdout, 'buffer', sys.stdout), help='Output file')
 p.add_argument('file', type=argparse.FileType('rb'))
 
 def main(args):


### PR DESCRIPTION
I manually optimized zsh completion script as the generator can not handle arguments correctly. And I found `-e` is not used in `asm.py` command line tool, deprecate it.