### PR TITLE
fix #2737: pwnlib.shellcraft submodule imports on python 3.12+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
 - [#2725][2725] feat(libcdb): add extra_mirrors arg + PWNLIB_EXTRA_LIBC_MIRRORS env to download_libraries
 - [#2677][2677] refactor: replace unsafe eval with safeeval.const in ROP cache loading
 - [#2675][2675] feat(term): add zellij support
@@ -195,6 +196,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2725]: https://github.com/Gallopsled/pwntools/pull/2725
 [2730]: https://github.com/Gallopsled/pwntools/pull/2730
 [2733]: https://github.com/Gallopsled/pwntools/pull/2733
+[2739]: https://github.com/Gallopsled/pwntools/pull/2739
 
 ## 4.15.1
 

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -18,5 +18,4 @@ pwnlib/rop/call.py:0: error: Need type annotation for "args" (hint: "args: list[
 pwnlib/rop/call.py:0: error: Need type annotation for "values" (hint: "values: list[<type>] = ...")  [var-annotated]
 pwnlib/rop/rop.py:0: error: Need type annotation for "descriptions" (hint: "descriptions: dict[<type>, <type>] = ...")  [var-annotated]
 pwnlib/rop/srop.py:0: error: Need type annotation for "_regs" (hint: "_regs: list[<type>] = ...")  [var-annotated]
-pwnlib/shellcraft/__init__.py:0: error: Argument 1 to "append" of "list" has incompatible type "LazyImporter"; expected "MetaPathFinderProtocol"  [arg-type]
 pwnlib/update.py:0: error: "Callable[[bool], Version]" has no attribute "cached"  [attr-defined]

--- a/pwnlib/shellcraft/__init__.py
+++ b/pwnlib/shellcraft/__init__.py
@@ -1,3 +1,5 @@
+import importlib.abc
+import importlib.util
 import itertools
 import os
 import re
@@ -167,8 +169,8 @@ tether = sys.modules[__name__]
 # Create the module structure
 shellcraft = module(__name__, '')
 
-class LazyImporter:
-    def find_module(self, fullname, path=None):
+class LazyImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, fullname, path=None, target=None):
         if not fullname.startswith('pwnlib.shellcraft.'):
             return None
 
@@ -179,9 +181,15 @@ class LazyImporter:
             if not isinstance(cur, ModuleType):
                 return None
 
-        return self
+        return importlib.util.spec_from_loader(fullname, self)
 
-    def load_module(self, fullname):
-        return sys.modules[fullname]
+    def create_module(self, spec):
+        # The submodule was already built and registered in sys.modules by
+        # the getattr walk in find_spec, so hand that object back instead
+        # of letting the import system make a fresh empty module.
+        return sys.modules.get(spec.name)
+
+    def exec_module(self, module):
+        pass
 
 sys.meta_path.append(LazyImporter())


### PR DESCRIPTION
fixes #2737. on python 3.12+ pwnlib.shellcraft.amd64 throws ModuleNotFoundError because LazyImporter still uses find_module which 3.12 dropped. moved it to find_spec, same tree walk.

tested it, amd64 and i386 import, nested amd64.linux imports, bogus stuff still errors, shellcraft.amd64.linux.sh() still generates shellcode.
