### PR TITLE
fix: apply force_to_bytes to readline result in non-term_mode path

### DIFF
--- a/pwnlib/term/readline.py
+++ b/pwnlib/term/readline.py
@@ -380,7 +380,7 @@ def readline(_size=-1, prompt='', float=True, priority=10):
     from pwnlib.term import term_mode
     if not term_mode:
         six.print_(prompt, end='', flush=True)
-        return getattr(sys.stdin, 'buffer', sys.stdin).readline(_size).rstrip(b'\n')
+        return force_to_bytes(getattr(sys.stdin, 'buffer', sys.stdin).readline(_size)).rstrip(b'\n')
     show_suggestions = False
     eof = False
     if prompt:


### PR DESCRIPTION
`readline()` calls `.rstrip(b'\n')` on the result of `sys.stdin.readline()`, which returns a `str` when `sys.stdin.buffer` is unavailable, causing a `TypeError`. Applied the existing `force_to_bytes()` helper to ensure the result is always bytes before `.rstrip()` is called.

Fixes #2584