### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -321,7 +321,7 @@ class AdbDevice(Device):
                     r.recvline() # Rest of the line
                     r.sendline('avd name')
                     self.avd = r.recvline().strip()
-            except:
+            except Exception:
                 pass
 
         self._initialized = True

--- a/pwnlib/constants/cgc/aarch64.py
+++ b/pwnlib/constants/cgc/aarch64.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/alpha.py
+++ b/pwnlib/constants/cgc/alpha.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/amd64.py
+++ b/pwnlib/constants/cgc/amd64.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/arm.py
+++ b/pwnlib/constants/cgc/arm.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/i386.py
+++ b/pwnlib/constants/cgc/i386.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/ia64.py
+++ b/pwnlib/constants/cgc/ia64.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/mips.py
+++ b/pwnlib/constants/cgc/mips.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/powerpc.py
+++ b/pwnlib/constants/cgc/powerpc.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/powerpc64.py
+++ b/pwnlib/constants/cgc/powerpc64.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/s390.py
+++ b/pwnlib/constants/cgc/s390.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/s390x.py
+++ b/pwnlib/constants/cgc/s390x.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/sparc.py
+++ b/pwnlib/constants/cgc/sparc.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/constants/cgc/sparc64.py
+++ b/pwnlib/constants/cgc/sparc64.py
@@ -1,1 +1,29 @@
-thumb.py
+from pwnlib.constants.constant import Constant
+
+terminate = Constant('terminate', 1)
+SYS_terminate = Constant('SYS_terminate', 1)
+__NR_terminate = Constant('__NR_terminate', 1)
+
+transmit = Constant('transmit', 2)
+SYS_transmit = Constant('SYS_transmit', 2)
+__NR_transmit = Constant('__NR_transmit', 2)
+
+receive = Constant('receive', 3)
+SYS_receive = Constant('SYS_receive', 3)
+__NR_receive = Constant('__NR_receive', 3)
+
+fdwait = Constant('fdwait', 4)
+SYS_fdwait = Constant('SYS_fdwait', 4)
+__NR_fdwait = Constant('__NR_fdwait', 4)
+
+allocate = Constant('allocate', 5)
+SYS_allocate = Constant('SYS_allocate', 5)
+__NR_allocate = Constant('__NR_allocate', 5)
+
+deallocate = Constant('deallocate', 6)
+SYS_deallocate = Constant('SYS_deallocate', 6)
+__NR_deallocate = Constant('__NR_deallocate', 6)
+
+random = Constant('random', 7)
+SYS_random = Constant('SYS_random', 7)
+__NR_random = Constant('__NR_random', 7)

--- a/pwnlib/shellcraft/registers.py
+++ b/pwnlib/shellcraft/registers.py
@@ -304,7 +304,7 @@ def current():
 #         'mips': mips,
 #         'mips64': mips
 #         }[context.arch]
-#     except:
+#     except Exception:
 #         return False
 
 def register_size(reg):

--- a/pwnlib/term/windows_termcap.py
+++ b/pwnlib/term/windows_termcap.py
@@ -34,7 +34,7 @@ def init():
     if 'PWNLIB_NOTERM' not in os.environ:
         try:
             enable_vt_mode()
-        except:
+        except Exception:
             # If the terminal doesn't support ANSI escape codes, don't use them.
             return
 

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -1594,6 +1594,6 @@ def _read_in_thread(recv_queue, proc_stdout):
                 recv_queue.put(b)
             else:
                 break
-    except:
+    except Exception:
         # Ignore any errors during Python shutdown
         pass


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.