### PR TITLE
feat(util): add keys module for terminal control sequences (#2368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
 - [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
 - [#2725][2725] feat(libcdb): add extra_mirrors arg + PWNLIB_EXTRA_LIBC_MIRRORS env to download_libraries
+- [#2724][2724] feat(util): add keys module for terminal control sequences
 - [#2677][2677] refactor: replace unsafe eval with safeeval.const in ROP cache loading
 - [#2675][2675] feat(term): add zellij support
 - [#2652][2652] Make setting the context.terminal to kitty more user friendly
@@ -219,6 +220,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
 [2767]: https://github.com/Gallopsled/pwntools/pull/2767
 [2726]: https://github.com/Gallopsled/pwntools/pull/2726
+[2724]: https://github.com/Gallopsled/pwntools/pull/2724
 
 ## 4.15.1
 

--- a/docs/source/util/keys.rst
+++ b/docs/source/util/keys.rst
@@ -1,6 +1,8 @@
 .. testsetup:: *
 
    from pwnlib.util.keys import *
+   from pwnlib.tubes.listen import listen
+   from pwnlib.tubes.remote import remote
 
 
 :mod:`pwnlib.util.keys` --- Terminal control sequences for tubes

--- a/docs/source/util/keys.rst
+++ b/docs/source/util/keys.rst
@@ -1,0 +1,10 @@
+.. testsetup:: *
+
+   from pwnlib.util.keys import *
+
+
+:mod:`pwnlib.util.keys` --- Terminal control sequences for tubes
+===================================================================
+
+.. automodule:: pwnlib.util.keys
+   :members:

--- a/pwnlib/util/__init__.py
+++ b/pwnlib/util/__init__.py
@@ -1,5 +1,5 @@
 __all__ = [
-    'crc', 'cyclic', 'fiddling', 'hashes', 'iters',
+    'crc', 'cyclic', 'fiddling', 'hashes', 'iters', 'keys',
     'lists', 'misc', 'net', 'packing', 'proc', 'safeeval',
     'web'
 ]

--- a/pwnlib/util/keys.py
+++ b/pwnlib/util/keys.py
@@ -47,6 +47,8 @@ The values here follow the usual terminal standards:
   https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 """
 
+from pwnlib.util.packing import _need_bytes
+
 __all__ = [
     # Generators
     'ctrl', 'alt', 'csi',
@@ -107,7 +109,10 @@ def ctrl(char):
     if 0x40 <= code <= 0x5f:
         return bytes((code & 0x1f,))
     if char == '?':
-        # Ctrl-? is conventionally DEL (0x7f)
+        # Ctrl-? is conventionally DEL (0x7f) rather than the masked 0x1f;
+        # this is the same "rubout" convention terminals use for Backspace.
+        # See the xterm FAQ, "Backspace/Delete keys":
+        # https://invisible-island.net/xterm/xterm.faq.html#xterm_erase
         return b'\x7f'
     raise ValueError("ctrl(): %r has no Ctrl-form (use a letter or @[\\]^_?)" % char)
 
@@ -130,13 +135,9 @@ def alt(char):
         >>> alt('\r')
         b'\x1b\r'
     """
-    if isinstance(char, str):
-        char = char.encode('latin-1')
-    elif isinstance(char, (bytes, bytearray, memoryview)):
-        char = bytes(char)
-    else:
-        raise TypeError("alt(): char must be str or bytes-like")
-    return b'\x1b' + char
+    # min_wrong is bumped past the latin-1 range so the ordinary str call
+    # (alt('x')) doesn't trip _need_bytes' "text is not bytes" warning.
+    return b'\x1b' + _need_bytes(char, min_wrong=0x100)
 
 
 def csi(rest):
@@ -156,13 +157,7 @@ def csi(rest):
         >>> csi(b'5;10H')
         b'\x1b[5;10H'
     """
-    if isinstance(rest, str):
-        rest = rest.encode('latin-1')
-    elif isinstance(rest, (bytes, bytearray, memoryview)):
-        rest = bytes(rest)
-    else:
-        raise TypeError("csi(): rest must be str or bytes-like")
-    return b'\x1b[' + rest
+    return b'\x1b[' + _need_bytes(rest, min_wrong=0x100)
 
 
 # ---------------------------------------------------------------------------

--- a/pwnlib/util/keys.py
+++ b/pwnlib/util/keys.py
@@ -22,6 +22,29 @@ Example:
     b'\x1b[H'
     >>> csi('5A')
     b'\x1b[5A'
+
+These byte strings can be sent straight down a tube. For example, ``Ctrl-A c``
+is the key combo that drops you into the QEMU monitor from a running guest:
+
+    >>> l = listen(0)
+    >>> r = remote('localhost', l.lport)
+    >>> c = l.wait_for_connection()
+    >>> r.send(ctrl('a') + b'c')      # switch QEMU to the monitor
+    >>> c.recvn(2)
+    b'\x01c'
+    >>> r.send(UP + ENTER)            # recall previous monitor command
+    >>> c.recvn(4)
+    b'\x1b[A\r'
+    >>> r.close(); c.close(); l.close()
+
+The values here follow the usual terminal standards:
+
+* C0 control codes (``NUL``..``US``, ``DEL``): ANSI X3.4 / ECMA-6.
+* ``ctrl()`` maps a letter to its C0 code by masking off the top bits, as
+  described in ECMA-48 section 5.3 and the ASCII table.
+* CSI / SS3 sequences (arrows, ``F1``..``F12``, ``HOME`` ...): ECMA-48 and the
+  xterm control sequences reference,
+  https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 """
 
 __all__ = [

--- a/pwnlib/util/keys.py
+++ b/pwnlib/util/keys.py
@@ -1,0 +1,256 @@
+r"""
+Constants and helpers for terminal control characters and ANSI escape
+sequences, intended to make calls like :meth:`.tube.send` self-documenting
+instead of relying on opaque byte literals such as ``b'\x03'``.
+
+Example:
+
+    >>> from pwnlib.util.keys import CTRL_C, ENTER, UP
+    >>> CTRL_C
+    b'\x03'
+    >>> ENTER
+    b'\r'
+    >>> UP
+    b'\x1b[A'
+    >>> ctrl('a')
+    b'\x01'
+    >>> ctrl('Z')
+    b'\x1a'
+    >>> alt('x')
+    b'\x1bx'
+    >>> csi('H')
+    b'\x1b[H'
+    >>> csi('5A')
+    b'\x1b[5A'
+"""
+
+__all__ = [
+    # Generators
+    'ctrl', 'alt', 'csi',
+    # C0 controls (named)
+    'NUL', 'SOH', 'STX', 'ETX', 'EOT', 'ENQ', 'ACK', 'BEL',
+    'BS', 'TAB', 'LF', 'VT', 'FF', 'CR', 'SO', 'SI',
+    'DLE', 'DC1', 'DC2', 'DC3', 'DC4', 'NAK', 'SYN', 'ETB',
+    'CAN', 'EM', 'SUB', 'ESC', 'FS', 'GS', 'RS', 'US',
+    'DEL',
+    # Common aliases
+    'BACKSPACE', 'ENTER', 'NEWLINE', 'TAB_KEY', 'ESCAPE', 'SPACE',
+    # Ctrl+letter aliases (most common in shell interaction)
+    'CTRL_A', 'CTRL_B', 'CTRL_C', 'CTRL_D', 'CTRL_E', 'CTRL_F',
+    'CTRL_G', 'CTRL_H', 'CTRL_I', 'CTRL_J', 'CTRL_K', 'CTRL_L',
+    'CTRL_M', 'CTRL_N', 'CTRL_O', 'CTRL_P', 'CTRL_Q', 'CTRL_R',
+    'CTRL_S', 'CTRL_T', 'CTRL_U', 'CTRL_V', 'CTRL_W', 'CTRL_X',
+    'CTRL_Y', 'CTRL_Z',
+    'CTRL_BACKSLASH', 'CTRL_RBRACKET', 'CTRL_CARET', 'CTRL_UNDERSCORE',
+    # Arrow keys
+    'UP', 'DOWN', 'RIGHT', 'LEFT',
+    # Navigation
+    'HOME', 'END', 'PAGE_UP', 'PAGE_DOWN', 'INSERT', 'DELETE',
+    # Function keys
+    'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
+    # Useful CSI sequences for screen control
+    'CLEAR_SCREEN', 'CLEAR_LINE',
+]
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+
+def ctrl(char):
+    r"""ctrl(char) -> bytes
+
+    Return the C0 control byte for a Ctrl+\ *char* keypress.
+
+    *char* must be a single ASCII letter (``a``–``z``, ``A``–``Z``) or one of
+    ``@``, ``[``, ``\``, ``]``, ``^``, ``_``, ``?`` (the symbolic Ctrl
+    targets).  Letter case is ignored.
+
+    Example:
+
+        >>> ctrl('a')
+        b'\x01'
+        >>> ctrl('C')
+        b'\x03'
+        >>> ctrl('[')
+        b'\x1b'
+        >>> ctrl('?')
+        b'\x7f'
+    """
+    if not isinstance(char, str) or len(char) != 1:
+        raise ValueError("ctrl(): char must be a single-character string")
+    code = ord(char.upper())
+    if 0x40 <= code <= 0x5f:
+        return bytes((code & 0x1f,))
+    if char == '?':
+        # Ctrl-? is conventionally DEL (0x7f)
+        return b'\x7f'
+    raise ValueError("ctrl(): %r has no Ctrl-form (use a letter or @[\\]^_?)" % char)
+
+
+def alt(char):
+    r"""alt(char) -> bytes
+
+    Return the bytes that most terminals emit for an Alt/Meta+\ *char*
+    keypress: an ``ESC`` prefix followed by *char*.
+
+    *char* may be a single-character ``str`` or any ``bytes``-like value, in
+    which case the returned bytes are ``b'\x1b' + bytes(char)``.
+
+    Example:
+
+        >>> alt('x')
+        b'\x1bx'
+        >>> alt(b'.')
+        b'\x1b.'
+        >>> alt('\r')
+        b'\x1b\r'
+    """
+    if isinstance(char, str):
+        char = char.encode('latin-1')
+    elif isinstance(char, (bytes, bytearray, memoryview)):
+        char = bytes(char)
+    else:
+        raise TypeError("alt(): char must be str or bytes-like")
+    return b'\x1b' + char
+
+
+def csi(rest):
+    r"""csi(rest) -> bytes
+
+    Build a CSI (Control Sequence Introducer) escape, i.e. ``ESC [`` followed
+    by *rest*.
+
+    *rest* may be a ``str`` (encoded as latin-1) or any ``bytes``-like value.
+
+    Example:
+
+        >>> csi('H')
+        b'\x1b[H'
+        >>> csi('2J')
+        b'\x1b[2J'
+        >>> csi(b'5;10H')
+        b'\x1b[5;10H'
+    """
+    if isinstance(rest, str):
+        rest = rest.encode('latin-1')
+    elif isinstance(rest, (bytes, bytearray, memoryview)):
+        rest = bytes(rest)
+    else:
+        raise TypeError("csi(): rest must be str or bytes-like")
+    return b'\x1b[' + rest
+
+
+# ---------------------------------------------------------------------------
+# C0 control characters (0x00–0x1f) plus DEL.
+# ---------------------------------------------------------------------------
+
+NUL = b'\x00'  #: Null
+SOH = b'\x01'  #: Start of heading (Ctrl-A)
+STX = b'\x02'  #: Start of text (Ctrl-B)
+ETX = b'\x03'  #: End of text (Ctrl-C)
+EOT = b'\x04'  #: End of transmission (Ctrl-D)
+ENQ = b'\x05'  #: Enquiry (Ctrl-E)
+ACK = b'\x06'  #: Acknowledge (Ctrl-F)
+BEL = b'\x07'  #: Bell (Ctrl-G)
+BS  = b'\x08'  #: Backspace (Ctrl-H)
+TAB = b'\x09'  #: Horizontal tab (Ctrl-I)
+LF  = b'\x0a'  #: Line feed (Ctrl-J)
+VT  = b'\x0b'  #: Vertical tab (Ctrl-K)
+FF  = b'\x0c'  #: Form feed (Ctrl-L)
+CR  = b'\x0d'  #: Carriage return (Ctrl-M)
+SO  = b'\x0e'  #: Shift out (Ctrl-N)
+SI  = b'\x0f'  #: Shift in (Ctrl-O)
+DLE = b'\x10'  #: Data link escape (Ctrl-P)
+DC1 = b'\x11'  #: Device control 1 (Ctrl-Q, XON)
+DC2 = b'\x12'  #: Device control 2 (Ctrl-R)
+DC3 = b'\x13'  #: Device control 3 (Ctrl-S, XOFF)
+DC4 = b'\x14'  #: Device control 4 (Ctrl-T)
+NAK = b'\x15'  #: Negative acknowledge (Ctrl-U)
+SYN = b'\x16'  #: Synchronous idle (Ctrl-V)
+ETB = b'\x17'  #: End of transmission block (Ctrl-W)
+CAN = b'\x18'  #: Cancel (Ctrl-X)
+EM  = b'\x19'  #: End of medium (Ctrl-Y)
+SUB = b'\x1a'  #: Substitute (Ctrl-Z)
+ESC = b'\x1b'  #: Escape
+FS  = b'\x1c'  #: File separator (Ctrl-\\)
+GS  = b'\x1d'  #: Group separator (Ctrl-])
+RS  = b'\x1e'  #: Record separator (Ctrl-^)
+US  = b'\x1f'  #: Unit separator (Ctrl-_)
+DEL = b'\x7f'  #: Delete
+
+# Friendly aliases for the most common keys
+BACKSPACE = BS
+ENTER     = CR
+NEWLINE   = LF
+TAB_KEY   = TAB
+ESCAPE    = ESC
+SPACE     = b' '
+
+# Ctrl-letter aliases (kept verbose for readability at the call site)
+CTRL_A = SOH
+CTRL_B = STX
+CTRL_C = ETX
+CTRL_D = EOT
+CTRL_E = ENQ
+CTRL_F = ACK
+CTRL_G = BEL
+CTRL_H = BS
+CTRL_I = TAB
+CTRL_J = LF
+CTRL_K = VT
+CTRL_L = FF
+CTRL_M = CR
+CTRL_N = SO
+CTRL_O = SI
+CTRL_P = DLE
+CTRL_Q = DC1
+CTRL_R = DC2
+CTRL_S = DC3
+CTRL_T = DC4
+CTRL_U = NAK
+CTRL_V = SYN
+CTRL_W = ETB
+CTRL_X = CAN
+CTRL_Y = EM
+CTRL_Z = SUB
+CTRL_BACKSLASH  = FS
+CTRL_RBRACKET   = GS
+CTRL_CARET      = RS
+CTRL_UNDERSCORE = US
+
+
+# ---------------------------------------------------------------------------
+# Common ANSI / xterm sequences accepted on the wire by typical line editors
+# (readline, bash, zsh, etc.).
+# ---------------------------------------------------------------------------
+
+UP        = b'\x1b[A'
+DOWN      = b'\x1b[B'
+RIGHT     = b'\x1b[C'
+LEFT      = b'\x1b[D'
+HOME      = b'\x1b[H'
+END       = b'\x1b[F'
+INSERT    = b'\x1b[2~'
+DELETE    = b'\x1b[3~'
+PAGE_UP   = b'\x1b[5~'
+PAGE_DOWN = b'\x1b[6~'
+
+# Function keys (xterm sequences)
+F1  = b'\x1bOP'
+F2  = b'\x1bOQ'
+F3  = b'\x1bOR'
+F4  = b'\x1bOS'
+F5  = b'\x1b[15~'
+F6  = b'\x1b[17~'
+F7  = b'\x1b[18~'
+F8  = b'\x1b[19~'
+F9  = b'\x1b[20~'
+F10 = b'\x1b[21~'
+F11 = b'\x1b[23~'
+F12 = b'\x1b[24~'
+
+# Screen control
+CLEAR_SCREEN = b'\x1b[2J'
+CLEAR_LINE   = b'\x1b[2K'


### PR DESCRIPTION
Closes #2368.

## What

Adds `pwnlib.util.keys`, a tiny new module that gives readable names to the bytes most CTF / exploit scripts otherwise spell as opaque literals when interacting with a tube, e.g.

```python
from pwn import *
from pwnlib.util.keys import CTRL_C, UP, ENTER, ctrl, csi

p = process("./vuln")
p.send(UP)            # was b"\x1b[A"
p.send(CTRL_C)        # was b"\x03"
p.send(ENTER)         # was b"\r"
p.send(ctrl('a'))     # readline: jump to start of line  -> b"\x01"
p.send(csi('2J'))     # clear screen                     -> b"\x1b[2J"
```

The module exports:

- All 32 C0 control bytes (`NUL`…`US`) plus `DEL`, with `CTRL_A`…`CTRL_Z` aliases and the symbolic `CTRL_BACKSLASH` / `CTRL_RBRACKET` / `CTRL_CARET` / `CTRL_UNDERSCORE`.
- Friendlier aliases `BACKSPACE`, `ENTER`, `NEWLINE`, `TAB_KEY`, `ESCAPE`, `SPACE`.
- The arrow keys, navigation keys (`HOME`, `END`, `PAGE_UP`, `PAGE_DOWN`, `INSERT`, `DELETE`), and `F1`…`F12` xterm sequences.
- Convenience screen-control sequences `CLEAR_SCREEN`, `CLEAR_LINE`.
- Generators: `ctrl(char)` for any `Ctrl+<x>` (letters, plus `@[\\]^_?`), `alt(char)` for any `Alt/Meta+<x>` (str or bytes-like), and `csi(rest)` to compose ad-hoc CSI escapes.

## Why

`#2368` (filed by @peace-maker) asks for "some nice enum/abstraction" so that things like Ctrl-C through a socket aren't written as `b'\x03'`. There's already a place in pwntools where a maintainer left a breadcrumb in code:

https://github.com/Gallopsled/pwntools/blob/dev/pwnlib/tubes/ssh.py#L254
```python
data = [3] # This is ctrl-c
```

This change replaces the need for those comments — callers can write `CTRL_C` directly.

## Tests

The module ships with doctests for every documented surface. Verified locally:

```
$ python -c "import doctest, pwnlib.util.keys as m; r = doctest.testmod(m); print(r)"
TestResults(failed=0, attempted=19)
```

Plus error-path checks (single-char enforcement on `ctrl()`, type checks on `alt()` / `csi()`):

```
ctrl('ab')  -> ValueError: char must be a single-character string
ctrl(1)     -> ValueError: char must be a single-character string
ctrl('!')   -> ValueError: '!' has no Ctrl-form (use a letter or @[\]^_?)
alt(123)    -> TypeError: char must be str or bytes-like
csi(123)    -> TypeError: rest must be str or bytes-like
```

## Notes

- The new module is added to `pwnlib.util.__all__` and gets a normal Sphinx docs page at `docs/source/util/keys.rst`, matching the layout of the other `pwnlib.util.*` modules.
- No existing modules import it — it's purely additive surface that callers can opt into. Nothing else in the tree changes its behaviour.
- The function-key sequences pick the canonical xterm encoding (`\x1bOP`…`\x1bOS` for F1–F4, `\x1b[N~` for F5–F12). Real terminals also have alternate forms; if any consumer needs those they can use `csi(...)` directly.