### PR TITLE
Allow running with Unicorn 2.1.[34] but throw when emulating MIPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
         pip install --upgrade wheel build
         pip install --upgrade flake8 appdirs
         pip install --upgrade --editable .
+        # Pin to known working version until 2.1.5 is out. https://github.com/unicorn-engine/unicorn/issues/2134
+        pip install 'unicorn==2.1.2'
 
     - name: Sanity checks
       run:  PWNLIB_NOTERM=1 python -bb -c 'from pwn import *; print(pwnlib.term.term_mode)'
@@ -285,7 +287,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install --upgrade --editable .
-    
+
     - name: Sanity checks
       run: |
         python -bb -c 'from pwn import *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,9 +133,11 @@ The table below shows which release corresponds to each branch, and what date th
 
 - [#2694][2694] fix: pad bytes fields to correct field size in FileStructure
 - [#2701][2701] Fix `adb._build_date()` crash on devices with non-standard locale date strings
+- [#2721][2721] Allow running with Unicorn 2.1.[34] but throw when emulating MIPS
 
 [2694]: https://github.com/Gallopsled/pwntools/pull/2694
 [2701]: https://github.com/Gallopsled/pwntools/pull/2701
+[2721]: https://github.com/Gallopsled/pwntools/pull/2721
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/elf/plt.py
+++ b/pwnlib/elf/plt.py
@@ -78,6 +78,13 @@ def __ensure_memory_to_run_unicorn():
 def prepare_unicorn_and_context(elf, got, address, data):
     import unicorn as U
 
+    if elf.arch in ('mips', 'mips64'):
+        # Unicorn 2.1.3 and 2.1.4 have a crashing bug when trying to emulate MIPS.
+        # https://github.com/unicorn-engine/unicorn/issues/2134
+        if U.UC_VERSION_MAJOR == 2 and U.UC_VERSION_MINOR == 1 and U.UC_VERSION_PATCH in (3, 4):
+            raise OSError("Unicorn Engine 2.1.3 and 2.1.4 have a crashing bug when emulating MIPS, please install an earlier or later version: https://github.com/unicorn-engine/unicorn/issues/2134")
+
+
     __ensure_memory_to_run_unicorn()
 
     # Instantiate the emulator with the correct arguments for the current

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "psutil>=3.3.0",
     "intervaltree>=3.0",
     "sortedcontainers",
-    "unicorn>=2.0.1, !=2.1.3, !=2.1.4",  # see https://github.com/unicorn-engine/unicorn/issues/2134
+    "unicorn>=2.0.1",
     "six>=1.12.0",
     "rpyc",
     "colored_traceback<0.4; python_version < '3'",


### PR DESCRIPTION
Unicorn 2.1.5 wasn't released for a while and 2.1.2 doesn't have binary wheels for Python 3.14. This made installing pwntools on newer Python versions more annoying since you had to build Unicorn yourself.

The only problem with the blocked versions is MIPS emulation, so only avoid that while allowing to use Unicorn 2.1.3 or 2.1.4 for other architectures.

Refs #2621