### PR TITLE
Remove python-dateutil dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2686][2686] Add glibc safe-linking `glibc.reveal_ptr_same_page`
 - [#2704][2704] ssh: Fix distro lookup on Ubuntu 24.04
 - [#2655][2655] Add `context.debugger` to select which debugger to use
+- [#2713][2713] Remove python-dateutil dependency
 
 [2677]: https://github.com/Gallopsled/pwntools/pull/2677
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
@@ -176,6 +177,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2686]: https://github.com/Gallopsled/pwntools/pull/2686
 [2704]: https://github.com/Gallopsled/pwntools/pull/2704
 [2655]: https://github.com/Gallopsled/pwntools/pull/2655
+[2713]: https://github.com/Gallopsled/pwntools/pull/2713
 
 ## 4.15.1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 capstone
 coverage[toml]
-python-dateutil
 doc2dash
 docutils>=0.18
 intervaltree

--- a/pwnlib/adb/adb.py
+++ b/pwnlib/adb/adb.py
@@ -46,6 +46,7 @@ the :mod:`pwnlib.adb` module.
 
 """
 
+import datetime
 import functools
 import glob
 import logging
@@ -55,8 +56,6 @@ import shutil
 import stat
 import tempfile
 import time
-
-import dateutil.parser
 
 from pwnlib import atexit
 from pwnlib import tubes
@@ -1272,7 +1271,6 @@ properties = Property()
 
 def _build_date():
     """Returns the build date in the form YYYY-MM-DD as a string"""
-    import datetime
 
     # Use ro.build.date.utc (integer epoch seconds) which is set by the
     # AOSP build system and available on all standard Android devices.
@@ -1281,7 +1279,7 @@ def _build_date():
     utc = getprop('ro.build.date.utc')
     if utc and utc.strip().isdigit():
         try:
-            as_datetime = datetime.datetime.fromtimestamp(int(utc.strip()), dateutil.tz.UTC)
+            as_datetime = datetime.datetime.fromtimestamp(int(utc.strip()), tz=datetime.timezone.utc)
             return as_datetime.strftime('%Y-%b-%d')
         except (OSError, OverflowError, ValueError):
             pass
@@ -1290,6 +1288,11 @@ def _build_date():
     as_string = getprop('ro.build.date')
     if not as_string:
         return ''
+    try:
+        import dateutil.parser
+    except ImportError:
+        log.exception("dateutil is required to parse ro.build.date since ro.build.date.utc is missing.  Please install it with 'pip install python-dateutil'")
+
     try:
         as_datetime = dateutil.parser.parse(as_string)
     except (ValueError, OverflowError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "requests>=2.0",
     "pygments>=2.0",
     "pysocks",
-    "python-dateutil",
     "packaging",
     "psutil>=3.3.0",
     "intervaltree>=3.0",


### PR DESCRIPTION
It is only used for parsing the `ro.build.date` string in Android adb. Since we use `ro.build.date.utc` now as primary build time source, don't require `python-dateutil` anymore, but keep optional support.

Makes pwntools a tiny bit more slim.
Refs #2245 