### PR TITLE
Supporting multiarch with modified argv[0] (including x86_64 binaries)

### DIFF
--- a/pwnlib/gdb.py
+++ b/pwnlib/gdb.py
@@ -241,8 +241,8 @@ def debug_shellcode(data, gdbscript=None, vma=None, api=False):
 
     return debug(tmp_elf, gdbscript=gdbscript, arch=context.arch, api=api)
 
-def _execve_script(argv, executable, env, ssh, preexec_fn, preexec_args):
-    """_execve_script(argv, executable, env, ssh, preexec_fn, preexec_args) -> str
+def _execve_script(argv, executable, env, ssh, which, preexec_fn, preexec_args):
+    """_execve_script(argv, executable, env, ssh, which, preexec_fn, preexec_args) -> str
 
     Returns the filename of a python script that calls
     execve the specified program with the specified arguments.
@@ -254,6 +254,7 @@ def _execve_script(argv, executable, env, ssh, preexec_fn, preexec_args):
         executable(bytes): Path to the program to run
         env(dict): Environment variables to pass to the program
         ssh(ssh): SSH connection to use if we are debugging a remote process
+        which(callable): Function to find the path of a binary.
         preexec_fn(callable): Callable to invoke before exec()
         preexec_args(tuple): Args to pass to callable
 
@@ -267,7 +268,8 @@ def _execve_script(argv, executable, env, ssh, preexec_fn, preexec_args):
         # ssh.process with run=false creates the script for us
         return ssh.process(argv, executable=executable, env=env, run=False)
 
-    script = misc._create_execve_script(argv=argv, executable=executable, env=env, log=log, preexec_fn=preexec_fn,
+    script = misc._create_execve_script(argv=argv, executable=executable, env=env,
+                                        which=which, log=log, preexec_fn=preexec_fn,
                                         preexec_args=preexec_args)
     script = script.strip()
     # Create a temporary file to hold the script
@@ -292,7 +294,7 @@ def _gdbserver_args(pid=None, path=None, port=0, gdbserver_args=None, args=None,
         port(int): Port to use for gdbserver, default: random
         gdbserver_args(list): List of additional arguments to pass to gdbserver
         args(list): List of arguments to provide on the debugger command line
-        which(callaable): Function to find the path of a binary.
+        which(callable): Function to find the path of a binary.
         env(dict): Environment variables to pass to the program
         python_wrapper_script(str): Path to a python script to use with ``--wrapper``
 
@@ -676,7 +678,7 @@ def debug(args, gdbscript=None, gdb_args=None, exe=None, ssh=None, env=None, por
             # but can use the ``--wrapper`` option to execute commands and catches
             # ``execve`` calls.
             # Therefore, we use a wrapper script to execute the target binary
-            script = _execve_script(args, executable=exe, env=env, ssh=ssh, preexec_fn=preexec_fn, preexec_args=preexec_args)
+            script = _execve_script(args, executable=exe, env=env, ssh=ssh, which=which, preexec_fn=preexec_fn, preexec_args=preexec_args)
             args = _gdbserver_args(gdbserver_args=gdbserver_args, args=args, port=port, which=which, env=env, python_wrapper_script=script)
     else:
         qemu_port = port if port != 0 else random.randint(1024, 65535)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -956,7 +956,7 @@ class ssh(Timeout, Logger):
         """
         cwd = cwd or self.cwd
         script = misc._create_execve_script(argv=argv, executable=executable,
-                cwd=cwd, env=env, stdin=stdin, stdout=stdout, stderr=stderr,
+                cwd=cwd, env=env, which=self.which, stdin=stdin, stdout=stdout, stderr=stderr,
                 ignore_environ=ignore_environ, preexec_fn=preexec_fn, preexec_args=preexec_args,
                 aslr=aslr, setuid=setuid, shell=shell, log=self)
 

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -736,7 +736,7 @@ def register_sizes(regs, in_sizes):
     return lists.concat(regs), sizes, bigger, smaller
 
 
-def _create_execve_script(argv=None, executable=None, cwd=None, env=None, ignore_environ=None,
+def _create_execve_script(argv=None, executable=None, cwd=None, env=None, which=None, ignore_environ=None,
         stdin=0, stdout=1, stderr=2, preexec_fn=None, preexec_args=(), aslr=None, setuid=None,
         shell=False, log=log):
     """
@@ -753,6 +753,8 @@ def _create_execve_script(argv=None, executable=None, cwd=None, env=None, ignore
             on :attr:`cwd` or set via :meth:`set_working_directory`.
         env(dict):
             Environment variables to add to the environment.
+        which(callable):
+            Function to find the path of a binary.
         ignore_environ(bool):
             Ignore default environment.  By default use default environment iff env not specified.
         stdin(int, str):
@@ -784,6 +786,9 @@ def _create_execve_script(argv=None, executable=None, cwd=None, env=None, ignore
     """
     if not argv and not executable:
         log.error("Must specify argv or executable")
+
+    if not which:
+        log.error("Must specify which_ parameter")
 
     aslr      = aslr if aslr is not None else context.aslr
 

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -826,9 +826,13 @@ def _create_execve_script(argv=None, executable=None, cwd=None, env=None, ignore
     func_src  = inspect.getsource(func).strip()
     setuid = True if setuid is None else bool(setuid)
 
-
+    # gdbserver wrappers are freezing on first execve syscall (for debugging the wanted program).
+    # It is not related to fork&exec.
+    # `/usr/bin/env python3` overrides first execve (because env is executing python3).
+    # Resolving python3 before shebang does, for not clashing with wrapper's first execve syscall.
+    python_path = which('python3')
     script = r"""
-#!/usr/bin/env python3
+#!%(python_path)s
 import os, sys, ctypes, resource, platform, stat
 from collections import OrderedDict
 try:


### PR DESCRIPTION
## Supporting multiarch with modified argv[0]
### Conclusion
The final conclusion is that we need one of the next two situations when connecting to a gdbserver.
1. gdbserver arch is synced with gdb-host arch.
2. gdb-host arch isn't set
   1. Any solution like gdb-multiarch/auto arch did not work.

### Root Cause
1. When we debug a program with gdbserver wrappers, the gdbserver freezes when it comes to the first execve syscall
   1. Not relevant for fork&exec.   
   2. gdbserver arch (with wrappers) is chosen by the first execve syscall and set to the next binary.
   3. gdbserver shebang of wrappers importance
       1. `#!/usr/bin/python3` - runs until the first execve and sets the arch to the next binary.
       2. `#!/usr/bin/env python3` - runs until python3 execve (first execve), and sets the arch to the same as python3.
   4. gdb-host arch is set to the binary mentioned or nothing (for us it's auto).

### Current Situation
1. Currently in pwntools the shebang is `#!/usr/bin/env python3` so gdbserver arch is set to python3 (e.g AMD64).
2. gdb-host is set to another binary (e.g i386).

### Error Occurred
<img width="1218" height="227" alt="image" src="https://github.com/user-attachments/assets/c098ce64-492a-4cd6-8301-648aa219b079" />


### Fixes Available
1. Removing the specified exe from gdb host when editing argv[0] (Not ideal and hard to implement).
2. Resolving python3 path in pwntools and setting it hardcoded for the python wrapper (Done).