### PR TITLE
loongarch64: fix mov assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2702][2702] ssh: Don't cache username in ssh checksec output
 - [#2722][2722] safeeval: allow LIST_APPEND and SET_ADD opcodes (Python 3.14)
 - [#2730][2730] Fix atexception handlers in term mode
+- [#2733][2733] loongarch64: fix incorrect mov assembly template
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -193,6 +194,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2722]: https://github.com/Gallopsled/pwntools/pull/2722
 [2725]: https://github.com/Gallopsled/pwntools/pull/2725
 [2730]: https://github.com/Gallopsled/pwntools/pull/2730
+[2733]: https://github.com/Gallopsled/pwntools/pull/2733
 
 ## 4.15.1
 

--- a/pwnlib/shellcraft/templates/loongarch64/linux/syscall.asm
+++ b/pwnlib/shellcraft/templates/loongarch64/linux/syscall.asm
@@ -13,90 +13,65 @@ Any of the arguments can be expressions to be evaluated by :func:`pwnlib.constan
 Example:
 
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall('SYS_execve', 1, 'sp', 2, 0).rstrip())
-            addi.d   $a0, $r0, 1
-            addi.d   $a1, $sp, 0
-            addi.d   $a2, $r0, 2
-            addi.d   $a3, $r0, 0
-            addi.d   $a7, $r0, 221
+            li.d     $a0, 1
+            move     $a1, $sp
+            li.d     $a2, 2
+            li.d     $a3, 0
+            li.d     $a7, 221
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall('SYS_execve', 2, 1, 0, 20).rstrip())
-            addi.d   $a0, $r0, 2
-            addi.d   $a1, $r0, 1
-            addi.d   $a2, $r0, 0
-            addi.d   $a3, $r0, 20
-            addi.d   $a7, $r0, 221
+            li.d     $a0, 2
+            li.d     $a1, 1
+            li.d     $a2, 0
+            li.d     $a3, 20
+            li.d     $a7, 221
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall().rstrip())
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall('a7', 'a0', 'a1').rstrip())
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall('a3', None, None, 1).rstrip())
-            addi.d   $a2, $r0, 1
-            addi.d   $a7, $a3, 0
+            li.d     $a2, 1
+            move     $a7, $a3
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall(
         ...               'SYS_mmap', 0, 0x1000,
         ...               'PROT_READ | PROT_WRITE | PROT_EXEC',
         ...               'MAP_PRIVATE',
         ...               -1, 0).rstrip())
-            addi.d   $a0, $r0, 0
-            addi.d   $a1, $r0, 1
-            lu52i.d  $a1, $a1, 0
-            addi.d   $a2, $r0, 7
-            addi.d   $a3, $r0, 2
-            addi.d   $a4, $r0, 15
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            addi.d   $a5, $r0, 0
-            addi.d   $a7, $r0, 222
+            li.d     $a0, 0
+            li.d     $a1, 4096
+            li.d     $a2, 7
+            li.d     $a3, 2
+            li.d     $a4, 18446744073709551615
+            li.d     $a5, 0
+            li.d     $a7, 222
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.linux.syscall(
         ...               'SYS_mmap', 0, 0x1000,
         ...               'PROT_READ | PROT_WRITE | PROT_EXEC',
         ...               'MAP_PRIVATE',
         ...               -1, 0).rstrip())
-            addi.d   $a0, $r0, 0
-            addi.d   $a1, $r0, 1
-            lu52i.d  $a1, $a1, 0
-            addi.d   $a2, $r0, 7
-            addi.d   $a3, $r0, 2
-            addi.d   $a4, $r0, 15
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            lu52i.d  $a4, $a4, -1
-            addi.d   $a5, $r0, 0
-            addi.d   $a7, $r0, 222
+            li.d     $a0, 0
+            li.d     $a1, 4096
+            li.d     $a2, 7
+            li.d     $a3, 2
+            li.d     $a4, 18446744073709551615
+            li.d     $a5, 0
+            li.d     $a7, 222
             syscall  0
         >>> print(pwnlib.shellcraft.loongarch64.openat('AT_FDCWD', '/home/pwn/flag').rstrip())
             /* openat(fd='AT_FDCWD', file='/home/pwn/flag', oflag=0) */
-            addi.d   $t8, $r0, 7
-            lu52i.d  $t8, $t8, 1904
-            lu52i.d  $t8, $t8, 758
-            lu52i.d  $t8, $t8, 1389
-            lu52i.d  $t8, $t8, 1782
-            lu52i.d  $t8, $t8, -2001
+            li.d     $t8, 8606431000579237935
             addi.d   $sp, $sp, -8
             st.d     $t8, $sp, 0
-            addi.d   $t8, $r0, 1654
-            lu52i.d  $t8, $t8, 364
-            lu52i.d  $t8, $t8, 1634
-            lu52i.d  $t8, $t8, -146
+            li.d     $t8, 113668128124782
             addi.d   $sp, $sp, -8
             st.d     $t8, $sp, 0
-            addi.d   $a1, $sp, 0
-            addi.d   $a0, $r0, 15
-            lu52i.d  $a0, $a0, -1
-            lu52i.d  $a0, $a0, -1
-            lu52i.d  $a0, $a0, -1
-            lu52i.d  $a0, $a0, -1
-            lu52i.d  $a0, $a0, -100
-            addi.d   $a2, $r0, 0
-            addi.d   $a7, $r0, 56
+            move     $a1, $sp
+            li.d     $a0, 18446744073709551516
+            li.d     $a2, 0
+            li.d     $a7, 56
             syscall  0
 </%docstring>
 <%

--- a/pwnlib/shellcraft/templates/loongarch64/mov.asm
+++ b/pwnlib/shellcraft/templates/loongarch64/mov.asm
@@ -15,8 +15,6 @@ If src is a string that is not a register, then it will locally set
 string. Note that this means that this shellcode can change behavior depending
 on the value of `context.os`.
 
-There is no effort done to avoid newlines and null bytes in the generated code.
-
 Args:
 
   dst (str): The destination register.
@@ -25,16 +23,13 @@ Args:
 Example:
 
     >>> print(shellcraft.loongarch64.mov('t0', 0).rstrip())
-        addi.d   $t0, $r0, 0
+        li.d     $t0, 0
     >>> print(shellcraft.loongarch64.mov('t0', 0x2000).rstrip())
-        addi.d   $t0, $r0, 2
-        lu52i.d  $t0, $t0, 0
+        li.d     $t0, 8192
     >>> print(shellcraft.loongarch64.mov('t0', 0xcafebabe).rstrip())
-        addi.d   $t0, $r0, 202
-        lu52i.d  $t0, $t0, -21
-        lu52i.d  $t0, $t0, -1346
+        li.d     $t0, 3405691582
     >>> print(shellcraft.loongarch64.mov('t1', 'sp').rstrip())
-        addi.d   $t1, $sp, 0
+        move     $t1, $sp
 
 </%docstring>
 <%
@@ -59,31 +54,12 @@ if src_reg == 0:
 %>
 
 % if dst_reg == 0 or dst_reg == src_reg:
-    /* ld ${dst}, ${src} is a noop */
+    /* mov ${dst}, ${src} is a noop */
 % elif src_reg is not None:
-    addi.d   $${dst}, $${src}, 0
+    move     $${dst}, $${src}
 % else:
 ## Source is an immediate, normalize to [0, 2**64)
-
 <% src = packing.unpack(packing.pack(src, word_size=64), word_size=64, sign=False) %>
 ## Immediates are always sign-extended to 64-bit
-
-% if src == 0:
-    addi.d   $${dst}, $r0, 0
-% else:
-<%
-parts = []
-fullsrc = src
-while src != 0:
-    parts.append(packing.unpack(packing.pack((src & 0xfff), word_size=12, sign=False), word_size=12, sign=True))
-    src = src >> 12
-%>
-% for idx, part in enumerate(reversed(parts)):
-    % if idx == 0:
-    addi.d   $${dst}, $r0, ${part}
-    % else:
-    lu52i.d  $${dst}, $${dst}, ${part}
-    % endif
-% endfor
-% endif
+    li.d     $${dst}, ${src}
 % endif

--- a/pwnlib/shellcraft/templates/loongarch64/pushstr.asm
+++ b/pwnlib/shellcraft/templates/loongarch64/pushstr.asm
@@ -15,39 +15,31 @@ Example:
     >>> print(shellcraft.loongarch64.pushstr('').rstrip())
         st.d     $r0, -8(sp)
     >>> print(shellcraft.loongarch64.pushstr('a').rstrip())
-        addi.d   $t8, $r0, 97
+        li.d     $t8, 97
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
     >>> print(shellcraft.loongarch64.pushstr('aa').rstrip())
-        addi.d   $t8, $r0, 6
-        lu52i.d  $t8, $t8, 353
+        li.d     $t8, 24929
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
     >>> print(shellcraft.loongarch64.pushstr('aaaa').rstrip())
-        addi.d   $t8, $r0, 97
-        lu52i.d  $t8, $t8, 1558
-        lu52i.d  $t8, $t8, 353
+        li.d     $t8, 1633771873
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
     >>> print(shellcraft.loongarch64.pushstr('aaaaa').rstrip())
-        addi.d   $t8, $r0, 6
-        lu52i.d  $t8, $t8, 353
-        lu52i.d  $t8, $t8, 1558
-        lu52i.d  $t8, $t8, 353
+        li.d     $t8, 418245599585
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
     >>> print(shellcraft.loongarch64.pushstr('aaaa', append_null = False).rstrip())
-        addi.d   $t8, $r0, 97
-        lu52i.d  $t8, $t8, 1558
-        lu52i.d  $t8, $t8, 353
+        li.d     $t8, 1633771873
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
     >>> print(shellcraft.loongarch64.pushstr(b'\xc3').rstrip())
-        addi.d   $t8, $r0, 195
+        li.d     $t8, 195
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
     >>> print(shellcraft.loongarch64.pushstr(b'\xc3', append_null = False).rstrip())
-        addi.d   $t8, $r0, 195
+        li.d     $t8, 195
         addi.d   $sp, $sp, -8
         st.d     $t8, $sp, 0
 

--- a/pwnlib/shellcraft/templates/loongarch64/setregs.asm
+++ b/pwnlib/shellcraft/templates/loongarch64/setregs.asm
@@ -16,10 +16,10 @@ Args:
 Example:
 
     >>> print(shellcraft.setregs({'t0':1, 'a3':'0'}).rstrip())
-        addi.d   $a3, $r0, 0
-        addi.d   $t0, $r0, 1
+        li.d     $a3, 0
+        li.d     $t0, 1
     >>> print(shellcraft.setregs({'a0':'a1', 'a1':'a0', 'a2':'a1'}).rstrip())
-        addi.d   $a2, $a1, 0
+        move     $a2, $a1
         xor      $a1, $a1, $a0 /* xchg a1, a0 */
         xor      $a0, $a0, $a1
         xor      $a1, $a1, $a0


### PR DESCRIPTION
It turned out that the generator I wrote previously was incorrect.
These assembler pseudo-instructions should be lowered to correct code.

Changing `addi.d` to `move`, although `addi.d` is equivalent when moving a register to another, `move` (which lowers to `or rd, rj, 0`), is a standard alias, easier to understand, and some disassemblers can recognize `or rd, rj, 0` and show them as `move rd, rj`.

# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.blog/news-insights/product-news/change-the-base-branch-of-a-pull-request/

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
