### PR TITLE
fix: delay upstream DNS resolution to prevent nginx startup failures

### DIFF
--- a/travis/libcdb_nginx_cache.conf
+++ b/travis/libcdb_nginx_cache.conf
@@ -10,20 +10,24 @@ http {
     access_log /dev/stdout cache_st;
     # Use Docker's embedded DNS server to resolve hostnames at runtime
     # instead of at startup.
-    resolver 127.0.0.11 8.8.8.8 ipv6=off;
+    resolver 127.0.0.11 8.8.8.8 ipv6=off valid=30s;
+    # Set default resolver for all upstreams to avoid startup-time DNS resolution
+    # This is a workaround for the occasional 'host not found in upstream' error
+    # in Docker environments where DNS may not be immediately available.
 
     server {
         listen 3000;
         proxy_cache my_cache;
 
         location / {
-            proxy_set_header Host debuginfod.elfutils.org;
+            set $upstream_host "debuginfod.elfutils.org";
+            proxy_set_header Host $upstream_host;
             proxy_ssl_server_name on;
             proxy_cache_revalidate on;
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://debuginfod.elfutils.org/;
+            proxy_pass https://$upstream_host/;
         }
     }
 
@@ -32,14 +36,15 @@ http {
         proxy_cache my_cache;
 
         location / {
-            proxy_set_header Host libc.rip;
+            set $upstream_host "libc.rip";
+            proxy_set_header Host $upstream_host;
             proxy_ssl_server_name on;
             proxy_cache_methods GET HEAD POST;
             proxy_cache_revalidate on;
             proxy_cache_key $scheme://$host$uri$is_args$query_string$request_body;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://libc.rip/;
+            proxy_pass https://$upstream_host/;
         }
     }
 
@@ -48,12 +53,13 @@ http {
         proxy_cache my_cache;
 
         location / {
-            proxy_set_header Host archive.ubuntu.com;
+            set $upstream_host "archive.ubuntu.com";
+            proxy_set_header Host $upstream_host;
             proxy_cache_revalidate on;
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass http://archive.ubuntu.com/;
+            proxy_pass http://$upstream_host/;
         }
     }
 
@@ -62,14 +68,15 @@ http {
         proxy_cache my_cache;
 
         location / {
-            proxy_set_header Host gitlab.com;
+            set $upstream_host "gitlab.com";
+            proxy_set_header Host $upstream_host;
             proxy_ssl_server_name on;
             proxy_cache_revalidate on;
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_ignore_headers Cache-Control Set-Cookie;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://gitlab.com/;
+            proxy_pass https://$upstream_host/;
         }
     }
 
@@ -78,13 +85,15 @@ http {
         proxy_cache my_cache;
 
         location / {
-            proxy_set_header Host debuginfod.ubuntu.com;
+            set $upstream_host "debuginfod.ubuntu.com";
+            proxy_set_header Host $upstream_host;
             proxy_ssl_server_name on;
             proxy_cache_revalidate on;
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://debuginfod.ubuntu.com/;
+            proxy_pass https://$upstream_host/;
         }
     }
 }
+


### PR DESCRIPTION
## Summary

The nginx cache proxy fails to start in CI with the error:
```
nginx: [emerg] host not found in upstream "debuginfod.elfutils.org"
```

This happens because nginx resolves upstream domains at config parse time,
but Docker's embedded DNS (127.0.0.11) may not be fully available when
the container starts.

## Solution

Changed all `proxy_pass` directives from:
```nginx
proxy_pass https://debuginfod.elfutils.org/;
```

To use the variable pattern:
```nginx
set $upstream_host "debuginfod.elfutils.org";
proxy_pass https://$upstream_host/;
```

This defers DNS resolution to the first request, when Docker DNS is guaranteed
to be available.

## Testing

The change can be verified by running:
```bash
./travis/test_nginx_cache.sh
```

## Fixes

Fixes #2712