### PR TITLE
ssh: Discard stderr of `lsb_release` for Distro lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2671][2671] ssh: support raw string input for 'key' argument as documented
 - [#2688][2688] Close SSH client connection when authentication failed
 - [#2686][2686] Add glibc safe-linking `glibc.reveal_ptr_same_page`
+- [#2704][2704] ssh: Fix distro lookup on Ubuntu 24.04
 
 [2677]: https://github.com/Gallopsled/pwntools/pull/2677
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
@@ -172,6 +173,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2671]: https://github.com/Gallopsled/pwntools/pull/2671
 [2688]: https://github.com/Gallopsled/pwntools/pull/2688
 [2686]: https://github.com/Gallopsled/pwntools/pull/2686
+[2704]: https://github.com/Gallopsled/pwntools/pull/2704
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1989,7 +1989,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
                 if not self.which('lsb_release'):
                     return
 
-                with self.process(['lsb_release', '-irs']) as io:
+                with self.process(['lsb_release', '-irs'], stderr='/dev/null') as io:
                     lsb_info = io.recvall().strip().decode()
                     self._platform_info['distro'], self._platform_info['distro_ver'] = lsb_info.split()
             except Exception:


### PR DESCRIPTION
The "No LSB modules are available." spam interferes with parsing the output for the initial checksec distro parsing when connecting to a new host. Redirect stderr to `/dev/null` to ignore it.

Before:
```
[+] Connecting to bandit.labs.overthewire.org on port 2220: Done
[*] bandit0@bandit.labs.overthewire.org:
    Distro    Unknown
    OS:       linux
    Arch:     amd64
    Version:  6.14.0
    ASLR:     Disabled
    SHSTK:    Disabled
    IBT:      Disabled
```

After:
```
[+] Connecting to bandit.labs.overthewire.org on port 2220: Done
[*] bandit0@bandit.labs.overthewire.org:
    Distro    Ubuntu 24.04
    OS:       linux
    Arch:     amd64
    Version:  6.14.0
    ASLR:     Disabled
    SHSTK:    Disabled
    IBT:      Disabled
```