### PR TITLE
Update `run_in_new_terminal` docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2671][2671] ssh: support raw string input for 'key' argument as documented
 - [#2688][2688] Close SSH client connection when authentication failed
 - [#2686][2686] Add glibc safe-linking `glibc.reveal_ptr_same_page`
+- [#2706][2706] doc: Update `run_in_new_terminal` docstring with new overrides
 
 [2677]: https://github.com/Gallopsled/pwntools/pull/2677
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -1256,6 +1256,12 @@ class ContextType(object):
         Default terminal used by :meth:`pwnlib.util.misc.run_in_new_terminal`.
         Can be a string or an iterable of strings.  In the latter case the first
         entry is the terminal and the rest are default arguments.
+        
+        Note:
+            :meth:`pwnlib.util.misc.run_in_new_terminal` has special handlers for
+            supported terminals with windowing capabilities, which might apply
+            to terminals set with this context option. See its documentation
+            for additional information on this behavior.
         """
         if isinstance(value, (bytes, str)):
             return [value]

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -308,8 +308,12 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
         kill_at_exit (bool): Whether to close the command/terminal on process exit.
         preexec_fn (callable): Callable to invoke before exec().
 
-    Note:
-        The command is opened with ``/dev/null`` for stdin, stdout, stderr.
+    Notes:
+        - The command is opened with ``/dev/null`` for stdin, stdout, stderr.
+        - When ``context.terminal`` is not a path and the terminal is one of the above
+          which support windowing/tiling, this will also cause the terminal to split.
+          Setting ``context.terminal`` to a path (e.g. using ``which(terminal)``)
+          bypasses this.
 
     Returns:
       PID of the new terminal process

--- a/pwnlib/util/misc.py
+++ b/pwnlib/util/misc.py
@@ -279,6 +279,17 @@ def run_in_new_terminal(command, terminal=None, args=None, kill_at_exit=True, pr
         - If ``$TERM_PROGRAM`` is set, that is used.
         - If X11 is detected (by the presence of the ``$DISPLAY`` environment
           variable), ``x-terminal-emulator`` is used.
+        - If kitty is detected (by the presence of the ``$KITTY_PID`` environment
+          variable), a new kitty window will be opened.
+        - If Terminator is detected (by the presence of the ``$TERMINATOR_UUID``
+          environment variable), a new terminator window will be opened.
+        - If GNOME Terminal is detected (by the presence of the ``$GNOME_TERMINAL_SCREEN``
+          and ``$GNOME_TERMINAL_SERVICE`` environment variables), a new GNOME
+          Terminal will be opened.
+        - If Alacritty is detected (by the presence of the ``$ALACRITTY_SOCKET``
+          and ``$ALACRITTY_WINDOW_ID`` environment variables), Alacritty is used.
+        - If Tilix is detected (by the presence of the ``$TILIX_ID`` environment
+          variable), a new pane is split.
         - If KDE Konsole is detected (by the presence of the ``$KONSOLE_VERSION``
           environment variable), a terminal will be split.
         - If WSL (Windows Subsystem for Linux) is detected (by the presence of


### PR DESCRIPTION
`run_in_new_terminal` currently handles many terminals and adds windowing functionality to them. When these overrides are unwanted, it is very difficult to find how to disable it without looking at pwntools' source code, which feels counter-intuitive, given that the entire point of these overrides is so the user doesn't have to deal with them, as just setting the `context.terminal` to whatever the terminal needs would do the same thing (e.g. replacing `kitty` with `kitten @ launch` in ones `context.terminal`). Adding a boolean context section seems like a good solution.

Implementation details are up to debate; I added a bypass for this functionality at the top of the function, but setting `terminal` to `which(terminal)` early would also do the same, although I feel this is a very hacky and roundabout way of implementing this.