### PR TITLE
fix(ssh): resolve PermissionError on Windows during SFTP upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2704][2704] ssh: Fix distro lookup on Ubuntu 24.04
 - [#2655][2655] Add `context.debugger` to select which debugger to use
 - [#2713][2713] Remove python-dateutil dependency
+- [#2720][2720] ssh: resolve PermissionError on Windows during SFTP upload
 
 [2677]: https://github.com/Gallopsled/pwntools/pull/2677
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
@@ -179,6 +180,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2704]: https://github.com/Gallopsled/pwntools/pull/2704
 [2655]: https://github.com/Gallopsled/pwntools/pull/2655
 [2713]: https://github.com/Gallopsled/pwntools/pull/2713
+[2720]: https://github.com/Gallopsled/pwntools/pull/2720
 
 ## 4.15.1
 

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -9,7 +9,7 @@ import tempfile
 import threading
 import time
 
-from io import StringIO
+from io import StringIO, BytesIO
 
 from pwnlib import atexit, term
 from pwnlib.context import context, LocalContext
@@ -1621,11 +1621,10 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             remote = os.path.join(self.cwd, remote)
 
         if self.sftp:
-            with tempfile.NamedTemporaryFile() as f:
-                f.write(data)
-                f.flush()
-                self.sftp.put(f.name, remote)
-                return
+            flo = BytesIO(data)
+            file_size = len(data)
+            self.sftp.putfo(flo, remote, file_size=file_size)
+            return
 
         with context.local(log_level = 'ERROR'):
             cmd = 'cat > ' + sh_string(remote)


### PR DESCRIPTION
When running scripts on Windows, uploading dynamically generated data via SSH/SFTP `ssh.upload_file()` crashes with a `PermissionError: [Errno 13] Permission denied`. 

This occurs because `tempfile.NamedTemporaryFile(delete=True, delete_on_close=True)` does not support reopen file again within its `with` block as Python docs states. The previous implementation used `sftp.put(f.name)`, which attempts to re-open the file path internally, triggering the OS-level lock restriction.

Replace with `sftp.putfo()`. By passing the file-like object directly to `putfo`, we reuse the existing open file descriptor. This entirely circumvents tempfile usage while maintaining cross-platform compatibility.

Some references:
- https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file/23212515#23212515
