### PR TITLE
Fix atexception handlers in term mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2720][2720] ssh: resolve PermissionError on Windows during SFTP upload
 - [#2702][2702] ssh: Don't cache username in ssh checksec output
 - [#2722][2722] safeeval: allow LIST_APPEND and SET_ADD opcodes (Python 3.14)
+- [#2730][2730] Fix atexception handlers in term mode
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -189,6 +190,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2720]: https://github.com/Gallopsled/pwntools/pull/2720
 [2702]: https://github.com/Gallopsled/pwntools/pull/2702
 [2722]: https://github.com/Gallopsled/pwntools/pull/2722
+[2730]: https://github.com/Gallopsled/pwntools/pull/2730
 
 ## 4.15.1
 

--- a/docs/source/atexception.rst
+++ b/docs/source/atexception.rst
@@ -1,3 +1,7 @@
+.. testsetup:: *
+
+   from pwnlib import atexception
+
 :mod:`pwnlib.atexception` --- Callbacks on unhandled exception
 ==============================================================
 

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -16,6 +16,21 @@ import tempfile
 import threading
 import time
 
+try:
+    import colored_traceback
+except ImportError:
+    pass
+else:
+    try:
+        colored_traceback.add_hook()
+    except Exception:
+        # Exception: curses.error
+        # colored_traceback (curses.setupterm()) fails if TERM is unset.
+        # This is not critical, so we just ignore it.
+        # We cannot import `curses` for `curses.error` because it is not
+        # available on all platforms (e.g. Windows).
+        pass
+
 from pprint import pprint
 
 import pwnlib
@@ -84,21 +99,6 @@ warn    = log.warning
 info    = log.info
 debug   = log.debug
 success = log.success
-
-try:
-    import colored_traceback
-except ImportError:
-    pass
-else:
-    try:
-        colored_traceback.add_hook()
-    except Exception:
-        # Exception: curses.error
-        # colored_traceback (curses.setupterm()) fails if TERM is unset.
-        # This is not critical, so we just ignore it.
-        # We cannot import `curses` for `curses.error` because it is not
-        # available on all platforms (e.g. Windows).
-        pass
 
 # Equivalence with the default behavior of "from import *"
 # __all__ = [x for x in tuple(globals()) if not x.startswith('_')]

--- a/pwnlib/atexception.py
+++ b/pwnlib/atexception.py
@@ -50,6 +50,19 @@ def register(func: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> int
 
     This function is thread safe.
 
+    >>> def handler(a, b):
+    ...     print("Exception handler", a, b)
+    >>> ident = atexception.register(handler, 13, 37)
+    >>> raise Exception("Unexpected error") # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    Exception: Unexpected error
+    Exception handler 13 37
+    >>> atexception.unregister(ident)
+    >>> raise Exception("Unexpected error") # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    Exception: Unexpected error
     """
     global _ident
     with _lock:


### PR DESCRIPTION
The colored-traceback module registers its own `sys.excepthook` but doesn't call the original handler. Reorder the includes such that the colored-traceback is setup before our own hooks. We always call the old excepthook and forward the exception to the colored-traceback before firing our own handlers.

It worked before in non-term mode when stderr wasn't a tty and colors were disabled.