### PR TITLE
fix(remote): make Ctrl-C interrupt blocking getaddrinfo() (#2540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
 - [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
 - [#2725][2725] feat(libcdb): add extra_mirrors arg + PWNLIB_EXTRA_LIBC_MIRRORS env to download_libraries
+- [#2728][2728] fix(remote): make Ctrl-C interrupt blocking getaddrinfo() (#2540)
 - [#2677][2677] refactor: replace unsafe eval with safeeval.const in ROP cache loading
 - [#2675][2675] feat(term): add zellij support
 - [#2652][2652] Make setting the context.terminal to kitty more user friendly
@@ -219,6 +220,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
 [2767]: https://github.com/Gallopsled/pwntools/pull/2767
 [2726]: https://github.com/Gallopsled/pwntools/pull/2726
+[2728]: https://github.com/Gallopsled/pwntools/pull/2728
 
 ## 4.15.1
 

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -1,5 +1,3 @@
-import contextlib
-import signal
 import socket
 import socks
 import threading
@@ -11,31 +9,43 @@ from pwnlib.tubes.sock import sock
 log = getLogger(__name__)
 
 
-@contextlib.contextmanager
-def _interruptible_block():
-    """Temporarily reset SIGINT to its default handler for the duration of the
-    block, then restore the previous handler.
+def _resolve_interruptible(host, port, fam, typ):
+    """Resolve *host*/*port* with :func:`socket.getaddrinfo` while keeping the
+    lookup abortable with Ctrl-C (#2540).
 
-    This lets a Ctrl-C interrupt blocking C-level calls such as
-    :func:`socket.getaddrinfo`, which on glibc hold the GIL and are otherwise
-    uninterruptible from Python (#2540).
+    ``getaddrinfo`` blocks inside glibc holding the GIL, so a pending SIGINT
+    isn't turned into a ``KeyboardInterrupt`` until the call returns. A stalled
+    DNS query is therefore uninterruptible on the main thread. We run the lookup
+    on a daemon thread and poll for it with a short timeout, so the main thread
+    keeps returning to the interpreter and can raise ``KeyboardInterrupt``. On
+    interrupt the daemon thread is just abandoned (being a daemon it won't hold
+    up exit), so the usual cleanup routines still run instead of the process
+    being torn down mid-flight.
 
-    Signal handlers can only be changed from the main thread, so on any other
-    thread (or in embedded interpreters that refuse the change) this is a
-    no-op and the caller's existing semantics are preserved.
+    Signals only reach the main thread, so anywhere else we resolve inline and
+    keep the previous blocking behaviour.
     """
     if threading.current_thread() is not threading.main_thread():
-        yield
-        return
-    try:
-        old = signal.signal(signal.SIGINT, signal.SIG_DFL)
-    except ValueError:
-        yield
-        return
-    try:
-        yield
-    finally:
-        signal.signal(signal.SIGINT, old)
+        return socket.getaddrinfo(host, port, fam, typ, 0, socket.AI_PASSIVE)
+
+    result = {}
+    done = threading.Event()
+
+    def resolve():
+        try:
+            result['addrinfos'] = socket.getaddrinfo(host, port, fam, typ, 0, socket.AI_PASSIVE)
+        except BaseException as e:
+            result['error'] = e
+        finally:
+            done.set()
+
+    threading.Thread(target=resolve, name='pwnlib-getaddrinfo', daemon=True).start()
+    while not done.wait(0.1):
+        pass
+
+    if 'error' in result:
+        raise result['error']
+    return result['addrinfos']
 
 class remote(sock):
     r"""Creates a TCP or UDP-connection to a remote host. It supports
@@ -137,8 +147,7 @@ class remote(sock):
         timeout = self.timeout
 
         with self.waitfor('Opening connection to %s on port %s' % (self.rhost, self.rport)) as h:
-            with _interruptible_block():
-                addrinfos = socket.getaddrinfo(self.rhost, self.rport, fam, typ, 0, socket.AI_PASSIVE)
+            addrinfos = _resolve_interruptible(self.rhost, self.rport, fam, typ)
             for res in addrinfos:
                 self.family, self.type, self.proto, _canonname, sockaddr = res
 

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -1,11 +1,41 @@
+import contextlib
+import signal
 import socket
 import socks
+import threading
 
 from pwnlib.log import getLogger
 from pwnlib.timeout import Timeout
 from pwnlib.tubes.sock import sock
 
 log = getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _interruptible_block():
+    """Temporarily reset SIGINT to its default handler for the duration of the
+    block, then restore the previous handler.
+
+    This lets a Ctrl-C interrupt blocking C-level calls such as
+    :func:`socket.getaddrinfo`, which on glibc hold the GIL and are otherwise
+    uninterruptible from Python (#2540).
+
+    Signal handlers can only be changed from the main thread, so on any other
+    thread (or in embedded interpreters that refuse the change) this is a
+    no-op and the caller's existing semantics are preserved.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+    try:
+        old = signal.signal(signal.SIGINT, signal.SIG_DFL)
+    except ValueError:
+        yield
+        return
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, old)
 
 class remote(sock):
     r"""Creates a TCP or UDP-connection to a remote host. It supports
@@ -107,7 +137,9 @@ class remote(sock):
         timeout = self.timeout
 
         with self.waitfor('Opening connection to %s on port %s' % (self.rhost, self.rport)) as h:
-            for res in socket.getaddrinfo(self.rhost, self.rport, fam, typ, 0, socket.AI_PASSIVE):
+            with _interruptible_block():
+                addrinfos = socket.getaddrinfo(self.rhost, self.rport, fam, typ, 0, socket.AI_PASSIVE)
+            for res in addrinfos:
                 self.family, self.type, self.proto, _canonname, sockaddr = res
 
                 if self.type not in [socket.SOCK_STREAM, socket.SOCK_DGRAM]:


### PR DESCRIPTION
Closes #2540.

## What

`pwnlib.tubes.remote.remote(host, port)` calls `socket.getaddrinfo()` to resolve `host`. On glibc, `getaddrinfo` holds the GIL during the libc DNS round-trip and swallows SIGINT, so a hung resolver leaves the script unkillable from Ctrl-C until the kernel-level resolver timeout (often ~30s).

This PR follows the workaround @Arusekk suggested in the issue thread: swap the SIGINT handler to `SIG_DFL` for the duration of the resolution call, then restore the original handler.

```python
@contextlib.contextmanager
def _interruptible_block():
    if threading.current_thread() is not threading.main_thread():
        yield
        return
    try:
        old = signal.signal(signal.SIGINT, signal.SIG_DFL)
    except ValueError:
        yield
        return
    try:
        yield
    finally:
        signal.signal(signal.SIGINT, old)
```

`remote._connect` now wraps the `socket.getaddrinfo(...)` call in this context.

## Why

Quoted from the issue's main reporter (@tesuji):
> I would like to use ctrl-C to quit immediately in these cases.

And from @Arusekk:
> Maybe we can set SIGINT handler to SIG_DFL as a workaround?

That's exactly what this does, scoped narrowly to the resolver call so it doesn't perturb anything else.

## Tests

- Existing `remote()` round-trip against a local `listen()` socket still passes (resolution to a literal IP is instantaneous).
- `_interruptible_block` swap+restore verified directly: `signal.getsignal(SIGINT)` is `SIG_DFL` inside, equal to the original handler outside.
- On a non-main thread the context is a no-op (signal handlers can only be changed from the main thread, so we don't try).

## Notes

- Pure-additive: no existing call signature changes. Anyone who *wants* to keep their custom SIGINT handler around their own getaddrinfo can call it directly without going through `remote()`.
- The fix only covers `pwnlib.tubes.remote.remote._connect`; if a similar hang ever shows up in another tube's resolver call it can reuse `_interruptible_block` (or be lifted into a shared module).