### PR TITLE
fix(ssh): ssh.which returning None for POSIX paths when running on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2702][2702] ssh: Don't cache username in ssh checksec output
 - [#2722][2722] safeeval: allow LIST_APPEND and SET_ADD opcodes (Python 3.14)
 - [#2730][2730] Fix atexception handlers in term mode
+- [#2732][2732] ssh: fix `ssh.which` returns None for POSIX paths when running on Windows
 - [#2733][2733] loongarch64: fix incorrect mov assembly template
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
@@ -196,6 +197,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2722]: https://github.com/Gallopsled/pwntools/pull/2722
 [2725]: https://github.com/Gallopsled/pwntools/pull/2725
 [2730]: https://github.com/Gallopsled/pwntools/pull/2730
+[2732]: https://github.com/Gallopsled/pwntools/pull/2732
 [2733]: https://github.com/Gallopsled/pwntools/pull/2733
 [2739]: https://github.com/Gallopsled/pwntools/pull/2739
 [2740]: https://github.com/Gallopsled/pwntools/pull/2740

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -294,7 +294,7 @@ class ContextType:
         >>> context.os == 'linux'
         True
         >>> context.arch = 'arm'
-        >>> vars(context) == {'arch': 'arm', 'bits': 32, 'endian': 'little', 'os': 'linux', 'newline': b'\n'}
+        >>> vars(context) == {'arch': 'arm', 'bits': 32, 'endian': 'little', 'os': 'linux', 'newline': b'\n', 'path_sep': b'/', 'pathlist_sep': b':'}
         True
         >>> context.endian
         'little'
@@ -368,6 +368,8 @@ class ContextType:
         'randomize': False,
         'rename_corefiles': True,
         'newline': b'\n',
+        'path_sep': b'/',
+        'pathlist_sep': b':',
         'throw_eof_on_incomplete_line': None,
         'noptrace': False,
         'os': 'linux',
@@ -378,8 +380,8 @@ class ContextType:
         'timeout': Timeout.maximum,
     }
 
-    unix_like    = {'newline': b'\n'}
-    windows_like = {'newline': b'\r\n'}
+    unix_like    = {'newline': b'\n', 'path_sep': b'/', 'pathlist_sep': b':'}
+    windows_like = {'newline': b'\r\n', 'path_sep': b'\\', 'pathlist_sep': b';'}
 
     #: Keys are valid values for :meth:`pwnlib.context.ContextType.os`
     oses = _longest({
@@ -470,7 +472,7 @@ class ContextType:
 
             >>> context.clear()
             >>> context.os   = 'linux'
-            >>> vars(context) == {'os': 'linux', 'newline': b'\n'}
+            >>> vars(context) == {'os': 'linux', 'newline': b'\n', 'path_sep': b'/', 'pathlist_sep': b':'}
             True
         """
         return self._tls.copy()
@@ -1165,8 +1167,12 @@ class ContextType:
             >>> context.clear()
             >>> context.newline == b'\n' # Default value
             True
+            >>> context.path_sep == b'/' # Default value
+            True
             >>> context.os = 'windows'
             >>> context.newline == b'\r\n' # New value
+            True
+            >>> context.path_sep == b'\\' # New value
             True
 
             Note that expressly setting :attr:`newline` means that we use
@@ -1182,7 +1188,7 @@ class ContextType:
 
             >>> context.clear()
             >>> context.os = 'windows'
-            >>> vars(context) == {'os': 'windows', 'newline': b'\r\n'}
+            >>> vars(context) == {'os': 'windows', 'newline': b'\r\n', 'path_sep': b'\\', 'pathlist_sep': b';'}
             True
         """
         os = os.lower()
@@ -1530,6 +1536,30 @@ class ContextType:
         # circular imports
         from pwnlib.util.packing import _need_bytes
         return _need_bytes(v)
+
+    @_validator
+    def path_sep(self, v):
+        """Sets the path separator used for Tubes by default.
+
+        This configures the path separator used by e.g. ``which`` and similar
+        functions.
+        """
+        # circular imports
+        from pwnlib.util.packing import _need_bytes
+        return _need_bytes(v)
+
+
+    @_validator
+    def pathlist_sep(self, v):
+        """Sets the path list separator used for Tubes by default.
+
+        This configures the path list separator used by functions that 
+        inspect or split path lists such as ``PATH``.
+        """
+        # circular imports
+        from pwnlib.util.packing import _need_bytes
+        return _need_bytes(v)
+
 
     @_validator
     def throw_eof_on_incomplete_line(self, v):

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -294,7 +294,7 @@ class ContextType:
         >>> context.os == 'linux'
         True
         >>> context.arch = 'arm'
-        >>> vars(context) == {'arch': 'arm', 'bits': 32, 'endian': 'little', 'os': 'linux', 'newline': b'\n', 'path_sep': b'/', 'pathlist_sep': b':'}
+        >>> vars(context) == {'arch': 'arm', 'bits': 32, 'endian': 'little', 'os': 'linux', 'newline': b'\n'}
         True
         >>> context.endian
         'little'
@@ -368,8 +368,6 @@ class ContextType:
         'randomize': False,
         'rename_corefiles': True,
         'newline': b'\n',
-        'path_sep': b'/',
-        'pathlist_sep': b':',
         'throw_eof_on_incomplete_line': None,
         'noptrace': False,
         'os': 'linux',
@@ -380,8 +378,8 @@ class ContextType:
         'timeout': Timeout.maximum,
     }
 
-    unix_like    = {'newline': b'\n', 'path_sep': b'/', 'pathlist_sep': b':'}
-    windows_like = {'newline': b'\r\n', 'path_sep': b'\\', 'pathlist_sep': b';'}
+    unix_like    = {'newline': b'\n'}
+    windows_like = {'newline': b'\r\n'}
 
     #: Keys are valid values for :meth:`pwnlib.context.ContextType.os`
     oses = _longest({
@@ -472,7 +470,7 @@ class ContextType:
 
             >>> context.clear()
             >>> context.os   = 'linux'
-            >>> vars(context) == {'os': 'linux', 'newline': b'\n', 'path_sep': b'/', 'pathlist_sep': b':'}
+            >>> vars(context) == {'os': 'linux', 'newline': b'\n'}
             True
         """
         return self._tls.copy()
@@ -1167,12 +1165,8 @@ class ContextType:
             >>> context.clear()
             >>> context.newline == b'\n' # Default value
             True
-            >>> context.path_sep == b'/' # Default value
-            True
             >>> context.os = 'windows'
             >>> context.newline == b'\r\n' # New value
-            True
-            >>> context.path_sep == b'\\' # New value
             True
 
             Note that expressly setting :attr:`newline` means that we use
@@ -1188,7 +1182,7 @@ class ContextType:
 
             >>> context.clear()
             >>> context.os = 'windows'
-            >>> vars(context) == {'os': 'windows', 'newline': b'\r\n', 'path_sep': b'\\', 'pathlist_sep': b';'}
+            >>> vars(context) == {'os': 'windows', 'newline': b'\r\n'}
             True
         """
         os = os.lower()
@@ -1536,30 +1530,6 @@ class ContextType:
         # circular imports
         from pwnlib.util.packing import _need_bytes
         return _need_bytes(v)
-
-    @_validator
-    def path_sep(self, v):
-        """Sets the path separator used for Tubes by default.
-
-        This configures the path separator used by e.g. ``which`` and similar
-        functions.
-        """
-        # circular imports
-        from pwnlib.util.packing import _need_bytes
-        return _need_bytes(v)
-
-
-    @_validator
-    def pathlist_sep(self, v):
-        """Sets the path list separator used for Tubes by default.
-
-        This configures the path list separator used by functions that 
-        inspect or split path lists such as ``PATH``.
-        """
-        # circular imports
-        from pwnlib.util.packing import _need_bytes
-        return _need_bytes(v)
-
 
     @_validator
     def throw_eof_on_incomplete_line(self, v):

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1122,7 +1122,7 @@ class ssh(Timeout, Logger):
         system which adds the current working directory to the end of ``$PATH``.
         """
         # If name is a path, do not attempt to resolve it.
-        if os.path.sep in program:
+        if '/' in program:
             return program
 
         program = packing._encode(program)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1479,8 +1479,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
         fingerprint = fingerprint and self._get_fingerprint(remote) or None
         if fingerprint is None:
-            local = os.path.normpath(remote)
-            local = os.path.basename(local)
+            local = self._pathlib(remote).name
             local += time.strftime('-%Y-%m-%d-%H%M%S')
             local = os.path.join(self._cachedir, local)
 
@@ -1549,7 +1548,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
 
         if not local:
-            local = os.path.basename(os.path.normpath(remote))
+            local = self._pathlib(remote).name
 
         with self.progress('Downloading %r to %r' % (remote, local)) as p:
             local_tmp = self._download_to_cache(remote, p)
@@ -1626,7 +1625,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         """
         data = packing._need_bytes(data)
         # If a relative path was provided, prepend the cwd
-        if os.path.normpath(remote) == os.path.basename(remote):
+        if str(self._pathlib(remote)) == self._pathlib(remote).name:
             remote = str(self._pathlib(self.cwd) / remote)
 
         if self.sftp:

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -592,6 +592,7 @@ class ssh(Timeout, Logger):
     pid = None
 
     _cwd = '.'
+    _sep = '/'
     _tried_sftp = False
 
     def __init__(self, user=None, host=None, port=22, password=None, key=None,
@@ -1122,14 +1123,15 @@ class ssh(Timeout, Logger):
         system which adds the current working directory to the end of ``$PATH``.
         """
         # If name is a path, do not attempt to resolve it.
-        if context.path_sep.decode() in program:
+        if self._sep in program:
             return program
 
         program = packing._encode(program)
+        pathsep = self._sep.encode()
 
         result = self.system(b'export PATH=$PATH:$PWD; command -v ' + program).recvall().strip()
 
-        if (context.path_sep + program) not in result:
+        if (pathsep + program) not in result:
             return None
 
         return packing._decode(result)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import re
 import shutil
 import string
@@ -593,6 +594,7 @@ class ssh(Timeout, Logger):
 
     _cwd = '.'
     _sep = '/'
+    _pathlib = pathlib.PurePosixPath
     _tried_sftp = False
 
     def __init__(self, user=None, host=None, port=22, password=None, key=None,
@@ -696,6 +698,10 @@ class ssh(Timeout, Logger):
         self._ibt = None
 
         misc.mkdir_p(self._cachedir)
+
+        if context.os == 'windows':
+            self._sep = '\\'
+            self._pathlib = pathlib.PureWindowsPath    
 
         import paramiko
 
@@ -1621,7 +1627,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         data = packing._need_bytes(data)
         # If a relative path was provided, prepend the cwd
         if os.path.normpath(remote) == os.path.basename(remote):
-            remote = os.path.join(self.cwd, remote)
+            remote = str(self._pathlib(self.cwd) / remote)
 
         if self.sftp:
             flo = BytesIO(data)
@@ -1652,9 +1658,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
 
         if remote is None:
-            remote = os.path.normpath(filename)
-            remote = os.path.basename(remote)
-            remote = os.path.join(self.cwd, remote)
+            remote = str(self._pathlib(self.cwd) / self._pathlib(filename).name)
 
         with open(filename, 'rb') as fd:
             data = fd.read()
@@ -1911,7 +1915,7 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
         status = 0
 
         if symlink and not isinstance(symlink, (bytes, str)):
-            symlink = os.path.join(self.pwd(), b'*')
+            symlink = str(self._pathlib(self.pwd().decode()) / '*')
         if not hasattr(symlink, 'encode') and hasattr(symlink, 'decode'):
             symlink = symlink.decode('utf-8')
             

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1122,14 +1122,14 @@ class ssh(Timeout, Logger):
         system which adds the current working directory to the end of ``$PATH``.
         """
         # If name is a path, do not attempt to resolve it.
-        if '/' in program:
+        if context.path_sep.decode() in program:
             return program
 
         program = packing._encode(program)
 
         result = self.system(b'export PATH=$PATH:$PWD; command -v ' + program).recvall().strip()
 
-        if (b'/' + program) not in result:
+        if (context.path_sep + program) not in result:
             return None
 
         return packing._decode(result)

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -1548,7 +1548,8 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
 
 
         if not local:
-            local = self._pathlib(remote).name
+            remote_str = remote.decode() if not hasattr(remote, 'encode') else remote
+            local = self._pathlib(remote_str).name
 
         with self.progress('Downloading %r to %r' % (remote, local)) as p:
             local_tmp = self._download_to_cache(remote, p)
@@ -1624,8 +1625,11 @@ from ctypes import *; libc = CDLL('libc.so.6'); print(libc.getenv(%r))
             Hello, world
         """
         data = packing._need_bytes(data)
+        if not hasattr(remote, 'encode'):
+            remote = remote.decode('utf-8')
         # If a relative path was provided, prepend the cwd
-        if str(self._pathlib(remote)) == self._pathlib(remote).name:
+        remote_path = self._pathlib(remote)
+        if str(remote_path) == remote_path.name:
             remote = str(self._pathlib(self.cwd) / remote)
 
         if self.sftp:


### PR DESCRIPTION
## Problem
When running Pwntools on Windows to interact with a remote POSIX system, `ssh.which` fails to recognize program names that include a POSIX path separator `/`.
This results in the method returning `None` even if the file exists and is executable.

## Analysis
The current implementation uses `os.path.sep` to determine if the `program` argument should be treated as a path:

https://github.com/Gallopsled/pwntools/blob/4e1780781f34aa7186686e05ed3cebddd55f22bd/pwnlib/tubes/ssh.py#L1125-L1134

On Windows, `os.path.sep` is `\\`. If a user passes a path containing `/` (whether it is an absolute path like `/usr/bin/sh` or a relative one like `bin/sh`), the check fails. The code then attempts to resolve the name via `command -v`, but the subsequent validation `if (b'/' + program) not in result` fails because the return value from `command -v` does not match the expected format for non-path arguments.

Since the `ssh` module is intrinsically designed for POSIX-compatible targets (using shell commands like `export PATH` and `command -v`), the path separator check should be platform-independent and specifically look for `/`.


## Reproduction (on Windows)

Environment: Pwntools v4.15.0, Python 3.14.3, Windows 11

```py
with pwn.ssh(host="some_linux") as ssh:
    print("which sh", ssh.which('sh'))
    print("which /usr/bin/sh", ssh.which('/usr/bin/sh'))
```

```console
[x] Connecting to some_linux on port 22
[+] Connecting to some_linux on port 22: Done
[!] Couldn't check security settings on 'some_linux'
[x] Opening new channel: b'export PATH=$PATH:$PWD; command -v sh'
[+] Opening new channel: b'export PATH=$PATH:$PWD; command -v sh': Done
[*] Closed SSH channel with some_linux
which sh /usr/bin/sh
[x] Opening new channel: b'export PATH=$PATH:$PWD; command -v /usr/bin/sh'
[+] Opening new channel: b'export PATH=$PATH:$PWD; command -v /usr/bin/sh': Done
[*] Closed SSH channel with some_linux
which /usr/bin/sh None
[*] Closed connection to 'some_linux'
```
