### PR TITLE
Update Python version requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 keywords = ["pwntools", "exploit", "ctf", "capture", "the", "flag", "binary", "wargame", "overflow", "stack", "heap", "defcon"]
 
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 dependencies = [
     "paramiko>=1.15.2",
     "mako>=1.0.0",


### PR DESCRIPTION
With #2647 merged, python 3.10 is now **required**. On python 3.8, we get this traceback:

```
  File "/usr/local/lib/python3.8/dist-packages/pwnlib/tubes/__init__.py", line 12, in <module>
    from pwnlib.tubes import listen
  File "/usr/local/lib/python3.8/dist-packages/pwnlib/tubes/listen.py", line 7, in <module>
    from pwnlib.tubes.sock import sock
  File "/usr/local/lib/python3.8/dist-packages/pwnlib/tubes/sock.py", line 6, in <module>
    from pwnlib.tubes.tube import tube
  File "/usr/local/lib/python3.8/dist-packages/pwnlib/tubes/tube.py", line 17, in <module>
    from pwnlib.util import fiddling
  File "/usr/local/lib/python3.8/dist-packages/pwnlib/util/fiddling.py", line 16, in <module>
    from pwnlib.util import packing
  File "/usr/local/lib/python3.8/dist-packages/pwnlib/util/packing.py", line 1219, in <module>
    def overlap(*structs: bytes | tuple[bytes, int]) -> bytes:
TypeError: 'type' object is not subscriptable
```

Alternatively, the project should seek to continue only using features supported by python 3.6.

Additionally, CI should *also* test against this minimum-supported version to prevent issues like this from happening again. Otherwise, it's really easy to see ✅ and hit merge.
