### PR TITLE
docs: execute context.clear() in doctests for Sphinx 9 compatibility

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -143,9 +143,6 @@ Additionally, you can use a shorthand to set all of the values at once.
     >>> asm('nop')
     b'\xe3 \xf0\x00'
 
-.. doctest::
-   :hide:
-
     >>> context.clear()
 
 Setting Logging Verbosity
@@ -158,9 +155,6 @@ For example, setting
     >>> context.log_level = 'debug'
 
 Will cause all of the data sent and received by a ``tube`` to be printed to the screen.
-
-.. doctest::
-   :hide:
 
     >>> context.clear()
 


### PR DESCRIPTION
## Summary

In Sphinx 9, doctest blocks marked with `:hide:` are not executed. This causes `context.clear()` calls in hidden blocks to be skipped, leading to assembler tests using the wrong architecture (arm instead of i386).

## Fix

This change moves `context.clear()` out of hidden doctest blocks into visible doctest lines, ensuring they are executed properly in Sphinx 9+.

## Changes

- `docs/source/intro.rst`: Replaced two hidden doctest blocks containing `context.clear()` with visible doctest lines.

## Testing

The issue manifests when running doctests with Sphinx 9+, where hidden blocks are not executed. This fix ensures the context clearing happens as part of the visible doctest flow.

Fixes Gallopsled/pwntools#2711