### PR TITLE
safeeval: allow LIST_APPEND and SET_ADD opcodes (Python 3.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2713][2713] Remove python-dateutil dependency
 - [#2720][2720] ssh: resolve PermissionError on Windows during SFTP upload
 - [#2702][2702] ssh: Don't cache username in ssh checksec output
+- [#2722][2722] safeeval: allow LIST_APPEND and SET_ADD opcodes (Python 3.14)
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -185,6 +186,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2713]: https://github.com/Gallopsled/pwntools/pull/2713
 [2720]: https://github.com/Gallopsled/pwntools/pull/2720
 [2702]: https://github.com/Gallopsled/pwntools/pull/2702
+[2722]: https://github.com/Gallopsled/pwntools/pull/2722
 
 ## 4.15.1
 

--- a/pwnlib/util/safeeval.py
+++ b/pwnlib/util/safeeval.py
@@ -3,7 +3,7 @@ _const_codes = [
     'BUILD_LIST','BUILD_MAP', 'MAP_ADD', 'BUILD_TUPLE','BUILD_SET',
     'BUILD_CONST_KEY_MAP', 'BUILD_STRING',
     'LOAD_CONST','LOAD_SMALL_INT','RETURN_VALUE','STORE_SUBSCR', 'STORE_MAP',
-    'LIST_TO_TUPLE', 'LIST_EXTEND', 'SET_UPDATE', 'DICT_UPDATE', 'DICT_MERGE',
+    'LIST_TO_TUPLE', 'LIST_APPEND', 'LIST_EXTEND', 'SET_ADD', 'SET_UPDATE', 'DICT_UPDATE', 'DICT_MERGE',
     'COPY', 'RESUME', 'RETURN_CONST'
     ]
 
@@ -69,6 +69,10 @@ def const(expr):
         Traceback (most recent call last):
         ...
         ValueError: opcode BINARY_ADD not allowed
+        >>> const("[" + ",".join(str(i) for i in range(40)) + "]") == list(range(40))
+        True
+        >>> const("{" + ",".join(str(i) for i in range(40)) + "}") == set(range(40))
+        True
     """
 
     c = test_expr(expr, _const_codes)


### PR DESCRIPTION
Closes #2719.

Python 3.14 changed bytecode emission for large list and set literals — for ~25+ elements, instead of `BUILD_LIST 0` + `LIST_EXTEND` (with a constant tuple), it now emits `BUILD_LIST 0` followed by a `LIST_APPEND 1` per element. Same for sets (`SET_ADD` instead of `SET_UPDATE`).

`safeeval.expr` / `safeeval.const` reject these on 3.14:

```
>>> safeeval.expr("[" + ",".join(str(i) for i in range(60)) + "]")
ValueError: opcode LIST_APPEND not allowed
```

This adds `LIST_APPEND` and `SET_ADD` to `_const_codes`, mirroring how #2243 added `MAP_ADD` for the equivalent dict change in 3.10+. Per @peace-maker's comment on the issue, both are included.

The safety boundary is unchanged: both opcodes are pure stack manipulation (pop a value, append to a list/set deeper in the stack — no name lookup, no method dispatch on user objects). Comprehensions still require `FOR_ITER` / `GET_ITER` which remain disallowed, so this doesn't enable evaluating arbitrary comprehensions.

Includes regression doctests (40-element list and set) that pass on both 3.13 (hits LIST_EXTEND/SET_UPDATE) and 3.14 (hits LIST_APPEND/SET_ADD).