### PR TITLE
setup: install docs to FHS-compliant share/doc/pwntools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
 - [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
 - [#2725][2725] feat(libcdb): add extra_mirrors arg + PWNLIB_EXTRA_LIBC_MIRRORS env to download_libraries
 - [#2677][2677] refactor: replace unsafe eval with safeeval.const in ROP cache loading
@@ -197,6 +198,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2730]: https://github.com/Gallopsled/pwntools/pull/2730
 [2733]: https://github.com/Gallopsled/pwntools/pull/2733
 [2739]: https://github.com/Gallopsled/pwntools/pull/2739
+[2740]: https://github.com/Gallopsled/pwntools/pull/2740
 
 ## 4.15.1
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if not os.path.exists(PythonH):
 
 setup(
     version              = '5.0.0dev',
-    data_files           = [('pwntools-doc',
+    data_files           = [('share/doc/pwntools',
                              glob.glob('*.md') + glob.glob('*.txt')),
                             ],
     package_data         = {


### PR DESCRIPTION
# Pwntools Pull Request

Please provide a high-level explanation of what this pull request is for.

Fixes #2150 

Docs were installed to `/usr/pwntools-doc`, which isn't [Filesystem Hierarchy Standard](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) compliant. This changes the `data_files` target to `share/doc/pwntools` so they install to `/usr/share/doc/pwntools` instead.