### PR TITLE
util: Add a high-level of C data type implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2722][2722] safeeval: allow LIST_APPEND and SET_ADD opcodes (Python 3.14)
 - [#2730][2730] Fix atexception handlers in term mode
 - [#2733][2733] loongarch64: fix incorrect mov assembly template
+- [#2742][2742] util: Add a high-level of C data type implementation
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -199,6 +200,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2733]: https://github.com/Gallopsled/pwntools/pull/2733
 [2739]: https://github.com/Gallopsled/pwntools/pull/2739
 [2740]: https://github.com/Gallopsled/pwntools/pull/2740
+[2742]: https://github.com/Gallopsled/pwntools/pull/2742
 
 ## 4.15.1
 

--- a/docs/source/util/c_primitives.rst
+++ b/docs/source/util/c_primitives.rst
@@ -2,7 +2,6 @@
 
    from pwnlib.util.c_primitives import *
 
-
 :mod:`pwnlib.util.c_primitives` --- C data types with pure Python
 =================================================================
 

--- a/docs/source/util/c_primitives.rst
+++ b/docs/source/util/c_primitives.rst
@@ -1,0 +1,10 @@
+.. testsetup:: *
+
+   from pwnlib.util.c_primitives import *
+
+
+:mod:`pwnlib.util.c_primitives` --- C data types with pure Python
+=================================================================
+
+.. automodule:: pwnlib.util.c_primitives
+   :members:

--- a/docs/source/util/c_primitives.rst
+++ b/docs/source/util/c_primitives.rst
@@ -2,6 +2,9 @@
 
    from pwnlib.util.c_primitives import *
 
+   import doctest
+   doctest_additional_flags = doctest.OPTIONFLAGS_BY_NAME['LINUX']
+
 :mod:`pwnlib.util.c_primitives` --- C data types with pure Python
 =================================================================
 

--- a/pwnlib/libc/c_primitives.py
+++ b/pwnlib/libc/c_primitives.py
@@ -1,3 +1,17 @@
+"""
+A generic module to construct C data types with pure Python. Downstream data types may
+consider combine basic types in ``ctypes`` and ``CArray``, ``CStruct`` and ``CUnion``
+in this module to implement basically all C types.
+
+This module provides some features that ``ctypes`` can not:
+1. User may access composite variables with ``slice`` to fetch memory.
+2. User may set composite members with ``bytes`` object.
+3. Easy to layout arch-specific types or layout in packed form. e.g., layout pointer
+   for 32-bit types but on 64-bit Python.
+4. Directly return ``int`` on basic types.
+5. Print composite types in a pwner-friendly form.
+"""
+
 from __future__ import annotations
 
 from collections import OrderedDict
@@ -63,6 +77,18 @@ def _remove_non_verbose_tail(s: TextIOBase, v: bool) -> None:
 
 
 class PwnType:
+    """
+    The base type of composite C types. DO NOT inherit this class when implementing
+    a specific C type. Use specific class down below.
+
+    All variables, including basic C types, are not stored with value directly. Instead,
+    the component offset and size is stored, and the actual value is fetched via memory.
+    Every composite type stores a ``memoryview`` object on initialization (or create a
+    buffer to construct a ``memoryview`` object) so later variables can be read
+    directly on memory. In this case, setting underlying memory buffer can affect
+    variable value, helping pwners write exploits painlessly.
+    """
+
     _32_size_cache_: int
     _64_size_cache_: int
     _32_align_cache_: int
@@ -72,7 +98,7 @@ class PwnType:
     _len: int
 
     def __init__(self, view: memoryview | None) -> None:
-        self._len = PwnType.calc_size(self)
+        self._len = PwnType._calc_size(self)
         if view is None:
             self._buf = bytearray(self._len)
             self._view = memoryview(self._buf)
@@ -80,7 +106,16 @@ class PwnType:
             self._buf = None
             self._view = view
 
-    def copy_from(self, value: Any) -> type[Any] | None:
+    def _copy_from(self, value: Any) -> type[Any] | None:
+        """
+        Sets a variable with a buffer, or an object of the same type.
+
+        Arguments:
+            value: The object to set up current object buffer.
+
+        Returns:
+            ``None`` if succeeded, or the type of ``value``.
+        """
         if isinstance(value, (str, bytes, bytearray)):
             b = _need_bytes(value)
             if len(b) > self._len:
@@ -93,28 +128,38 @@ class PwnType:
         return None
 
     @staticmethod
-    def calc_align(typ: CType) -> int:
+    def _calc_align(typ: CType) -> int:
+        """
+        Calculates the required align on C level of ``typ``. For basic C types, the
+        align is basically equal to the size of the type. As for composite types, the
+        align is the max align in members.
+        """
         if issubclass(typ, CTYPE_BASE):
-            return PwnType.calc_size(typ)
+            return PwnType._calc_size(typ)
         align_attr = f'_{context.bits}_align_cache_'
         if hasattr(typ, align_attr):
             return getattr(typ, align_attr)
         if issubclass(typ, (CStruct, CUnion)):
-            align = max(PwnType.calc_align(f[1]) for f in typ._fields_)
+            align = max(PwnType._calc_align(f[1]) for f in typ._fields_)
         elif issubclass(typ, CArray):
             if hasattr(typ, '_align_'):  # here _align_ is type-range
                 align = typ._align_
             else:
-                align = PwnType.calc_align(typ._type_)
+                align = PwnType._calc_align(typ._type_)
         elif issubclass(typ, (CEnum, CFlag)):
-            align = PwnType.calc_align(typ._size_type_)
+            align = PwnType._calc_align(typ._size_type_)
         else:
             raise NotImplementedError
         setattr(typ, align_attr, align)
         return align
 
     @staticmethod
-    def calc_size(typ: CType | PwnType) -> int:
+    def _calc_size(typ: CType | PwnType) -> int:
+        """
+        Calculate how many bytes does ``typ`` takes. For ``CStruct``, if coder manually
+        set all struct member offsets, it is considered that the struct is packed, or
+        else the struct size will align up. (The default not-packed bahavior.)
+        """
         if not isinstance(typ, type):
             typ = type(typ)
         if issubclass(typ, CTYPE_BASE):
@@ -134,32 +179,41 @@ class PwnType:
                     offset = field[2] if is64b else field[3]
                 else:  # offset need to be calculated
                     maybe_packed = False
-                    f_align = PwnType.calc_align(field_t)
+                    f_align = PwnType._calc_align(field_t)
                     # align up struct_len
                     offset = ((struct_len + f_align - 1) // f_align) * f_align
                 offsets[field[0]] = offset
-                field_len = PwnType.calc_size(field_t)
+                field_len = PwnType._calc_size(field_t)
                 struct_len = max(struct_len, offset + field_len)
             setattr(typ, offset_table_attr, offsets)
             if not maybe_packed:
-                align = PwnType.calc_align(typ)
+                align = PwnType._calc_align(typ)
                 struct_len = ((struct_len + align - 1) // align) * align
             size_cache = struct_len
         elif issubclass(typ, CArray):
             if typ._count_ == 0:
                 return 0
-            size_cache = PwnType.calc_align(typ) * typ._count_
+            size_cache = PwnType._calc_align(typ) * typ._count_
         elif issubclass(typ, CUnion):
-            size_cache = max(PwnType.calc_size(field[1]) for field in typ._fields_)
+            size_cache = max(PwnType._calc_size(field[1]) for field in typ._fields_)
         elif issubclass(typ, (CEnum, CFlag)):
-            size_cache = PwnType.calc_size(typ._size_type_)
+            size_cache = PwnType._calc_size(typ._size_type_)
         else:
             raise NotImplementedError
         setattr(typ, cache_attr, size_cache)
         return size_cache
 
     @staticmethod
-    def print_to_stream(s: TextIOBase, v: bool, indent: int, o: PwnType) -> None:
+    def _print_to_stream(s: TextIOBase, v: bool, indent: int, o: PwnType) -> None:
+        """
+        Recursively print composite into an IO stream.
+
+        Arguments:
+            s: The stream to write into.
+            v: ``True`` if writing for ``repr``, ``False`` if writing for ``str``.
+            indent: The current indentation.
+            o: The composite object to write.
+        """
         step = 2 if v else 0
         if isinstance(o, CCharArray):
             s.write('<')
@@ -193,7 +247,7 @@ class PwnType:
             for i in range(o._int_count):
                 s.write(' ' * indent)
                 if o._components:
-                    PwnType.print_to_stream(s, v, indent, o._components[i])
+                    PwnType._print_to_stream(s, v, indent, o._components[i])
                 else:
                     off = i * o._align_
                     unpacked = unpack(
@@ -219,7 +273,7 @@ class PwnType:
                 if v:
                     s.write(f'{off:<+#{w}x} {field} = ')
                 if isinstance(value, PwnType):
-                    PwnType.print_to_stream(s, v, indent, value)
+                    PwnType._print_to_stream(s, v, indent, value)
                 else:  # isinstance(value[0], int)
                     unpacked = unpack(
                         bytes(o._view[off : off + value]),
@@ -241,7 +295,7 @@ class PwnType:
                 if v:
                     s.write(f'{field} = ')
                 if isinstance(value, PwnType):
-                    PwnType.print_to_stream(s, v, indent, value)
+                    PwnType._print_to_stream(s, v, indent, value)
                 else:  # isinstance(value, int)
                     unpacked = unpack(bytes(o._view[:value]), value * 8)
                     s.write(f'{unpacked:#x},')
@@ -260,13 +314,13 @@ class PwnType:
 
     def __str__(self) -> str:
         with StringIO() as s:
-            PwnType.print_to_stream(s, False, 0, self)
+            PwnType._print_to_stream(s, False, 0, self)
             s.truncate(s.tell() - 2)  # strip comma and separator
             return s.getvalue()
 
     def __repr__(self) -> str:
         with StringIO() as s:
-            PwnType.print_to_stream(s, True, 0, self)
+            PwnType._print_to_stream(s, True, 0, self)
             s.truncate(s.tell() - 2)  # strip comma and separator
             return s.getvalue()
 
@@ -282,6 +336,9 @@ class PwnType:
         return self._view == value._view
 
     def _get_slice(self, subscript: Any) -> bytes | None:
+        """
+        A helper method to allow user to get object's underlying memory with ``slice``.
+        """
         if isinstance(subscript, slice):
             if subscript.step is not None:
                 raise ValueError(f'Slice step is not supported')
@@ -307,6 +364,10 @@ class PwnType:
         return None
 
     def _set_slice(self, subscript: Any, value: Any) -> bool:
+        """
+        A helper method to allow user to set object's underlying memory with ``slice``
+        and a buffer with the same size as the object.
+        """
         if isinstance(subscript, slice):
             if subscript.step is not None:
                 raise ValueError(f'Slice step is not supported')
@@ -346,9 +407,27 @@ class PwnType:
 
 
 class CArray(PwnType, Generic[ArrayItemT]):
+    """
+    A generic array to implement statments like ``int arr[3];`` in C. An array can be
+    accessed with ``int`` subscript. ``slice`` is used to access underlying memory not
+    objects.
+    """
+
     _type_: CType
+    """
+    The type of elements in array.
+    """
     _count_: int
+    """
+    The count of elements in array. This value can be ``0`` if and only if the array is
+    constructed with a ``memoryview``, and the length of that memoryview is not ``0``.
+    An internal count will be calculated in that case so user still have bound
+    restrictions when accessing elements.
+    """
     _align_: int
+    """
+    Optional special align for the array.
+    """
     _int_size: int
     _int_count: int
     _components: list[PwnType] | None
@@ -363,7 +442,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
             if len(self._view) == 0:
                 raise BufferError('Zero-length array has no writable memory')
 
-        self._int_size = PwnType.calc_size(self._type_)
+        self._int_size = PwnType._calc_size(self._type_)
         if not hasattr(self, '_align_'):
             self._align_ = self._int_size
         if self._len:
@@ -434,7 +513,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
             else:
                 # isinstance(self._components, list[PwnType])
                 # a.k.a. isinstance(self._type_, PwnType)
-                typ = self._components[idx].copy_from(value)
+                typ = self._components[idx]._copy_from(value)
                 if typ is not None:
                     expected = self._type_
                     raise ValueError(f"Can't set {_type(expected)} with {_type(typ)}")
@@ -444,11 +523,32 @@ class CArray(PwnType, Generic[ArrayItemT]):
 
 
 class CCharArray(CArray[int]):
+    """
+    A specific array type targeting char array. Set variable with this type will print
+    hexdump of elements.
+    """
+
     _type_ = c_char
 
 
 class CStruct(PwnType):
+    """
+    Base type of C structure. A structure can be accessed like member, or ``dict``.
+    See examples below.
+    """
+
     _fields_: list[tuple[str, CType] | tuple[str, CType, int, int]]
+    """
+    A ``list`` of struct members. If the struct is not packed, and you would like to
+    calculate offsets automatically, then fill out members with 2-element tuples,
+    member name and the member type.
+
+    If the struct is packed, you would need to fill out all members with 4-element
+    tuples, member name, member type, offset for 64-bit targets and offset for 32-bit
+    targets.
+
+    Please refer to ``CStruct`` for examples.
+    """
     _components: OrderedDict[str, CompCValue]
     _len: int
     _offsets32_: dict[str, int]
@@ -466,9 +566,9 @@ class CStruct(PwnType):
             field_t = field[1]
             off = self._int_offsets[field[0]]
             if issubclass(field_t, CTYPE_BASE):
-                self._components[field[0]] = PwnType.calc_size(field[1])
+                self._components[field[0]] = PwnType._calc_size(field[1])
             else:
-                size = PwnType.calc_size(field_t)
+                size = PwnType._calc_size(field_t)
                 assert issubclass(field_t, PwnType)
                 if issubclass(field_t, CArray) and size == 0:
                     self._components[field[0]] = field_t(self._view[off:])
@@ -492,7 +592,7 @@ class CStruct(PwnType):
             else:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
         else:  # isinstance(rhs, PwnType)
-            typ = rhs.copy_from(value)
+            typ = rhs._copy_from(value)
             if typ is not None:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
 
@@ -537,18 +637,52 @@ class CStruct(PwnType):
         raise ValueError(f"Can not access struct with '{_type(key)}' subscript")
 
     def offsetof(self, field_name: str) -> int:
+        """
+        Get the offset of some member from struct start.
+
+        Arguments:
+            field_name: The name of a member exists in the struct.
+
+        Returns:
+            The offset from start.
+
+        Raises:
+            ValueError: ``field_name`` is not exist in the struct.
+        """
         if field_name not in self._components:
             raise ValueError(f"'{field_name}' is not exist in '{_type(self)}'")
         return self._int_offsets[field_name]
 
     def struntil(self, field_name: str) -> bytes:
+        """
+        Get sealed buffer until the member.
+
+        Arguments:
+            field_name: The name of a member exists in the struct.
+
+        Returns:
+            A ``bytes`` slice starts from struct beginning and ends at the member. The
+            member is excluded.
+
+        Raises:
+            ValueError: ``field_name`` is not exist in the struct.
+        """
         if field_name not in self._components:
             raise ValueError(f"'{field_name}' is not exist in '{_type(self)}'")
         return bytes(self._view[: self._int_offsets[field_name]])
 
 
 class CUnion(PwnType):
+    """
+    Base type of C union. Like struct, you can access members with dot or like
+    ``dict``. See examples below.
+    """
+
     _fields_: list[tuple[str, CType]]
+    """
+    A ``list`` of types in the union. The type is described in a ``tuple``, the first
+    element is member name, and the secone one is member type.
+    """
     _components: OrderedDict[str, CompCValue]
 
     def __init__(self, view: memoryview | None = None) -> None:
@@ -560,9 +694,9 @@ class CUnion(PwnType):
         for field in self._fields_:
             field_t = field[1]
             if issubclass(field_t, CTYPE_BASE):
-                self._components[field[0]] = PwnType.calc_size(field_t)
+                self._components[field[0]] = PwnType._calc_size(field_t)
             else:
-                size = PwnType.calc_size(field_t)
+                size = PwnType._calc_size(field_t)
                 assert issubclass(field_t, PwnType)
                 self._components[field[0]] = field_t(self._view[:size])
 
@@ -590,7 +724,7 @@ class CUnion(PwnType):
             else:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
         else:  # isinstance(rhs, PwnType)
-            typ = rhs.copy_from(value)
+            typ = rhs._copy_from(value)
             if typ is not None:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
 
@@ -628,8 +762,19 @@ class CUnion(PwnType):
 
 
 class CEnum(PwnType):
+    """
+    Base type of a C enum. This can be used to beautify struct output.
+    """
+
     _size_type_: CType
+    """
+    Defines how many bytes this enum takes.
+    """
     _enum_: type[IntEnum]
+    """
+    The internal ``IntEnum`` type. When accessing the ``CEnum``, a new ``IntEnum`` will
+    be initialized to resolve the value on the memory.
+    """
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_enum_'):
@@ -649,7 +794,7 @@ class CEnum(PwnType):
         raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
     def copy_from(self, value: Any) -> type[Any] | None:
-        typ = super().copy_from(value)
+        typ = super()._copy_from(value)
         if typ is None:
             return typ
         if isinstance(value, int):
@@ -683,8 +828,19 @@ class CEnum(PwnType):
 
 
 class CFlag(PwnType):
+    """
+    Base type of a C enum. This can be used to beautify struct output.
+    """
+
     _size_type_: CType
+    """
+    Defines how many bytes this enum takes.
+    """
     _flag_: type[IntFlag]
+    """
+    The internal ``IntFlag`` type. When accessing the ``CFlag``, a new ``IntFlag`` will
+    be initialized to resolve the value on the memory.
+    """
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_flag_'):
@@ -704,7 +860,7 @@ class CFlag(PwnType):
         raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
     def copy_from(self, value: Any) -> type[Any] | None:
-        typ = super().copy_from(value)
+        typ = super()._copy_from(value)
         if typ is None:
             return typ
         if isinstance(value, int):
@@ -734,6 +890,9 @@ def mk_anonymous_carray(
     count: int,
     align: int = 0,
 ) -> type[CArray[CompCValue]]:
+    """
+    Factory function to generate an anonymous ``CArray``.
+    """
     fields: dict[str, Any] = {'_type_': elem_type, '_count_': count}
     if align:
         fields['_align_'] = align
@@ -741,6 +900,9 @@ def mk_anonymous_carray(
 
 
 def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
+    """
+    Factory function to generate an anonymous ``CCharArray``.
+    """
     fields: dict[str, Any] = {'_type_': c_char, '_count_': count}
     if align:
         fields['_align_'] = align
@@ -750,8 +912,14 @@ def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
 def mk_anonymous_cstruct(
     fields: list[tuple[str, CType] | tuple[str, CType, int, int]],
 ) -> type[CStruct]:
+    """
+    Factory function to generate an anonymous ``CStruct``.
+    """
     return type('', (CStruct,), {'_fields_': fields})
 
 
 def mk_anonymous_cunion(fields: list[tuple[str, CType]]) -> type[CUnion]:
+    """
+    Factory function to generate an anonymous ``CUnion``.
+    """
     return type('', (CUnion,), {'_fields_': fields})

--- a/pwnlib/libc/c_primitives.py
+++ b/pwnlib/libc/c_primitives.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from ctypes import (
+    c_char,
     c_char_p,
     c_long,
     c_size_t,
@@ -14,7 +15,7 @@ from io import StringIO, TextIOBase
 from typing import Any
 
 from pwnlib.context import context
-from pwnlib.util.packing import _need_bytes, unpack, pack
+from pwnlib.util.packing import _need_bytes, pack, unpack
 
 CTYPE_BASE = c_long.__base__
 VAR_TYPES = [c_void_p, c_char_p, c_wchar_p, c_size_t, c_ssize_t, c_ulong, c_long]
@@ -140,7 +141,32 @@ class PwnType:
     @staticmethod
     def print_to_stream(s: TextIOBase, v: bool, indent: int, o: PwnType) -> None:
         step = 2 if v else 0
-        if isinstance(o, CArray):
+        if isinstance(o, CCharArray):
+            s.write('<')
+            if not v:
+                s.write(bytes(o._view).hex(' '))
+            elif o._len > 16:
+                _verbose_separator(s, v)
+                indent += step
+                for i in range(0, o._int_count, 16):
+                    s.write(' ' * indent)
+                    b = bytes(o._view[i : i + 16])
+                    s.write(b.hex(' ').ljust(49))
+                    s.write('|')
+                    s.writelines(chr(e) if 0x20 <= e < 0x7F else '.' for e in b)
+                    s.write('|')
+                    _separator(s, v)
+                indent -= step
+                s.write(' ' * indent)
+            else:
+                b = bytes(o._view)
+                s.write(b.hex(' '))
+                s.write('  |')
+                s.writelines(chr(e) if 0x20 <= e < 0x7F else '.' for e in b)
+                s.write('|')
+            s.write('>,')
+            _separator(s, v)
+        elif isinstance(o, CArray):
             s.write('[')
             _verbose_separator(s, v)
             indent += step
@@ -162,7 +188,8 @@ class PwnType:
             s.write('],')
             _separator(s, v)
         elif isinstance(o, CStruct):
-            w = max(o._int_offsets.values()) + 1  # use max offset as width
+            # use max offset as width
+            w = max(len(hex(off)) for off in o._int_offsets.values()) + 1
             s.write('{')
             _verbose_separator(s, v)
             indent += step
@@ -300,7 +327,7 @@ class CArray(PwnType):
     _int_count: int
     _components: list[PwnType] | None
 
-    def __init__(self, view: memoryview | None) -> None:
+    def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_type_') or not hasattr(self, '_count_'):
             raise NotImplementedError
         super().__init__(view)
@@ -375,6 +402,10 @@ class CArray(PwnType):
             return
 
         raise ValueError(f"Can not access array with '{_type(subscript)}' subscript")
+
+
+class CCharArray(CArray):
+    _type_ = c_char
 
 
 class CStruct(PwnType):
@@ -468,7 +499,7 @@ class CUnion(PwnType):
     _fields_: list[tuple[str, type]]
     _components: OrderedDict[str, PwnType | int]
 
-    def __init__(self, view: memoryview | None) -> None:
+    def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
             raise NotImplementedError
         super().__init__(view)
@@ -535,7 +566,7 @@ class CEnum(PwnType):
     _size_type_: type
     _enum_: type[IntEnum]
 
-    def __init__(self, view: memoryview | None) -> None:
+    def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_enum_'):
             raise NotImplementedError
         super().__init__(view)
@@ -586,7 +617,7 @@ class CFlag(PwnType):
     _size_type_: type
     _flag_: type[IntFlag]
 
-    def __init__(self, view: memoryview | None) -> None:
+    def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_flag_'):
             raise NotImplementedError
         super().__init__(view)
@@ -631,9 +662,16 @@ class CFlag(PwnType):
 
 def mk_anonymous_carray(elem_type: type, count: int, align: int = 0) -> type[CArray]:
     fields = {'_type_': elem_type, '_count_': count}
-    if align is not None:
+    if align:
         fields['_align_'] = align
     return type('', (CArray,), fields)
+
+
+def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
+    fields = {'_type_': c_char, '_count_': count}
+    if align:
+        fields['_align_'] = align
+    return type('', (CCharArray,), fields)
 
 
 def mk_anonymous_cstruct(

--- a/pwnlib/libc/c_primitives.py
+++ b/pwnlib/libc/c_primitives.py
@@ -111,7 +111,7 @@ class PwnType:
                 field_t = field[1]
                 if len(field) == 4:
                     offset = field[2] if is64b else field[3]
-                else: # offset need to be calculated
+                else:  # offset need to be calculated
                     maybe_packed = False
                     f_align = PwnType.calc_align(field_t)
                     # align up struct_len
@@ -162,20 +162,21 @@ class PwnType:
             s.write('],')
             _separator(s, v)
         elif isinstance(o, CStruct):
-            w = len(hex(o._len)) + 1
+            w = max(o._int_offsets.values()) + 1  # use max offset as width
             s.write('{')
             _verbose_separator(s, v)
             indent += step
             for field, value in o._components.items():
+                off = o._int_offsets[field]
                 s.write(' ' * indent)
                 if v:
-                    s.write(f'{value[1]:<+#{w}x} {field} = ')
-                if isinstance(value[0], PwnType):
-                    PwnType.print_to_stream(s, v, indent, value[0])
+                    s.write(f'{off:<+#{w}x} {field} = ')
+                if isinstance(value, PwnType):
+                    PwnType.print_to_stream(s, v, indent, value)
                 else:  # isinstance(value[0], int)
                     unpacked = unpack(
-                        bytes(o._view[value[1] : value[1] + value[0]]),
-                        value[0] * 8,
+                        bytes(o._view[off : off + value]),
+                        value * 8,
                     )
                     s.write(f'{unpacked:#x},')
                     _separator(s, v)
@@ -227,6 +228,11 @@ class PwnType:
 
     def __bytes__(self) -> bytes:
         return bytes(self._view)
+
+    def __eq__(self, value: object, /) -> bool:
+        if type(self) is not type(value):
+            return False
+        return self._view == value._view
 
     def __getitem__(self, subscript: Any) -> None | bytes:
         if isinstance(subscript, slice):
@@ -373,50 +379,49 @@ class CArray(PwnType):
 
 class CStruct(PwnType):
     _fields_: list[tuple[str, type, int, int] | tuple[str, type]]
-    _components: OrderedDict[str, tuple[int | PwnType, int]]
+    _components: OrderedDict[str, int | PwnType]
     _len: int
     _offsets32_: dict[str, int]
     _offsets64_: dict[str, int]
+    _int_offsets: dict[str, int]
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
             raise NotImplementedError
         super().__init__(view)
 
-        offsets = getattr(self, f'_offsets{context.bits}_')
+        self._int_offsets = getattr(self, f'_offsets{context.bits}_')
         self._components = OrderedDict()
         for field in self._fields_:
             field_t = field[1]
-            off = offsets[field[0]]
+            off = self._int_offsets[field[0]]
             if issubclass(field_t, CTYPE_BASE):
-                self._components[field[0]] = (PwnType.calc_size(field[1]), off)
+                self._components[field[0]] = PwnType.calc_size(field[1])
             else:
                 size = PwnType.calc_size(field_t)
                 if issubclass(field_t, CArray) and size == 0:
-                    self._components[field[0]] = (field_t(self._view[off:]), off)
+                    self._components[field[0]] = field_t(self._view[off:])
                 else:
-                    self._components[field[0]] = (
-                        field_t(self._view[off : off + size]),
-                        off,
-                    )
+                    self._components[field[0]] = field_t(self._view[off : off + size])
 
     def __setattr__(self, name: str, value: Any, /) -> None:
         if '_components' not in self.__dict__ or name not in self._components:
             object.__setattr__(self, name, value)
             return
         rhs = self._components[name]
-        if isinstance(rhs[0], int):
+        if isinstance(rhs, int):
+            off = self._int_offsets[name]
             if isinstance(value, int):
-                self._view[rhs[1] : rhs[1] + rhs[0]] = pack(value, rhs[0] * 8)
+                self._view[off : off + rhs] = pack(value, rhs * 8)
             elif isinstance(value, (str, bytes, bytearray)):
                 b = _need_bytes(value)
-                if len(b) > rhs[0]:
+                if len(b) > rhs:
                     raise ValueError(f'Setting bytes larger than {_type(self)}.{name}')
-                self._view[rhs[1] : rhs[1] + rhs[0]] = b.ljust(rhs[0], b'\x00')
+                self._view[off : off + rhs] = b.ljust(rhs, b'\x00')
             else:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
-        else:  # isinstance(rhs[0], PwnType)
-            typ = rhs[0].copy_from(value)
+        else:  # isinstance(rhs, PwnType)
+            typ = rhs.copy_from(value)
             if typ is not None:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
 
@@ -424,9 +429,10 @@ class CStruct(PwnType):
         if '_components' not in self.__dict__ or name not in self._components:
             raise AttributeError(f"'{_type(self)}' object has no attribute '{name}'")
         rhs = self._components[name]
-        if isinstance(rhs[0], int):
-            return unpack(bytes(self._view[rhs[1] : rhs[1] + rhs[0]]), rhs[0] * 8)
-        return self._components[name][0]  # PwnType
+        off = self._int_offsets[name]
+        if isinstance(rhs, int):
+            return unpack(bytes(self._view[off : off + rhs]), rhs * 8)
+        return self._components[name]  # PwnType
 
     def __getitem__(self, subscript: str | slice) -> Any:
         b = super().__getitem__(subscript)
@@ -446,6 +452,16 @@ class CStruct(PwnType):
             return
 
         raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+
+    def offsetof(self, field_name: str) -> int:
+        if field_name not in self._components:
+            raise ValueError(f"'{field_name}' is not exist in '{_type(self)}'")
+        return self._int_offsets[field_name]
+
+    def struntil(self, field_name: str) -> bytes:
+        if field_name not in self._components:
+            raise ValueError(f"'{field_name}' is not exist in '{_type(self)}'")
+        return bytes(self._view[: self._int_offsets[field_name]])
 
 
 class CUnion(PwnType):
@@ -548,6 +564,11 @@ class CEnum(PwnType):
     def __int__(self) -> int:
         return unpack(bytes(self._view), self._len * 8)
 
+    def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, int):
+            return int(self) == value
+        return super().__eq__(value)
+
     def __str__(self) -> str:
         val = int(self)
         if val in self._enum_:
@@ -594,6 +615,11 @@ class CFlag(PwnType):
     def __int__(self) -> int:
         return unpack(bytes(self._view), self._len * 8)
 
+    def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, int):
+            return int(self) == value
+        return super().__eq__(value)
+
     def __str__(self) -> str:
         val = int(self)
         return f'{val:#x} <{self._flag_(val)!s}>'
@@ -601,3 +627,20 @@ class CFlag(PwnType):
     def __repr__(self) -> str:
         val = int(self)
         return f'{val:#x} {self._flag_(val)!r}'
+
+
+def mk_anonymous_carray(elem_type: type, count: int, align: int = 0) -> type[CArray]:
+    fields = {'_type_': elem_type, '_count_': count}
+    if align is not None:
+        fields['_align_'] = align
+    return type('', (CArray,), fields)
+
+
+def mk_anonymous_cstruct(
+    fields: list[tuple[str, type] | tuple[str, type, int, int]],
+) -> type[CStruct]:
+    return ('', (CStruct,), {'_fields_': fields})
+
+
+def mk_anonymous_cunion(fields: list[tuple[str, type]]) -> type[CUnion]:
+    return ('', (CUnion,), {'_fields_': fields})

--- a/pwnlib/libc/c_primitives.py
+++ b/pwnlib/libc/c_primitives.py
@@ -72,6 +72,27 @@ class PwnType:
         return None
 
     @staticmethod
+    def calc_align(typ: type) -> int:
+        if issubclass(typ, CTYPE_BASE):
+            return PwnType.calc_size(typ)
+        align_attr = f'_{context.bits}_align_cache_'
+        if hasattr(typ, align_attr):
+            return getattr(typ, align_attr)
+        if issubclass(typ, (CStruct, CUnion)):
+            align = max(PwnType.calc_align(f[1]) for f in typ._fields_)
+        elif issubclass(typ, CArray):
+            if hasattr(typ, '_align_'):  # here _align_ is type-range
+                align = typ._align_
+            else:
+                align = PwnType.calc_align(typ._type_)
+        elif issubclass(typ, (CEnum, CFlag)):
+            align = PwnType.calc_align(typ._size_type_)
+        else:
+            raise NotImplementedError
+        setattr(typ, align_attr, align)
+        return align
+
+    @staticmethod
     def calc_size(typ: type | PwnType) -> int:
         if not isinstance(typ, type):
             typ = type(typ)
@@ -82,21 +103,31 @@ class PwnType:
             return getattr(typ, cache_attr)
         if issubclass(typ, CStruct):
             struct_len = 0
+            offset_table_attr = f'_offsets{context.bits}_'
+            offsets = {}
             is64b = context.bits == 64
+            maybe_packed = True
             for field in typ._fields_:
                 field_t = field[1]
-                offset = field[2] if is64b else field[3]
+                if len(field) == 4:
+                    offset = field[2] if is64b else field[3]
+                else: # offset need to be calculated
+                    maybe_packed = False
+                    f_align = PwnType.calc_align(field_t)
+                    # align up struct_len
+                    offset = ((struct_len + f_align - 1) // f_align) * f_align
+                offsets[field[0]] = offset
                 field_len = PwnType.calc_size(field_t)
                 struct_len = max(struct_len, offset + field_len)
+            setattr(typ, offset_table_attr, offsets)
+            if not maybe_packed:
+                align = PwnType.calc_align(typ)
+                struct_len = ((struct_len + align - 1) // align) * align
             size_cache = struct_len
         elif issubclass(typ, CArray):
             if typ._count_ == 0:
                 return 0
-            if hasattr(typ, '_align_'):  # here _align_ is type-range
-                field_len = typ._align_
-            else:
-                field_len = PwnType.calc_size(typ._type_)
-            size_cache = field_len * typ._count_
+            size_cache = PwnType.calc_align(typ) * typ._count_
         elif issubclass(typ, CUnion):
             size_cache = max(PwnType.calc_size(field[1]) for field in typ._fields_)
         elif issubclass(typ, (CEnum, CFlag)):
@@ -341,19 +372,22 @@ class CArray(PwnType):
 
 
 class CStruct(PwnType):
-    _fields_: list[tuple[str, type, int, int]]
+    _fields_: list[tuple[str, type, int, int] | tuple[str, type]]
     _components: OrderedDict[str, tuple[int | PwnType, int]]
     _len: int
+    _offsets32_: dict[str, int]
+    _offsets64_: dict[str, int]
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
             raise NotImplementedError
         super().__init__(view)
 
+        offsets = getattr(self, f'_offsets{context.bits}_')
         self._components = OrderedDict()
         for field in self._fields_:
             field_t = field[1]
-            off = field[2] if context.bits == 64 else field[3]
+            off = offsets[field[0]]
             if issubclass(field_t, CTYPE_BASE):
                 self._components[field[0]] = (PwnType.calc_size(field[1]), off)
             else:
@@ -415,7 +449,7 @@ class CStruct(PwnType):
 
 
 class CUnion(PwnType):
-    _fields_: list[str, type]
+    _fields_: list[tuple[str, type]]
     _components: OrderedDict[str, PwnType | int]
 
     def __init__(self, view: memoryview | None) -> None:

--- a/pwnlib/libc/c_primitives.py
+++ b/pwnlib/libc/c_primitives.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 from ctypes import (
     c_char,
@@ -9,16 +11,32 @@ from ctypes import (
     c_void_p,
     c_wchar_p,
     sizeof,
+    _SimpleCData,
 )
 from enum import Enum, Flag, IntEnum, IntFlag
 from io import StringIO, TextIOBase
-from typing import Any
+from typing import Any, Generic, TypeAlias, TypeVar, cast, overload
 
 from pwnlib.context import context
 from pwnlib.util.packing import _need_bytes, pack, unpack
 
-CTYPE_BASE = c_long.__base__
-VAR_TYPES = [c_void_p, c_char_p, c_wchar_p, c_size_t, c_ssize_t, c_ulong, c_long]
+BaseCType: TypeAlias = type[_SimpleCData]
+CompCType: TypeAlias = type['PwnType']
+CType: TypeAlias = BaseCType | CompCType
+CompCValue: TypeAlias = 'int | PwnType'
+BytesLike: TypeAlias = str | bytes | bytearray
+ArrayItemT = TypeVar('ArrayItemT', bound='CompCValue')
+
+CTYPE_BASE = cast(BaseCType, c_long.__base__)
+VAR_TYPES: list[BaseCType] = [
+    c_void_p,
+    c_char_p,
+    c_wchar_p,
+    c_size_t,
+    c_ssize_t,
+    c_ulong,
+    c_long,
+]
 
 
 def _type(o: Any) -> str:
@@ -47,6 +65,8 @@ def _remove_non_verbose_tail(s: TextIOBase, v: bool) -> None:
 class PwnType:
     _32_size_cache_: int
     _64_size_cache_: int
+    _32_align_cache_: int
+    _64_align_cache_: int
     _buf: bytearray | None
     _view: memoryview
     _len: int
@@ -60,7 +80,7 @@ class PwnType:
             self._buf = None
             self._view = view
 
-    def copy_from(self, value: Any) -> None | type:
+    def copy_from(self, value: Any) -> type[Any] | None:
         if isinstance(value, (str, bytes, bytearray)):
             b = _need_bytes(value)
             if len(b) > self._len:
@@ -73,7 +93,7 @@ class PwnType:
         return None
 
     @staticmethod
-    def calc_align(typ: type) -> int:
+    def calc_align(typ: CType) -> int:
         if issubclass(typ, CTYPE_BASE):
             return PwnType.calc_size(typ)
         align_attr = f'_{context.bits}_align_cache_'
@@ -94,7 +114,7 @@ class PwnType:
         return align
 
     @staticmethod
-    def calc_size(typ: type | PwnType) -> int:
+    def calc_size(typ: CType | PwnType) -> int:
         if not isinstance(typ, type):
             typ = type(typ)
         if issubclass(typ, CTYPE_BASE):
@@ -105,7 +125,7 @@ class PwnType:
         if issubclass(typ, CStruct):
             struct_len = 0
             offset_table_attr = f'_offsets{context.bits}_'
-            offsets = {}
+            offsets: dict[str, int] = {}
             is64b = context.bits == 64
             maybe_packed = True
             for field in typ._fields_:
@@ -257,11 +277,11 @@ class PwnType:
         return bytes(self._view)
 
     def __eq__(self, value: object, /) -> bool:
-        if type(self) is not type(value):
+        if not isinstance(value, PwnType) or type(self) is not type(value):
             return False
         return self._view == value._view
 
-    def __getitem__(self, subscript: Any) -> None | bytes:
+    def _get_slice(self, subscript: Any) -> bytes | None:
         if isinstance(subscript, slice):
             if subscript.step is not None:
                 raise ValueError(f'Slice step is not supported')
@@ -286,7 +306,7 @@ class PwnType:
             return bytes(self._view[start:stop])
         return None
 
-    def __setitem__(self, subscript: Any, value: Any) -> bool:
+    def _set_slice(self, subscript: Any, value: Any) -> bool:
         if isinstance(subscript, slice):
             if subscript.step is not None:
                 raise ValueError(f'Slice step is not supported')
@@ -318,9 +338,15 @@ class PwnType:
             return True
         return False
 
+    def __getitem__(self, key: Any) -> bytes | CompCValue | None:
+        return self._get_slice(key)
 
-class CArray(PwnType):
-    _type_: type
+    def __setitem__(self, key: Any, value: Any) -> None:
+        self._set_slice(key, value)
+
+
+class CArray(PwnType, Generic[ArrayItemT]):
+    _type_: CType
     _count_: int
     _align_: int
     _int_size: int
@@ -350,17 +376,24 @@ class CArray(PwnType):
             self._components = None
         else:
             step = self._align_
+            assert issubclass(self._type_, PwnType)
             self._components = [
                 self._type_(self._view[i * step : i * step + self._int_size])
                 for i in range(self._int_count)
             ]
 
-    def __getitem__(self, subscript: int | slice) -> Any:
-        b = super().__getitem__(subscript)
+    @overload
+    def __getitem__(self, key: slice) -> bytes: ...
+
+    @overload
+    def __getitem__(self, key: int) -> ArrayItemT: ...
+
+    def __getitem__(self, key: Any) -> bytes | CompCValue:
+        b = self._get_slice(key)
         if b is not None:
             return b
-        if isinstance(subscript, int):
-            idx = subscript
+        if isinstance(key, int):
+            idx = key
             if idx < 0:
                 idx += self._int_count
             if idx >= self._int_count or idx < 0:
@@ -374,14 +407,20 @@ class CArray(PwnType):
                 )
             # isinstance(self._components, list)
             return self._components[idx]
-        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+        raise ValueError(f"Can not access struct with '{_type(key)}' subscript")
 
-    def __setitem__(self, subscript: int | slice, value: Any) -> None:
-        if super().__setitem__(subscript, value):
+    @overload
+    def __setitem__(self, key: slice, value: BytesLike) -> None: ...
+
+    @overload
+    def __setitem__(self, key: int, value: BytesLike | CompCValue) -> None: ...
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        if self._set_slice(key, value):
             return
 
-        if isinstance(subscript, int):
-            idx = subscript
+        if isinstance(key, int):
+            idx = key
             if idx < 0:
                 idx += self._int_count
             if idx >= self._int_count or idx < 0:
@@ -401,16 +440,16 @@ class CArray(PwnType):
                     raise ValueError(f"Can't set {_type(expected)} with {_type(typ)}")
             return
 
-        raise ValueError(f"Can not access array with '{_type(subscript)}' subscript")
+        raise ValueError(f"Can not access array with '{_type(key)}' subscript")
 
 
-class CCharArray(CArray):
+class CCharArray(CArray[int]):
     _type_ = c_char
 
 
 class CStruct(PwnType):
-    _fields_: list[tuple[str, type, int, int] | tuple[str, type]]
-    _components: OrderedDict[str, int | PwnType]
+    _fields_: list[tuple[str, CType] | tuple[str, CType, int, int]]
+    _components: OrderedDict[str, CompCValue]
     _len: int
     _offsets32_: dict[str, int]
     _offsets64_: dict[str, int]
@@ -430,6 +469,7 @@ class CStruct(PwnType):
                 self._components[field[0]] = PwnType.calc_size(field[1])
             else:
                 size = PwnType.calc_size(field_t)
+                assert issubclass(field_t, PwnType)
                 if issubclass(field_t, CArray) and size == 0:
                     self._components[field[0]] = field_t(self._view[off:])
                 else:
@@ -456,7 +496,7 @@ class CStruct(PwnType):
             if typ is not None:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
 
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> CompCValue:
         if '_components' not in self.__dict__ or name not in self._components:
             raise AttributeError(f"'{_type(self)}' object has no attribute '{name}'")
         rhs = self._components[name]
@@ -465,24 +505,36 @@ class CStruct(PwnType):
             return unpack(bytes(self._view[off : off + rhs]), rhs * 8)
         return self._components[name]  # PwnType
 
-    def __getitem__(self, subscript: str | slice) -> Any:
-        b = super().__getitem__(subscript)
-        if b:
+    @overload
+    def __getitem__(self, key: slice) -> bytes: ...
+
+    @overload
+    def __getitem__(self, key: str) -> CompCValue: ...
+
+    def __getitem__(self, key: Any) -> bytes | CompCValue:
+        b = self._get_slice(key)
+        if b is not None:
             return b
-        if isinstance(subscript, str):
-            return getattr(self, subscript)
+        if isinstance(key, str):
+            return getattr(self, key)
 
-        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+        raise ValueError(f"Can not access struct with '{_type(key)}' subscript")
 
-    def __setitem__(self, subscript: str | slice, value: Any) -> None:
-        if super().__setitem__(subscript, value):
+    @overload
+    def __setitem__(self, key: slice, value: BytesLike) -> None: ...
+
+    @overload
+    def __setitem__(self, key: str, value: BytesLike | CompCValue) -> None: ...
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        if self._set_slice(key, value):
             return
 
-        if isinstance(subscript, str):
-            setattr(self, subscript, value)
+        if isinstance(key, str):
+            setattr(self, key, value)
             return
 
-        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+        raise ValueError(f"Can not access struct with '{_type(key)}' subscript")
 
     def offsetof(self, field_name: str) -> int:
         if field_name not in self._components:
@@ -496,8 +548,8 @@ class CStruct(PwnType):
 
 
 class CUnion(PwnType):
-    _fields_: list[tuple[str, type]]
-    _components: OrderedDict[str, PwnType | int]
+    _fields_: list[tuple[str, CType]]
+    _components: OrderedDict[str, CompCValue]
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
@@ -511,9 +563,10 @@ class CUnion(PwnType):
                 self._components[field[0]] = PwnType.calc_size(field_t)
             else:
                 size = PwnType.calc_size(field_t)
+                assert issubclass(field_t, PwnType)
                 self._components[field[0]] = field_t(self._view[:size])
 
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> CompCValue:
         if '_components' not in self.__dict__ or name not in self._components:
             raise AttributeError(f"'{_type(self)}' object has no attribute '{name}'")
         rhs = self._components[name]
@@ -531,59 +584,71 @@ class CUnion(PwnType):
                 self._view[:rhs] = pack(value, rhs * 8)
             elif isinstance(value, (str, bytes, bytearray)):
                 b = _need_bytes(value)
-                if len(b) > rhs[0]:
+                if len(b) > rhs:
                     raise ValueError(f'Setting bytes larger than {_type(self)}.{name}')
                 self._view[:rhs] = b.ljust(rhs, b'\x00')
             else:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
-        else:  # isinstance(rhs[0], PwnType)
+        else:  # isinstance(rhs, PwnType)
             typ = rhs.copy_from(value)
             if typ is not None:
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
 
-    def __getitem__(self, subscript: Any) -> Any:
-        b = super().__getitem__(subscript)
+    @overload
+    def __getitem__(self, key: slice) -> bytes: ...
+
+    @overload
+    def __getitem__(self, key: str) -> CompCValue: ...
+
+    def __getitem__(self, key: Any) -> bytes | CompCValue:
+        b = self._get_slice(key)
         if b is not None:
             return b
 
-        if isinstance(subscript, str):
-            return getattr(self, subscript)
+        if isinstance(key, str):
+            return getattr(self, key)
 
-        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+        raise ValueError(f"Can not access struct with '{_type(key)}' subscript")
 
-    def __setitem__(self, subscript: Any, value: Any) -> None:
-        if super().__setitem__(subscript, value):
+    @overload
+    def __setitem__(self, key: slice, value: BytesLike) -> None: ...
+
+    @overload
+    def __setitem__(self, key: str, value: BytesLike | CompCValue) -> None: ...
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        if self._set_slice(key, value):
             return
 
-        if isinstance(subscript, str):
-            setattr(self, subscript, value)
+        if isinstance(key, str):
+            setattr(self, key, value)
             return
 
-        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+        raise ValueError(f"Can not access struct with '{_type(key)}' subscript")
 
 
 class CEnum(PwnType):
-    _size_type_: type
+    _size_type_: CType
     _enum_: type[IntEnum]
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_enum_'):
             raise NotImplementedError
         super().__init__(view)
-        self._enum_.__str__ = Enum.__str__
+        self._enum_.__str__ = Enum.__str__  # type: ignore[method-assign]
 
-    def __getitem__(self, subs: Any) -> None | bytes:
-        b = super().__getitem__(subs)
+    def __getitem__(self, key: slice) -> bytes:
+        b = self._get_slice(key)
         if b is not None:
             return b
-        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+        raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
-    def __setitem__(self, subs: Any, value: Any) -> None:
-        if super().__setitem__(subs, value):
+    def __setitem__(self, key: slice, value: BytesLike) -> None:
+        if self._set_slice(key, value):
             return
-        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+        raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
-    def copy_from(self, value: Any) -> None | type:
+    def copy_from(self, value: Any) -> type[Any] | None:
         typ = super().copy_from(value)
         if typ is None:
             return typ
@@ -602,39 +667,43 @@ class CEnum(PwnType):
 
     def __str__(self) -> str:
         val = int(self)
-        if val in self._enum_:
-            return f'{val:#x} <{self._enum_(val)!s}>'
-        return hex(val)
+        try:
+            member = self._enum_(val)
+        except ValueError:
+            return hex(val)
+        return f'{val:#x} <{member!s}>'
 
     def __repr__(self) -> str:
         val = int(self)
-        if val in self._enum_:
-            return f'{val:#x} {self._enum_(val)!r}'
-        return hex(val)
+        try:
+            member = self._enum_(val)
+        except ValueError:
+            return hex(val)
+        return f'{val:#x} {member!r}'
 
 
 class CFlag(PwnType):
-    _size_type_: type
+    _size_type_: CType
     _flag_: type[IntFlag]
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_flag_'):
             raise NotImplementedError
         super().__init__(view)
-        self._flag_.__str__ = Flag.__str__
+        self._flag_.__str__ = Flag.__str__  # type: ignore[method-assign]
 
-    def __getitem__(self, subs: Any) -> None | bytes:
-        b = super().__getitem__(subs)
+    def __getitem__(self, key: slice) -> bytes:
+        b = self._get_slice(key)
         if b is not None:
             return b
-        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+        raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
-    def __setitem__(self, subs: Any, value: Any) -> None:
-        if super().__setitem__(subs, value):
+    def __setitem__(self, key: slice, value: BytesLike) -> None:
+        if self._set_slice(key, value):
             return
-        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+        raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
-    def copy_from(self, value: Any) -> None | type:
+    def copy_from(self, value: Any) -> type[Any] | None:
         typ = super().copy_from(value)
         if typ is None:
             return typ
@@ -660,25 +729,29 @@ class CFlag(PwnType):
         return f'{val:#x} {self._flag_(val)!r}'
 
 
-def mk_anonymous_carray(elem_type: type, count: int, align: int = 0) -> type[CArray]:
-    fields = {'_type_': elem_type, '_count_': count}
+def mk_anonymous_carray(
+    elem_type: CType,
+    count: int,
+    align: int = 0,
+) -> type[CArray[CompCValue]]:
+    fields: dict[str, Any] = {'_type_': elem_type, '_count_': count}
     if align:
         fields['_align_'] = align
     return type('', (CArray,), fields)
 
 
 def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
-    fields = {'_type_': c_char, '_count_': count}
+    fields: dict[str, Any] = {'_type_': c_char, '_count_': count}
     if align:
         fields['_align_'] = align
     return type('', (CCharArray,), fields)
 
 
 def mk_anonymous_cstruct(
-    fields: list[tuple[str, type] | tuple[str, type, int, int]],
+    fields: list[tuple[str, CType] | tuple[str, CType, int, int]],
 ) -> type[CStruct]:
-    return ('', (CStruct,), {'_fields_': fields})
+    return type('', (CStruct,), {'_fields_': fields})
 
 
-def mk_anonymous_cunion(fields: list[tuple[str, type]]) -> type[CUnion]:
-    return ('', (CUnion,), {'_fields_': fields})
+def mk_anonymous_cunion(fields: list[tuple[str, CType]]) -> type[CUnion]:
+    return type('', (CUnion,), {'_fields_': fields})

--- a/pwnlib/libc/c_primitives.py
+++ b/pwnlib/libc/c_primitives.py
@@ -1,0 +1,569 @@
+from collections import OrderedDict
+from ctypes import (
+    c_char_p,
+    c_long,
+    c_size_t,
+    c_ssize_t,
+    c_ulong,
+    c_void_p,
+    c_wchar_p,
+    sizeof,
+)
+from enum import Enum, Flag, IntEnum, IntFlag
+from io import StringIO, TextIOBase
+from typing import Any
+
+from pwnlib.context import context
+from pwnlib.util.packing import _need_bytes, unpack, pack
+
+CTYPE_BASE = c_long.__base__
+VAR_TYPES = [c_void_p, c_char_p, c_wchar_p, c_size_t, c_ssize_t, c_ulong, c_long]
+
+
+def _type(o: Any) -> str:
+    if isinstance(o, type):
+        return o.__name__
+    return type(o).__name__
+
+
+def _separator(s: TextIOBase, v: bool) -> None:
+    if v:
+        s.write('\n')
+    else:
+        s.write(' ')
+
+
+def _verbose_separator(s: TextIOBase, v: bool) -> None:
+    if v:
+        s.write('\n')
+
+
+def _remove_non_verbose_tail(s: TextIOBase, v: bool) -> None:
+    if not v:
+        s.truncate(s.tell() - 2)
+
+
+class PwnType:
+    _32_size_cache_: int
+    _64_size_cache_: int
+    _buf: bytearray | None
+    _view: memoryview
+    _len: int
+
+    def __init__(self, view: memoryview | None) -> None:
+        self._len = PwnType.calc_size(self)
+        if view is None:
+            self._buf = bytearray(self._len)
+            self._view = memoryview(self._buf)
+        else:
+            self._buf = None
+            self._view = view
+
+    def copy_from(self, value: Any) -> None | type:
+        if isinstance(value, (str, bytes, bytearray)):
+            b = _need_bytes(value)
+            if len(b) > self._len:
+                raise ValueError(f'Setting bytes larger than {_type(self)}')
+            self._view[:] = b.ljust(self._len, b'\x00')
+        elif type(self) is type(value):
+            self._view[:] = value._view[:]
+        else:
+            return type(value)
+        return None
+
+    @staticmethod
+    def calc_size(typ: type | PwnType) -> int:
+        if not isinstance(typ, type):
+            typ = type(typ)
+        if issubclass(typ, CTYPE_BASE):
+            return context.bytes if typ in VAR_TYPES else sizeof(typ)
+        cache_attr = f'_{context.bits}_size_cache_'
+        if hasattr(typ, cache_attr):
+            return getattr(typ, cache_attr)
+        if issubclass(typ, CStruct):
+            struct_len = 0
+            is64b = context.bits == 64
+            for field in typ._fields_:
+                field_t = field[1]
+                offset = field[2] if is64b else field[3]
+                field_len = PwnType.calc_size(field_t)
+                struct_len = max(struct_len, offset + field_len)
+            size_cache = struct_len
+        elif issubclass(typ, CArray):
+            if typ._count_ == 0:
+                return 0
+            if hasattr(typ, '_align_'):  # here _align_ is type-range
+                field_len = typ._align_
+            else:
+                field_len = PwnType.calc_size(typ._type_)
+            size_cache = field_len * typ._count_
+        elif issubclass(typ, CUnion):
+            size_cache = max(PwnType.calc_size(field[1]) for field in typ._fields_)
+        elif issubclass(typ, (CEnum, CFlag)):
+            size_cache = PwnType.calc_size(typ._size_type_)
+        else:
+            raise NotImplementedError
+        setattr(typ, cache_attr, size_cache)
+        return size_cache
+
+    @staticmethod
+    def print_to_stream(s: TextIOBase, v: bool, indent: int, o: PwnType) -> None:
+        step = 2 if v else 0
+        if isinstance(o, CArray):
+            s.write('[')
+            _verbose_separator(s, v)
+            indent += step
+            for i in range(o._int_count):
+                s.write(' ' * indent)
+                if o._components:
+                    PwnType.print_to_stream(s, v, indent, o._components[i])
+                else:
+                    off = i * o._align_
+                    unpacked = unpack(
+                        bytes(o._view[off : off + o._int_size]),
+                        o._int_size * 8,
+                    )
+                    s.write(f'{unpacked:#x},')
+                    _separator(s, v)
+            _remove_non_verbose_tail(s, v)
+            indent -= step
+            s.write(' ' * indent)
+            s.write('],')
+            _separator(s, v)
+        elif isinstance(o, CStruct):
+            w = len(hex(o._len)) + 1
+            s.write('{')
+            _verbose_separator(s, v)
+            indent += step
+            for field, value in o._components.items():
+                s.write(' ' * indent)
+                if v:
+                    s.write(f'{value[1]:<+#{w}x} {field} = ')
+                if isinstance(value[0], PwnType):
+                    PwnType.print_to_stream(s, v, indent, value[0])
+                else:  # isinstance(value[0], int)
+                    unpacked = unpack(
+                        bytes(o._view[value[1] : value[1] + value[0]]),
+                        value[0] * 8,
+                    )
+                    s.write(f'{unpacked:#x},')
+                    _separator(s, v)
+            _remove_non_verbose_tail(s, v)
+            indent -= step
+            s.write(' ' * indent)
+            s.write('},')
+            _separator(s, v)
+        elif isinstance(o, CUnion):
+            s.write('{')
+            _verbose_separator(s, v)
+            indent += step
+            for field, value in o._components.items():
+                s.write(' ' * indent)
+                if v:
+                    s.write(f'{field} = ')
+                if isinstance(value, PwnType):
+                    PwnType.print_to_stream(s, v, indent, value)
+                else:  # isinstance(value, int)
+                    unpacked = unpack(bytes(o._view[:value]), value * 8)
+                    s.write(f'{unpacked:#x},')
+                    _separator(s, v)
+            _remove_non_verbose_tail(s, v)
+            indent -= step
+            s.write(' ' * indent)
+            s.write('},')
+            _separator(s, v)
+        elif isinstance(o, (CFlag, CEnum)):
+            s.write(repr(o) if v else str(o))
+            s.write(',')
+            _separator(s, v)
+        else:
+            raise NotImplementedError
+
+    def __str__(self) -> str:
+        with StringIO() as s:
+            PwnType.print_to_stream(s, False, 0, self)
+            s.truncate(s.tell() - 2)  # strip comma and separator
+            return s.getvalue()
+
+    def __repr__(self) -> str:
+        with StringIO() as s:
+            PwnType.print_to_stream(s, True, 0, self)
+            s.truncate(s.tell() - 2)  # strip comma and separator
+            return s.getvalue()
+
+    def __len__(self) -> int:
+        return self._len
+
+    def __bytes__(self) -> bytes:
+        return bytes(self._view)
+
+    def __getitem__(self, subscript: Any) -> None | bytes:
+        if isinstance(subscript, slice):
+            if subscript.step is not None:
+                raise ValueError(f'Slice step is not supported')
+            start = subscript.start
+            stop = subscript.stop
+            if start is None:
+                start = 0
+            elif start < 0:
+                start += self._len
+            elif start > self._len:
+                start = self._len
+            if stop is None:
+                stop = self._len
+            elif stop < 0:
+                stop += self._len
+            elif stop > self._len:
+                stop = self._len
+            if start < 0 or stop < 0:
+                raise ValueError(f'Illegal index on memoryview')
+            if start >= stop:
+                raise ValueError(f'Illegal access range on memoryview')
+            return bytes(self._view[start:stop])
+        return None
+
+    def __setitem__(self, subscript: Any, value: Any) -> bool:
+        if isinstance(subscript, slice):
+            if subscript.step is not None:
+                raise ValueError(f'Slice step is not supported')
+            start = subscript.start
+            stop = subscript.stop
+            if start is None:
+                start = 0
+            elif start < 0:
+                start += self._len
+            elif start > self._len:
+                start = self._len
+            if stop is None:
+                stop = self._len
+            elif stop < 0:
+                stop += self._len
+            elif stop > self._len:
+                stop = self._len
+            if start < 0 or stop < 0:
+                raise ValueError(f'Illegal index on memoryview')
+            if start >= stop:
+                raise ValueError(f'Illegal access range on memoryview')
+
+            if not isinstance(value, (bytes, bytearray, str)):
+                raise ValueError(f"Can't fill memory with {_type(value)}")
+            data = _need_bytes(value)
+            if len(data) > stop - start:
+                raise ValueError(f'Filling bytes larger than sliced memory')
+            self._view[start:stop] = data.ljust(stop - start, b'\x00')
+            return True
+        return False
+
+
+class CArray(PwnType):
+    _type_: type
+    _count_: int
+    _align_: int
+    _int_size: int
+    _int_count: int
+    _components: list[PwnType] | None
+
+    def __init__(self, view: memoryview | None) -> None:
+        if not hasattr(self, '_type_') or not hasattr(self, '_count_'):
+            raise NotImplementedError
+        super().__init__(view)
+        if self._len == 0:
+            if self._buf is not None:
+                raise BufferError('Allocating zero-length array')
+            if len(self._view) == 0:
+                raise BufferError('Zero-length array has no writable memory')
+
+        self._int_size = PwnType.calc_size(self._type_)
+        if not hasattr(self, '_align_'):
+            self._align_ = self._int_size
+        if self._len:
+            self._int_count = self._count_
+        else:
+            self._len = len(self._view)
+            self._int_count = self._len // self._align_
+
+        if issubclass(self._type_, CTYPE_BASE):
+            self._components = None
+        else:
+            step = self._align_
+            self._components = [
+                self._type_(self._view[i * step : i * step + self._int_size])
+                for i in range(self._int_count)
+            ]
+
+    def __getitem__(self, subscript: int | slice) -> Any:
+        b = super().__getitem__(subscript)
+        if b is not None:
+            return b
+        if isinstance(subscript, int):
+            idx = subscript
+            if idx < 0:
+                idx += self._int_count
+            if idx >= self._int_count or idx < 0:
+                raise IndexError(f'Illegal index on elements')
+            if self._components is None:
+                start = self._align_ * idx
+                end = start + self._int_size
+                return unpack(
+                    bytes(self._view[start:end]),
+                    self._int_size * 8,
+                )
+            # isinstance(self._components, list)
+            return self._components[idx]
+        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+
+    def __setitem__(self, subscript: int | slice, value: Any) -> None:
+        if super().__setitem__(subscript, value):
+            return
+
+        if isinstance(subscript, int):
+            idx = subscript
+            if idx < 0:
+                idx += self._int_count
+            if idx >= self._int_count or idx < 0:
+                raise IndexError(f'Illegal index on elements')
+            if self._components is None:
+                start = self._align_ * idx
+                end = start + self._int_size
+                if not isinstance(value, int):
+                    raise ValueError(f"Can't set int with {_type(value)}")
+                self._view[start:end] = pack(value, self._int_size * 8)
+            else:
+                # isinstance(self._components, list[PwnType])
+                # a.k.a. isinstance(self._type_, PwnType)
+                typ = self._components[idx].copy_from(value)
+                if typ is not None:
+                    expected = self._type_
+                    raise ValueError(f"Can't set {_type(expected)} with {_type(typ)}")
+            return
+
+        raise ValueError(f"Can not access array with '{_type(subscript)}' subscript")
+
+
+class CStruct(PwnType):
+    _fields_: list[tuple[str, type, int, int]]
+    _components: OrderedDict[str, tuple[int | PwnType, int]]
+    _len: int
+
+    def __init__(self, view: memoryview | None = None) -> None:
+        if not hasattr(self, '_fields_'):
+            raise NotImplementedError
+        super().__init__(view)
+
+        self._components = OrderedDict()
+        for field in self._fields_:
+            field_t = field[1]
+            off = field[2] if context.bits == 64 else field[3]
+            if issubclass(field_t, CTYPE_BASE):
+                self._components[field[0]] = (PwnType.calc_size(field[1]), off)
+            else:
+                size = PwnType.calc_size(field_t)
+                if issubclass(field_t, CArray) and size == 0:
+                    self._components[field[0]] = (field_t(self._view[off:]), off)
+                else:
+                    self._components[field[0]] = (
+                        field_t(self._view[off : off + size]),
+                        off,
+                    )
+
+    def __setattr__(self, name: str, value: Any, /) -> None:
+        if '_components' not in self.__dict__ or name not in self._components:
+            object.__setattr__(self, name, value)
+            return
+        rhs = self._components[name]
+        if isinstance(rhs[0], int):
+            if isinstance(value, int):
+                self._view[rhs[1] : rhs[1] + rhs[0]] = pack(value, rhs[0] * 8)
+            elif isinstance(value, (str, bytes, bytearray)):
+                b = _need_bytes(value)
+                if len(b) > rhs[0]:
+                    raise ValueError(f'Setting bytes larger than {_type(self)}.{name}')
+                self._view[rhs[1] : rhs[1] + rhs[0]] = b.ljust(rhs[0], b'\x00')
+            else:
+                raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
+        else:  # isinstance(rhs[0], PwnType)
+            typ = rhs[0].copy_from(value)
+            if typ is not None:
+                raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
+
+    def __getattr__(self, name: str) -> Any:
+        if '_components' not in self.__dict__ or name not in self._components:
+            raise AttributeError(f"'{_type(self)}' object has no attribute '{name}'")
+        rhs = self._components[name]
+        if isinstance(rhs[0], int):
+            return unpack(bytes(self._view[rhs[1] : rhs[1] + rhs[0]]), rhs[0] * 8)
+        return self._components[name][0]  # PwnType
+
+    def __getitem__(self, subscript: str | slice) -> Any:
+        b = super().__getitem__(subscript)
+        if b:
+            return b
+        if isinstance(subscript, str):
+            return getattr(self, subscript)
+
+        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+
+    def __setitem__(self, subscript: str | slice, value: Any) -> None:
+        if super().__setitem__(subscript, value):
+            return
+
+        if isinstance(subscript, str):
+            setattr(self, subscript, value)
+            return
+
+        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+
+
+class CUnion(PwnType):
+    _fields_: list[str, type]
+    _components: OrderedDict[str, PwnType | int]
+
+    def __init__(self, view: memoryview | None) -> None:
+        if not hasattr(self, '_fields_'):
+            raise NotImplementedError
+        super().__init__(view)
+
+        self._components = OrderedDict()
+        for field in self._fields_:
+            field_t = field[1]
+            if issubclass(field_t, CTYPE_BASE):
+                self._components[field[0]] = PwnType.calc_size(field_t)
+            else:
+                size = PwnType.calc_size(field_t)
+                self._components[field[0]] = field_t(self._view[:size])
+
+    def __getattr__(self, name: str) -> Any:
+        if '_components' not in self.__dict__ or name not in self._components:
+            raise AttributeError(f"'{_type(self)}' object has no attribute '{name}'")
+        rhs = self._components[name]
+        if isinstance(rhs, int):
+            return unpack(bytes(self._view[:rhs]), rhs * 8)
+        return self._components[name]  # PwnType
+
+    def __setattr__(self, name: str, value: Any, /) -> None:
+        if '_components' not in self.__dict__ or name not in self._components:
+            object.__setattr__(self, name, value)
+            return
+        rhs = self._components[name]
+        if isinstance(rhs, int):
+            if isinstance(value, int):
+                self._view[:rhs] = pack(value, rhs * 8)
+            elif isinstance(value, (str, bytes, bytearray)):
+                b = _need_bytes(value)
+                if len(b) > rhs[0]:
+                    raise ValueError(f'Setting bytes larger than {_type(self)}.{name}')
+                self._view[:rhs] = b.ljust(rhs, b'\x00')
+            else:
+                raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
+        else:  # isinstance(rhs[0], PwnType)
+            typ = rhs.copy_from(value)
+            if typ is not None:
+                raise ValueError(f"Can't set {_type(self)}.{name} with {_type(typ)}")
+
+    def __getitem__(self, subscript: Any) -> Any:
+        b = super().__getitem__(subscript)
+        if b is not None:
+            return b
+
+        if isinstance(subscript, str):
+            return getattr(self, subscript)
+
+        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+
+    def __setitem__(self, subscript: Any, value: Any) -> None:
+        if super().__setitem__(subscript, value):
+            return
+
+        if isinstance(subscript, str):
+            setattr(self, subscript, value)
+            return
+
+        raise ValueError(f"Can not access struct with '{_type(subscript)}' subscript")
+
+
+class CEnum(PwnType):
+    _size_type_: type
+    _enum_: type[IntEnum]
+
+    def __init__(self, view: memoryview | None) -> None:
+        if not hasattr(self, '_size_type_') or not hasattr(self, '_enum_'):
+            raise NotImplementedError
+        super().__init__(view)
+        self._enum_.__str__ = Enum.__str__
+
+    def __getitem__(self, subs: Any) -> None | bytes:
+        b = super().__getitem__(subs)
+        if b is not None:
+            return b
+        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+
+    def __setitem__(self, subs: Any, value: Any) -> None:
+        if super().__setitem__(subs, value):
+            return
+        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+
+    def copy_from(self, value: Any) -> None | type:
+        typ = super().copy_from(value)
+        if typ is None:
+            return typ
+        if isinstance(value, int):
+            self._view[:] = pack(value, self._len * 8)
+            return None
+        return typ
+
+    def __int__(self) -> int:
+        return unpack(bytes(self._view), self._len * 8)
+
+    def __str__(self) -> str:
+        val = int(self)
+        if val in self._enum_:
+            return f'{val:#x} <{self._enum_(val)!s}>'
+        return hex(val)
+
+    def __repr__(self) -> str:
+        val = int(self)
+        if val in self._enum_:
+            return f'{val:#x} {self._enum_(val)!r}'
+        return hex(val)
+
+
+class CFlag(PwnType):
+    _size_type_: type
+    _flag_: type[IntFlag]
+
+    def __init__(self, view: memoryview | None) -> None:
+        if not hasattr(self, '_size_type_') or not hasattr(self, '_flag_'):
+            raise NotImplementedError
+        super().__init__(view)
+        self._flag_.__str__ = Flag.__str__
+
+    def __getitem__(self, subs: Any) -> None | bytes:
+        b = super().__getitem__(subs)
+        if b is not None:
+            return b
+        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+
+    def __setitem__(self, subs: Any, value: Any) -> None:
+        if super().__setitem__(subs, value):
+            return
+        raise ValueError(f"'{_type(subs)}' is not supported to access '{_type(self)}'")
+
+    def copy_from(self, value: Any) -> None | type:
+        typ = super().copy_from(value)
+        if typ is None:
+            return typ
+        if isinstance(value, int):
+            self._view[:] = pack(value, self._len * 8)
+            return None
+        return typ
+
+    def __int__(self) -> int:
+        return unpack(bytes(self._view), self._len * 8)
+
+    def __str__(self) -> str:
+        val = int(self)
+        return f'{val:#x} <{self._flag_(val)!s}>'
+
+    def __repr__(self) -> str:
+        val = int(self)
+        return f'{val:#x} {self._flag_(val)!r}'

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -465,32 +465,36 @@ class PwnType:
             return False
         return self._view == value._view
 
+    def _normalize_slice(self, s: slice) -> slice:
+        if s.step is not None:
+            raise ValueError(f'Slice step is not supported')
+        start = s.start
+        stop = s.stop
+        if start is None:
+            start = 0
+        elif start < 0:
+            start += self._len
+        elif start > self._len:
+            start = self._len
+        if stop is None:
+            stop = self._len
+        elif stop < 0:
+            stop += self._len
+        elif stop > self._len:
+            stop = self._len
+        if start < 0 or stop < 0:
+            raise ValueError(f'Illegal index on memoryview')
+        if start >= stop:
+            raise ValueError(f'Illegal access range on memoryview')
+        return slice(start, stop, None)
+
     def _get_slice(self, subscript: Any) -> bytes | None:
         """
         A helper method to allow user to get object's underlying memory with ``slice``.
         """
         if isinstance(subscript, slice):
-            if subscript.step is not None:
-                raise ValueError(f'Slice step is not supported')
-            start = subscript.start
-            stop = subscript.stop
-            if start is None:
-                start = 0
-            elif start < 0:
-                start += self._len
-            elif start > self._len:
-                start = self._len
-            if stop is None:
-                stop = self._len
-            elif stop < 0:
-                stop += self._len
-            elif stop > self._len:
-                stop = self._len
-            if start < 0 or stop < 0:
-                raise ValueError(f'Illegal index on memoryview')
-            if start >= stop:
-                raise ValueError(f'Illegal access range on memoryview')
-            return bytes(self._view[start:stop])
+            s = self._normalize_slice(subscript)
+            return bytes(self._view[s.start:s.stop])
         return None
 
     def _set_slice(self, subscript: Any, value: Any) -> bool:
@@ -499,41 +503,43 @@ class PwnType:
         and a buffer with the same size as the object.
         """
         if isinstance(subscript, slice):
-            if subscript.step is not None:
-                raise ValueError(f'Slice step is not supported')
-            start = subscript.start
-            stop = subscript.stop
-            if start is None:
-                start = 0
-            elif start < 0:
-                start += self._len
-            elif start > self._len:
-                start = self._len
-            if stop is None:
-                stop = self._len
-            elif stop < 0:
-                stop += self._len
-            elif stop > self._len:
-                stop = self._len
-            if start < 0 or stop < 0:
-                raise ValueError(f'Illegal index on memoryview')
-            if start >= stop:
-                raise ValueError(f'Illegal access range on memoryview')
+            s = self._normalize_slice(subscript)
 
             if not isinstance(value, (bytes, bytearray, str)):
                 raise ValueError(f"Can't fill memory with {_type(value)}")
             data = _need_bytes(value)
-            if len(data) > stop - start:
+            if len(data) > s.stop - s.start:
                 raise ValueError(f'Filling bytes larger than sliced memory')
-            self._view[start:stop] = data.ljust(stop - start, b'\x00')
+            self._view[s.start:s.stop] = data.ljust(s.stop - s.start, b'\x00')
             return True
         return False
 
-    def __getitem__(self, key: Any) -> bytes | CompCValue | None:
-        return self._get_slice(key)
+    def _set_int_from(self, offset: int, size: int, value: Any) -> bool:
+        """
+        Set ``int`` field with ``BytesLike`` or ``int``.
 
-    def __setitem__(self, key: Any, value: Any) -> None:
-        self._set_slice(key, value)
+        Arguments:
+            offset: The offset of the field from ``self._view``.
+            size: The size of the field.
+            value: The object to assign the field.
+
+        Returns:
+            ``True`` if the field is assigned with ``value`` successfully, or ``False``
+            if the type of ``value`` is incompatible.
+
+        Raises:
+            ValueError: ``value`` is larger than size of the field.
+        """
+        if isinstance(value, int):
+            self._view[offset : offset + size] = pack(value, size * 8)
+        elif isinstance(value, (str, bytes, bytearray)):
+            data = _need_bytes(value)
+            if len(data) > size:
+                raise ValueError(f'Filling bytes larger than the field')
+            self._view[offset : offset + size] = data.ljust(size, b'\x00')
+        else:
+            return False
+        return True
 
 
 class CArray(PwnType, Generic[ArrayItemT]):
@@ -666,11 +672,8 @@ class CArray(PwnType, Generic[ArrayItemT]):
             if idx >= self._int_count or idx < 0:
                 raise IndexError(f'Illegal index on elements')
             if self._components is None:
-                start = self._align_ * idx
-                end = start + self._int_size
-                if not isinstance(value, int):
+                if not self._set_int_from(self._align_ * idx, self._int_size, value):
                     raise ValueError(f"Can't set int with {_type(value)}")
-                self._view[start:end] = pack(value, self._int_size * 8)
             else:
                 # isinstance(self._components, list[PwnType])
                 # a.k.a. isinstance(self._type_, PwnType)
@@ -824,15 +827,7 @@ class CStruct(PwnType):
             return
         rhs = self._components[name]
         if isinstance(rhs, int):
-            off = self._int_offsets[name]
-            if isinstance(value, int):
-                self._view[off : off + rhs] = pack(value, rhs * 8)
-            elif isinstance(value, (str, bytes, bytearray)):
-                b = _need_bytes(value)
-                if len(b) > rhs:
-                    raise ValueError(f'Setting bytes larger than {_type(self)}.{name}')
-                self._view[off : off + rhs] = b.ljust(rhs, b'\x00')
-            else:
+            if not self._set_int_from(self._int_offsets[name], rhs, value):
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
         else:  # isinstance(rhs, PwnType)
             typ = rhs._copy_from(value)
@@ -1005,14 +1000,7 @@ class CUnion(PwnType):
             return
         rhs = self._components[name]
         if isinstance(rhs, int):
-            if isinstance(value, int):
-                self._view[:rhs] = pack(value, rhs * 8)
-            elif isinstance(value, (str, bytes, bytearray)):
-                b = _need_bytes(value)
-                if len(b) > rhs:
-                    raise ValueError(f'Setting bytes larger than {_type(self)}.{name}')
-                self._view[:rhs] = b.ljust(rhs, b'\x00')
-            else:
+            if not self._set_int_from(0, rhs, value):
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
         else:  # isinstance(rhs, PwnType)
             typ = rhs._copy_from(value)

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -1217,7 +1217,7 @@ def mk_anonymous_carray(
     fields: dict[str, Any] = {'_type_': elem_type, '_count_': count}
     if align:
         fields['_align_'] = align
-    return type('', (CArray,), fields)
+    return type(f'AnonymousCArray[{_type(elem_type)}]', (CArray,), fields)
 
 
 def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
@@ -1233,7 +1233,7 @@ def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
     fields: dict[str, Any] = {'_type_': c_char, '_count_': count}
     if align:
         fields['_align_'] = align
-    return type('', (CCharArray,), fields)
+    return type('AnonymousCCharArray', (CCharArray,), fields)
 
 
 def mk_anonymous_cstruct(
@@ -1250,7 +1250,7 @@ def mk_anonymous_cstruct(
           +0x0 aaa = 0x0,
         }
     """
-    return type('', (CStruct,), {'_fields_': fields})
+    return type('AnonymousCStruct', (CStruct,), {'_fields_': fields})
 
 
 def mk_anonymous_cunion(fields: list[tuple[str, CType]]) -> type[CUnion]:
@@ -1266,4 +1266,4 @@ def mk_anonymous_cunion(fields: list[tuple[str, CType]]) -> type[CUnion]:
           y = 0x0,
         }
     """
-    return type('', (CUnion,), {'_fields_': fields})
+    return type('AnonymousCUnion', (CUnion,), {'_fields_': fields})

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -509,7 +509,7 @@ class PwnType:
                     max_bitlen = PwnType._calc_size(field_t) * 8
                     # fmt: off
                     if bitlen == 0:
-                        raise ValueError('bitlen == 0 is unsupported,'
+                        raise ValueError('bitlen == 0 is unsupported, '
                                          'use explicit offset instead')
                     if field_t not in BaseCType:
                         raise ValueError('Only BaseCType supports bitfield')
@@ -1065,6 +1065,9 @@ class CStruct(PwnType):
     See examples below.
 
     Examples:
+
+        Implement a basic C string struct with overlapped field:
+
         >>> from pwnlib.util.c_primitives import *
         >>> class CString(CStruct):
         ...     _fields_ = [
@@ -1100,11 +1103,13 @@ class CStruct(PwnType):
         True
         >>> cstr == b'xV4\x12\x00\x00\x00\x00@\x04\x04C\x98\x7f\x00\x00'
         True
-        >>> cstr['flag'] = 0xab
+        >>> cstr['flag'] = b'\xab'
         >>> cstr[3:4]
         b'\xab'
         >>> hex(cstr['size'])
         '0xab345678'
+        >>> cstr.struntil('string')
+        b'xV4\xab\x00\x00\x00\x00'
         >>> cstr.str
         Traceback (most recent call last):
         ...
@@ -1119,8 +1124,73 @@ class CStruct(PwnType):
         Traceback (most recent call last):
         ...
         ValueError: 'length' is not exist in 'CString'
-        >>> cstr.struntil('string')
-        b'xV4\xab\x00\x00\x00\x00'
+
+        Bitfield is also supported. Bitfield implementation has some known caveats,
+        please refer to :py:attr:`pwnlib.util.c_primitives.CStruct._fields_`.
+
+        >>> class StructA(CStruct):
+        ...     _fields_ = [
+        ...         ('f1', BaseCType.int @ 3),
+        ...         ('f2', BaseCType.int @ 5),
+        ...         ('f3', BaseCType.int @ 24, 4, 4),
+        ...         ('f4', BaseCType.char, 7, 7),
+        ...         ('f5', BaseCType.uint @ 20),
+        ...         ('f6', BaseCType.byte),
+        ...         ('f7', BaseCType.uint @ 10),
+        ...     ]
+        ...
+        >>> class StructB(CStruct):
+        ...     _fields_ = [
+        ...         ('fa', BaseCType.int @ 25),
+        ...         ('fb', BaseCType.ulonglong @ 32),
+        ...         ('fc', BaseCType.ulonglong @ 48),
+        ...     ]
+        ...
+        >>> a = StructA()
+        >>> a.offsetof('f1') == a.offsetof('f2') == 0
+        True
+        >>> a.f1 = 3
+        >>> a.f2 = 3
+        >>> a[4:8] = b'\xab\xcd\xef\x89'
+        >>> hex(a.f3)
+        '0xefcdab'
+        >>> hex(a.f4)
+        '0x89'
+        >>> a[:4]
+        b'\x1b\x00\x00\x00'
+        >>> a.offsetof('f5')
+        8
+        >>> b = StructB()
+        >>> len(b)
+        16
+        >>> b.fa = -1
+        >>> b.fb = 0x10101010
+        >>> hex(b.fa)
+        '0x1ffffff'
+        >>> hex(b.fb)
+        '0x10101010'
+        >>> b.fb = b''
+        >>> b[:8]
+        b'\x00\x00\x00\x00\x00\x00\x00\x00'
+        >>> b.offsetof('fa') == b.offsetof('fb') == 0 and b.offsetof('fc') == 8
+        True
+        >>> mk_anonymous_cstruct([('x', BaseCType.uchar @ 9)])()
+        Traceback (most recent call last):
+        ...
+        ValueError: Field 'x' takes bitsmore than it can hold (9 bits)
+        >>> mk_anonymous_cstruct([('x', (mk_anonymous_carray(BaseCType.int, 1), 1))])()
+        Traceback (most recent call last):
+        ...
+        ValueError: Only BaseCType supports bitfield
+        >>> mk_anonymous_cstruct([('x', BaseCType.uchar @ 0)])()
+        Traceback (most recent call last):
+        ...
+        ValueError: bitlen == 0 is unsupported, use explicit offset instead
+        >>> bad_value = mk_anonymous_cstruct([('x', BaseCType.uchar @ 3)])()
+        >>> bad_value.x = 8
+        Traceback (most recent call last):
+        ...
+        ValueError: value can not fit in bitfield 'x'
     """
 
     _fields_: list[tuple[str, BitFieldCType] | tuple[str, BitFieldCType, int, int]]
@@ -1137,6 +1207,13 @@ class CStruct(PwnType):
     of a :class:`pwnlib.util.c_primitives.BaseCType` and an ``int`` to indicate how
     many bits the member takes. Alternatively, you can use ``@`` on a ``BaseCType`` to
     simplify bitfield representation like ``BaseCType.int @ 24``.
+
+    .. note::
+        Bitfield size is inconsistent with compilers, e.g. ``int : 24``, which should
+        take only 3 bytes, is calculated as 4 bytes here. To emulate correct layout,
+        you may specify the element after bitfield explicitly. And writing bytes to
+        bitfield always fills the whole number container, instead of the bits that
+        bitfields holds.
 
     Please refer to :class:`pwnlib.util.c_primitives.CStruct` for examples.
     """
@@ -1224,7 +1301,7 @@ class CStruct(PwnType):
                     # need positive value to make following logic work
                     value += 1 << bitlen
                 if value.bit_length() > bitlen or value < 0:
-                    raise ValueError(f'value can not fit in bitfield {name}')
+                    raise ValueError(f"value can not fit in bitfield '{name}'")
                 off = self._int_offsets[name]
                 old = unpack(bytes(self._view[off : off + rhs]), rhs * 8)
                 mask = ((1 << bitlen) - 1) << bitstart

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -691,6 +691,9 @@ class PwnType:
     def __bytes__(self) -> bytes:
         return bytes(self._view)
 
+    def __flat__(self) -> bytes:
+        return bytes(self)
+
     def __eq__(self, value: object, /) -> bool:
         if isinstance(value, (str, bytes, bytearray)):
             return self._view == _need_bytes(value)

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -1277,7 +1277,6 @@ class CEnum(PwnType):
         if not hasattr(self, '_size_type_') or not hasattr(self, '_disp_type_'):
             raise NotImplementedError
         super().__init__(view)
-        self._disp_type_.__str__ = Enum.__str__  # type: ignore[method-assign]
 
     def __getitem__(self, key: slice) -> bytes:
         b = self._get_slice(key)
@@ -1313,7 +1312,7 @@ class CEnum(PwnType):
             member = self._disp_type_(val)
         except ValueError:
             return hex(val)
-        return f'{val:#x} <{member!s}>'
+        return f'{val:#x} <{Enum.__str__(member)}>'
 
     def __repr__(self) -> str:
         val = int(self)
@@ -1321,7 +1320,7 @@ class CEnum(PwnType):
             member = self._disp_type_(val)
         except ValueError:
             return hex(val)
-        return f'{val:#x} {member!r}'
+        return f'{val:#x} {Enum.__repr__(member)}'
 
 
 class CFlag(CEnum):
@@ -1368,15 +1367,14 @@ class CFlag(CEnum):
 
     def __init__(self, view: memoryview | None = None) -> None:
         super().__init__(view)
-        self._disp_type_.__str__ = Flag.__str__  # type: ignore[method-assign]
 
     def __str__(self) -> str:
         val = int(self)
-        return f'{val:#x} <{self._disp_type_(val)!s}>'
+        return f'{val:#x} <{Flag.__str__(self._disp_type_(val))}>'
 
     def __repr__(self) -> str:
         val = int(self)
-        return f'{val:#x} {self._disp_type_(val)!r}'
+        return f'{val:#x} {Flag.__repr__(self._disp_type_(val))}'
 
 
 def mk_anonymous_carray(

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -4,6 +4,7 @@ consider combine basic types in ``ctypes`` and ``CArray``, ``CStruct`` and ``CUn
 in this module to implement basically all C types.
 
 This module provides some features that ``ctypes`` can not:
+
 1. User may access composite variables with ``slice`` to fetch memory.
 2. User may set composite members with ``bytes`` object.
 3. Easy to layout arch-specific types or layout in packed form. e.g., layout pointer

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -15,7 +15,7 @@ This module provides some features that ``ctypes`` can not:
 Examples:
     Now let's try to emulate a complicated composite type with the following signature:
 
-.. code-block:: c
+    .. code-block:: c
 
         enum Token {
             NONE = 0,

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -293,9 +293,27 @@ class PwnType:
     """
 
     _32_size_cache_: int
+    """
+    32-bit composite type size. This field is automatically assigned when initializing
+    a composite type instance.
+    """
     _64_size_cache_: int
+    """
+    64-bit composite type size. This field is automatically assigned when initializing
+    a composite type instance.
+    """
     _32_align_cache_: int
+    """
+    32-bit composite type align. This field is automatically assigned when initializing
+    a composite type instance, but if you want to override alignment, e.g., setting a
+    type as ``packed``, set it to ``1`` when implementing the class.
+    """
     _64_align_cache_: int
+    """
+    64-bit composite type align. This field is automatically assigned when initializing
+    a composite type instance, but if you want to override alignment, e.g., setting a
+    type as ``packed``, set it to ``1`` when implementing the class.
+    """
     _buf: bytearray | None
     _view: memoryview
     _len: int
@@ -343,7 +361,11 @@ class PwnType:
         if hasattr(typ, align_attr):
             return getattr(typ, align_attr)
         if issubclass(typ, (CStruct, CUnion)):
-            align = max(PwnType._calc_align(f[1]) for f in typ._fields_)
+            if all(len(field) == 4 for field in typ._fields_):
+                # this is a packed struct
+                align = 1
+            else:
+                align = max(PwnType._calc_align(f[1]) for f in typ._fields_)
         elif issubclass(typ, CArray):
             if hasattr(typ, '_align_'):  # here _align_ is type-range
                 align = typ._align_
@@ -375,13 +397,11 @@ class PwnType:
             offset_table_attr = f'_offsets{context.bits}_'
             offsets: dict[str, int] = {}
             is64b = context.bits == 64
-            maybe_packed = True
             for field in typ._fields_:
                 field_t = field[1]
                 if len(field) == 4:
                     offset = field[2] if is64b else field[3]
                 else:  # offset need to be calculated
-                    maybe_packed = False
                     f_align = PwnType._calc_align(field_t)
                     # align up struct_len
                     offset = ((struct_len + f_align - 1) // f_align) * f_align
@@ -389,9 +409,8 @@ class PwnType:
                 field_len = PwnType._calc_size(field_t)
                 struct_len = max(struct_len, offset + field_len)
             setattr(typ, offset_table_attr, offsets)
-            if not maybe_packed:
-                align = PwnType._calc_align(typ)
-                struct_len = ((struct_len + align - 1) // align) * align
+            align = PwnType._calc_align(typ)
+            struct_len = ((struct_len + align - 1) // align) * align
             size_cache = struct_len
         elif issubclass(typ, CArray):
             if typ._count_ == 0:

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -29,11 +29,11 @@ Examples:
     ...
     >>> class CToken(CEnum):
     ...     _size_type_ = c_uint
-    ...     _enum_ = Token
+    ...     _disp_type_ = Token
     ...
     >>> class CPerm(CFlag):
     ...     _size_type_ = c_ubyte
-    ...     _flag_ = Perm
+    ...     _disp_type_ = Perm
     ...
     >>> class Name(CCharArray):
     ...     _count_ = 8
@@ -271,7 +271,7 @@ class PwnType:
                 align = typ._align_
             else:
                 align = PwnType._calc_align(typ._type_)
-        elif issubclass(typ, (CEnum, CFlag)):
+        elif issubclass(typ, CEnum):
             align = PwnType._calc_align(typ._size_type_)
         else:
             raise NotImplementedError
@@ -324,7 +324,7 @@ class PwnType:
                 size_cache = PwnType._calc_size(typ._type_) * typ._count_
         elif issubclass(typ, CUnion):
             size_cache = max(PwnType._calc_size(field[1]) for field in typ._fields_)
-        elif issubclass(typ, (CEnum, CFlag)):
+        elif issubclass(typ, CEnum):
             size_cache = PwnType._calc_size(typ._size_type_)
         else:
             raise NotImplementedError
@@ -433,7 +433,7 @@ class PwnType:
             s.write(' ' * indent)
             s.write('},')
             _separator(s, v)
-        elif isinstance(o, (CFlag, CEnum)):
+        elif isinstance(o, CEnum):
             s.write(repr(o) if v else str(o))
             s.write(',')
             _separator(s, v)
@@ -1053,7 +1053,7 @@ class CUnion(PwnType):
 
 
 class CEnum(PwnType):
-    """
+    r"""
     Base type of a C enum. This can be used to beautify struct output.
 
     Examples:
@@ -1066,7 +1066,7 @@ class CEnum(PwnType):
         ...
         >>> class X(CEnum):
         ...     _size_type_ = c_int
-        ...     _enum_ = XEnum
+        ...     _disp_type_ = XEnum
         ...
         >>> Xarr = mk_anonymous_carray(X, 1)
         >>> e = Xarr()
@@ -1086,17 +1086,17 @@ class CEnum(PwnType):
     """
     Defines how many bytes this enum takes.
     """
-    _enum_: type[IntEnum]
+    _disp_type_: type[IntEnum]
     """
-    The internal ``IntEnum`` type. When accessing the ``CEnum``, a new ``IntEnum`` will
-    be initialized to resolve the value on the memory.
+    The internal ``IntEnum`` type for display. When accessing the ``CEnum``, a new
+    ``IntEnum`` will be initialized to resolve the value on the memory.
     """
 
     def __init__(self, view: memoryview | None = None) -> None:
-        if not hasattr(self, '_size_type_') or not hasattr(self, '_enum_'):
+        if not hasattr(self, '_size_type_') or not hasattr(self, '_disp_type_'):
             raise NotImplementedError
         super().__init__(view)
-        self._enum_.__str__ = Enum.__str__  # type: ignore[method-assign]
+        self._disp_type_.__str__ = Enum.__str__  # type: ignore[method-assign]
 
     def __getitem__(self, key: slice) -> bytes:
         b = self._get_slice(key)
@@ -1129,7 +1129,7 @@ class CEnum(PwnType):
     def __str__(self) -> str:
         val = int(self)
         try:
-            member = self._enum_(val)
+            member = self._disp_type_(val)
         except ValueError:
             return hex(val)
         return f'{val:#x} <{member!s}>'
@@ -1137,13 +1137,13 @@ class CEnum(PwnType):
     def __repr__(self) -> str:
         val = int(self)
         try:
-            member = self._enum_(val)
+            member = self._disp_type_(val)
         except ValueError:
             return hex(val)
         return f'{val:#x} {member!r}'
 
 
-class CFlag(PwnType):
+class CFlag(CEnum):
     """
     Base type of a C flag. This can be used to beautify struct output.
 
@@ -1157,7 +1157,7 @@ class CFlag(PwnType):
         ...
         >>> class X(CFlag):
         ...     _size_type_ = c_int
-        ...     _flag_ = XFlag
+        ...     _disp_type_ = XFlag
         ...
         >>> Xarr = mk_anonymous_carray(X, 1)
         >>> f = Xarr()
@@ -1175,53 +1175,23 @@ class CFlag(PwnType):
     """
     Defines how many bytes this flag takes.
     """
-    _flag_: type[IntFlag]
+    _disp_type_: type[IntFlag]
     """
-    The internal ``IntFlag`` type. When accessing the ``CFlag``, a new ``IntFlag`` will
-    be initialized to resolve the value on the memory.
+    The internal ``IntFlag`` type for display. When accessing the ``CFlag``, a new
+    ``IntFlag`` will be initialized to resolve the value on the memory.
     """
 
     def __init__(self, view: memoryview | None = None) -> None:
-        if not hasattr(self, '_size_type_') or not hasattr(self, '_flag_'):
-            raise NotImplementedError
         super().__init__(view)
-        self._flag_.__str__ = Flag.__str__  # type: ignore[method-assign]
-
-    def __getitem__(self, key: slice) -> bytes:
-        b = self._get_slice(key)
-        if b is not None:
-            return b
-        raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
-
-    def __setitem__(self, key: slice, value: BytesLike) -> None:
-        if self._set_slice(key, value):
-            return
-        raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
-
-    def _copy_from(self, value: Any) -> type[Any] | None:
-        typ = super()._copy_from(value)
-        if typ is None:
-            return typ
-        if isinstance(value, int):
-            self._view[:] = pack(value, self._len * 8)
-            return None
-        return typ
-
-    def __int__(self) -> int:
-        return unpack(bytes(self._view), self._len * 8)
-
-    def __eq__(self, value: object, /) -> bool:
-        if isinstance(value, int):
-            return int(self) == value
-        return super().__eq__(value)
+        self._disp_type_.__str__ = Flag.__str__  # type: ignore[method-assign]
 
     def __str__(self) -> str:
         val = int(self)
-        return f'{val:#x} <{self._flag_(val)!s}>'
+        return f'{val:#x} <{self._disp_type_(val)!s}>'
 
     def __repr__(self) -> str:
         val = int(self)
-        return f'{val:#x} {self._flag_(val)!r}'
+        return f'{val:#x} {self._disp_type_(val)!r}'
 
 
 def mk_anonymous_carray(

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -158,9 +158,9 @@ Examples:
           00 00                                            |..|
         >,
         scores = [
-          0xbeef,
-          0x4647,
-          0x4445,
+          [0] = 0xbeef,
+          [1] = 0x4647,
+          [2] = 0x4445,
         ],
         pair = {
           +0x0 lo = 0xbeef,
@@ -170,8 +170,8 @@ Examples:
         },
       },
       +0x34 tokens = [
-        0x1 <Token.READ: 1>,
-        0x99,
+        [0] = 0x1 <Token.READ: 1>,
+        [1] = 0x99,
       ],
       +0x3c perm = 0x4 <Perm.X: 4>,
       +0x40 handler = 0x7f0643fa3f60,
@@ -550,8 +550,11 @@ class PwnType:
             s.write('[')
             _verbose_separator(s, v)
             indent += step
+            w = len(str(o._int_count))
             for i in range(o._int_count):
                 s.write(' ' * indent)
+                if v:
+                    s.write(f'[{i:<{w}}] = ')
                 if o._components:
                     PwnType._print_to_stream(s, v, indent, o._components[i])
                 else:
@@ -785,10 +788,10 @@ class CArray(PwnType, Generic[ArrayItemT]):
         16
         >>> arr
         [
-          0x13371337,
-          0xbeadde00,
-          0xef,
-          0x0,
+          [0] = 0x13371337,
+          [1] = 0xbeadde00,
+          [2] = 0xef,
+          [3] = 0x0,
         ]
         >>> for e in arr:
         ...     print(e)
@@ -1480,8 +1483,8 @@ def mk_anonymous_carray(
         >>> from pwnlib.util.c_primitives import *
         >>> mk_anonymous_carray(BaseCType.int, 2)()
         [
-          0x0,
-          0x0,
+          [0] = 0x0,
+          [1] = 0x0,
         ]
     """
     fields: dict[str, Any] = {'_type_': elem_type, '_count_': count}

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -504,7 +504,7 @@ class PwnType:
             s: A ``slice`` from user's code.
 
         Returns:
-            A ``slice`` which fits in ``[0, self._len)``.
+            A ``slice`` within the range of ``[0, self._len)``.
 
         Raises:
             ValueError: ``step`` is not ``None`` in user's slice.

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -1157,7 +1157,7 @@ class CEnum(PwnType):
     """
     Defines how many bytes this enum takes.
     """
-    _disp_type_: type[IntEnum]
+    _disp_type_: type[IntEnum] | type[IntFlag]
     """
     The internal ``IntEnum`` type for display. When accessing the ``CEnum``, a new
     ``IntEnum`` will be initialized to resolve the value on the memory.

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -545,8 +545,8 @@ class PwnType:
             the ``None``.
 
         Raises:
-            IndexError: See :func:`pwnlib.util.c_primitives._normalize_slice`.
-            ValueError: See :func:`pwnlib.util.c_primitives._normalize_slice`.
+            IndexError: See :func:`pwnlib.util.c_primitives.PwnType._normalize_slice`.
+            ValueError: See :func:`pwnlib.util.c_primitives.PwnType._normalize_slice`.
         """
         if isinstance(subscript, slice):
             return bytes(self._view[self._normalize_slice(subscript)])
@@ -565,10 +565,10 @@ class PwnType:
             Whether the underlying memory view is set with ``value`` successfully.
 
         Raises:
-            IndexError: See :func:`pwnlib.util.c_primitives._normalize_slice`.
-            ValueError: See :func:`pwnlib.util.c_primitives._normalize_slice`. Setting
-                        memory view with ``value`` which is incompatible with ``bytes``,
-                        or ``value`` is larger than memory view.
+            IndexError: See :func:`pwnlib.util.c_primitives.PwnType._normalize_slice`.
+            ValueError: See :func:`pwnlib.util.c_primitives.PwnType._normalize_slice`.
+                        Setting memory view with ``value`` which is incompatible with
+                        ``bytes``, or ``value`` is larger than memory view.
         """
         if isinstance(subscript, slice):
             s = self._normalize_slice(subscript)

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -13,6 +13,54 @@ This module provides some features that ``ctypes`` can not:
 5. Print composite types in a pwner-friendly form.
 
 Examples:
+    Now let's try to emulate a complicated composite type with the following signature:
+
+.. code-block:: c
+
+        enum Token {
+            NONE = 0,
+            READ = 1,
+            WRITE = 2,
+        };
+
+        enum __attribute__((packed)) Perm {
+            R = 1,
+            W = 2,
+            X = 4,
+        };
+
+        typedef char Name[8];
+        typedef char Raw[24];
+        typedef unsigned short Scores[3];
+
+        struct AutoHeader {
+            char tag;
+            enum Perm perm;
+            void *cursor;
+            enum Token kind;
+            Name name;
+        };
+
+        struct __attribute__((packed)) ManualPair {
+            unsigned short lo;
+            void *target;
+            unsigned int tail;
+        };
+
+        union Payload {
+            Raw raw;
+            Scores scores;
+            struct ManualPair pair;
+        };
+
+        struct Packet {
+            struct AutoHeader header;
+            union Payload payload;
+            enum Token tokens[2];
+            enum Perm perm;
+            void *handler;
+        };
+
     >>> from pwnlib.util.c_primitives import *
     >>> from ctypes import *
     >>> from enum import IntEnum, IntFlag
@@ -138,7 +186,7 @@ Examples:
     ...
     ValueError: Setting bytes larger than AutoHeader
     >>> newraw = Raw()
-    >>> pkt.payload.raw = newraw
+    >>> pkt.payload['raw'] = newraw
     >>> print(pkt.payload.raw)
     <00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
 """
@@ -1080,7 +1128,7 @@ class CUnion(PwnType):
         >>> xu[-99:] = b'123'
         Traceback (most recent call last):
         ...
-        ValueError: Illegal index on memoryview
+        IndexError: Illegal index on memoryview
         >>> xu.b = 9999
         Traceback (most recent call last):
         ...

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -355,7 +355,7 @@ class BaseCType(Enum):
             return 8
         return BaseCType.sizeof(e)
 
-    def __matmul__(self, bitlen: int) -> tuple[BaseCType, int]:
+    def __matmul__(self, bitlen: builtins.int) -> tuple[BaseCType, builtins.int]:
         """
         An alternative way to write bitfield. This shim converts ``BaseCType.int @ 24``
         to ``(BaseCType.int, 24)``, which may help you write shorter field descriptor
@@ -511,7 +511,7 @@ class PwnType:
                     if bitlen == 0:
                         raise ValueError('bitlen == 0 is unsupported, '
                                          'use explicit offset instead')
-                    if field_t not in BaseCType:
+                    if not isinstance(field_t, BaseCType):
                         raise ValueError('Only BaseCType supports bitfield')
                     if bitlen > max_bitlen or bitlen < 0:
                         raise ValueError(f"Field '{field[0]}' takes bits"
@@ -1282,6 +1282,7 @@ class CStruct(PwnType):
         bit_pair = self._int_bitfields.get(field)
         off = self._int_offsets[field]
         size = self._components[field]
+        assert isinstance(size, int)
         raw_val = unpack(bytes(self._view[off : off + size]), size * 8)
         if not bit_pair:
             return raw_val

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -138,7 +138,9 @@ Examples:
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Iterator
 from ctypes import (
+    _SimpleCData,
     c_char,
     c_char_p,
     c_long,
@@ -148,7 +150,6 @@ from ctypes import (
     c_void_p,
     c_wchar_p,
     sizeof,
-    _SimpleCData,
 )
 from enum import Enum, Flag, IntEnum, IntFlag
 from io import StringIO, TextIOBase
@@ -317,7 +318,10 @@ class PwnType:
         elif issubclass(typ, CArray):
             if typ._count_ == 0:
                 return 0
-            size_cache = PwnType._calc_align(typ) * typ._count_
+            if hasattr(typ, '_align_'):
+                size_cache = typ._align_ * typ._count_
+            else:
+                size_cache = PwnType._calc_size(typ._type_) * typ._count_
         elif issubclass(typ, CUnion):
             size_cache = max(PwnType._calc_size(field[1]) for field in typ._fields_)
         elif issubclass(typ, (CEnum, CFlag)):
@@ -677,6 +681,29 @@ class CArray(PwnType, Generic[ArrayItemT]):
             return
 
         raise ValueError(f"Can not access array with '{_type(key)}' subscript")
+
+    def _int_iterator(self) -> Iterator[int]:
+        """
+        A generator function to support iterating ``BaseCType`` ``CArray``.
+
+        Returns:
+            An iterator to iterate over underlying ``int`` values.
+        """
+        for i in range(self._int_count):
+            off = i * self._align_
+            bits = self._int_size * 8
+            yield unpack(bytes(self._view[off : off + self._int_size]), bits)
+
+    @overload
+    def __iter__(self: CArray[int]) -> Iterator[int]: ...
+
+    @overload
+    def __iter__(self: CArray[ArrayItemT]) -> Iterator[ArrayItemT]: ...
+
+    def __iter__(self) -> Iterator[CompCValue]:
+        if self._components is None:
+            return self._int_iterator()
+        return iter(self._components)
 
 
 class CCharArray(CArray[int]):

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -334,7 +334,7 @@ class BaseCType(Enum):
                     return context.bytes
                 return 4  # Windows
             case _:
-                raise NotImplementedError
+                raise NotImplementedError(f"sizeof '{_type(e)}' is not supported")
 
     @staticmethod
     def alignof(e: BaseCType) -> builtins.int:
@@ -455,7 +455,7 @@ class PwnType:
         elif issubclass(typ, CEnum):
             align = PwnType._calc_align(typ._size_type_)
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f'Calc align on {_type(typ)} is not supported')
         setattr(typ, align_attr, align)
         return align
 
@@ -505,7 +505,7 @@ class PwnType:
         elif issubclass(typ, CEnum):
             size_cache = PwnType._calc_size(typ._size_type_)
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f'Calc size on {_type(typ)} is not supported')
         setattr(typ, cache_attr, size_cache)
         return size_cache
 
@@ -619,7 +619,7 @@ class PwnType:
             s.write(',')
             _separator(s, v)
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f'{_type(o)} is not a PwnType instance')
 
     def __str__(self) -> str:
         with StringIO() as s:
@@ -764,8 +764,9 @@ class PwnType:
 class CArray(PwnType, Generic[ArrayItemT]):
     r"""
     A generic array to implement statments like ``int arr[3];`` in C. An array can be
-    accessed with ``int`` subscript. ``slice`` is used to access underlying memory not
-    objects.
+    accessed with ``int`` subscript. ``slice`` is used to access underlying memory view
+    object. E.g., for the definition above, write ``arr[1]`` to access second element,
+    or write ``arr[4:8]`` to get bytes representation of second element.
 
     Examples:
         A named array with 4 ints:
@@ -887,7 +888,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_type_') or not hasattr(self, '_count_'):
-            raise NotImplementedError
+            raise NotImplementedError('CArray subclass must define _type_ and _count_')
         super().__init__(view)
         if self._len == 0:
             if self._buf is not None:
@@ -1007,6 +1008,8 @@ class CCharArray(CArray[int]):
 class CStruct(PwnType):
     r"""
     Base type of C structure. A structure can be accessed like member, or ``dict``.
+    E.g., to access flags in a FILE struct instance one can write ``file._flags`` or
+    ``file['_flags']``. To get bytes representation of flags, write ``file[:4]``.
     See examples below.
 
     Examples:
@@ -1088,7 +1091,7 @@ class CStruct(PwnType):
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
-            raise NotImplementedError
+            raise NotImplementedError('CStruct subclass must define _fields_')
         super().__init__(view)
 
         self._int_offsets = getattr(self, f'_offsets{context.bits}_')
@@ -1198,7 +1201,9 @@ class CStruct(PwnType):
 class CUnion(PwnType):
     r"""
     Base type of C union. Like struct, you can access members with dot or like
-    ``dict``. See examples below.
+    ``dict``. E.g., to access ``sival_int`` in a ``sigval`` instance, one can write
+    ``val.sival_int`` or ``val['sival_int']``. To get bytes representation of
+    ``sival_int``, write ``val[:4]``. See examples below.
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
@@ -1257,7 +1262,7 @@ class CUnion(PwnType):
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
-            raise NotImplementedError
+            raise NotImplementedError('CUnion subclass must define _fields_')
         super().__init__(view)
 
         self._components = OrderedDict()
@@ -1370,7 +1375,8 @@ class CEnum(PwnType):
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_size_type_') or not hasattr(self, '_disp_type_'):
-            raise NotImplementedError
+            msg = 'CEnum subclass must define _size_type_ and _disp_type_'
+            raise NotImplementedError(msg)
         super().__init__(view)
 
     def __getitem__(self, key: slice) -> bytes:

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -202,6 +202,7 @@ from pwnlib.util.packing import _need_bytes, pack, unpack
 
 CompCType: TypeAlias = type['PwnType']
 CType: TypeAlias = 'BaseCType | CompCType'
+BitFieldCType: TypeAlias = 'CType | tuple[BaseCType, int]'
 CompCValue: TypeAlias = 'int | PwnType'
 BytesLike: TypeAlias = str | bytes | bytearray
 ArrayItemT = TypeVar('ArrayItemT', bound='CompCValue')
@@ -354,6 +355,20 @@ class BaseCType(Enum):
             return 8
         return BaseCType.sizeof(e)
 
+    def __matmul__(self, bitlen: int) -> tuple[BaseCType, int]:
+        """
+        An alternative way to write bitfield. This shim converts ``BaseCType.int @ 24``
+        to ``(BaseCType.int, 24)``, which may help you write shorter field descriptor
+        in :class:`pwnlib.util.c_primitives.CStruct` definition.
+
+        Arguments:
+            bitlen: How many bits does the field takes.
+
+        Returns:
+            A tuple consists of the enum itself and the ``bitlen``.
+        """
+        return (self, bitlen)
+
 
 class PwnType:
     """
@@ -446,7 +461,10 @@ class PwnType:
                 # this is a packed struct
                 align = 1
             else:
-                align = max(PwnType._calc_align(f[1]) for f in typ._fields_)
+                align = max(
+                    PwnType._calc_align(f[1][0] if isinstance(f[1], tuple) else f[1])
+                    for f in typ._fields_
+                )
         elif issubclass(typ, CArray):
             if hasattr(typ, '_align_'):  # here _align_ is type-range
                 align = typ._align_
@@ -477,18 +495,55 @@ class PwnType:
             struct_len = 0
             offset_table_attr = f'_offsets{context.bits}_'
             offsets: dict[str, int] = {}
+            bitfield_attr = f'_bitfields{context.bits}_'
+            bitfields: dict[str, tuple[int, int]] = {}
+
+            bitstart = 0
             is64b = context.bits == 64
-            for field in typ._fields_:
+            for idx, field in enumerate(typ._fields_):
                 field_t = field[1]
+                bitlen = 0
+                if isinstance(field_t, tuple):
+                    bitlen = field_t[1]
+                    field_t = field_t[0]
+                    max_bitlen = PwnType._calc_size(field_t) * 8
+                    # fmt: off
+                    if bitlen == 0:
+                        raise ValueError('bitlen == 0 is unsupported,'
+                                         'use explicit offset instead')
+                    if field_t not in BaseCType:
+                        raise ValueError('Only BaseCType supports bitfield')
+                    if bitlen > max_bitlen or bitlen < 0:
+                        raise ValueError(f"Field '{field[0]}' takes bits"
+                                         f"more than it can hold ({bitlen} bits)")
+                    # fmt: on
+
+                    if bitstart + bitlen > max_bitlen or len(field) == 4:
+                        # the previous container can't hold current bitfield
+                        # or user set explicit offset
+                        bitstart = 0
+                    bitfields[field[0]] = (bitstart, bitlen)
+
                 if len(field) == 4:
                     offset = field[2] if is64b else field[3]
+                elif bitstart and bitlen:
+                    # adjacent bitfields and they are fit in one real field
+                    # bitstart != 0 ensures idx - 1 is accessible
+                    prev_field = typ._fields_[idx - 1][0]
+                    offset = offsets[prev_field]
                 else:  # offset need to be calculated
                     f_align = PwnType._calc_align(field_t)
                     # align up struct_len
                     offset = ((struct_len + f_align - 1) // f_align) * f_align
                 offsets[field[0]] = offset
+
+                if bitlen:
+                    bitstart += bitlen
+                else:
+                    bitstart = 0
                 field_len = PwnType._calc_size(field_t)
                 struct_len = max(struct_len, offset + field_len)
+            setattr(typ, bitfield_attr, bitfields)
             setattr(typ, offset_table_attr, offsets)
             align = PwnType._calc_align(typ)
             struct_len = ((struct_len + align - 1) // align) * align
@@ -584,10 +639,7 @@ class PwnType:
                 if isinstance(value, PwnType):
                     PwnType._print_to_stream(s, v, indent, value)
                 else:  # isinstance(value[0], int)
-                    unpacked = unpack(
-                        bytes(o._view[off : off + value]),
-                        value * 8,
-                    )
+                    unpacked = o._get_int(field)
                     s.write(f'{unpacked:#x},')
                     _separator(s, v)
             _remove_non_verbose_tail(s, v)
@@ -1071,7 +1123,7 @@ class CStruct(PwnType):
         b'xV4\xab\x00\x00\x00\x00'
     """
 
-    _fields_: list[tuple[str, CType] | tuple[str, CType, int, int]]
+    _fields_: list[tuple[str, BitFieldCType] | tuple[str, BitFieldCType, int, int]]
     """
     A ``list`` of struct members. If the struct is not packed, and you would like to
     calculate offsets automatically, then fill out members with 2-element tuples,
@@ -1081,13 +1133,39 @@ class CStruct(PwnType):
     tuples, member name, member type, offset for 64-bit targets and offset for 32-bit
     targets.
 
-    Please refer to ``CStruct`` for examples.
+    To support bitfield in C, the second element, member type, can be a tuple consisting
+    of a :class:`pwnlib.util.c_primitives.BaseCType` and an ``int`` to indicate how
+    many bits the member takes. Alternatively, you can use ``@`` on a ``BaseCType`` to
+    simplify bitfield representation like ``BaseCType.int @ 24``.
+
+    Please refer to :class:`pwnlib.util.c_primitives.CStruct` for examples.
     """
     _components: OrderedDict[str, CompCValue]
     _len: int
     _offsets32_: dict[str, int]
+    """
+    32-bit cache for member offsets in the struct. This dict is dynamically
+    constructed during ``_calc_size``.
+    """
     _offsets64_: dict[str, int]
+    """
+    64-bit cache for member offsets in the struct. This dict is dynamically
+    constructed during ``_calc_size``.
+    """
+    _bitfields32_: dict[str, tuple[int, int]]
+    """
+    32-bit cache for bitfields information. The key is member name, and value is a
+    tuple consisting of ``bit_start`` and ``bitlen``. This dict is dynamically
+    constructed during ``_calc_size``.
+    """
+    _bitfields64_: dict[str, tuple[int, int]]
+    """
+    64-bit cache for bitfields information. The key is member name, and value is a
+    tuple consisting of ``bit_start`` and ``bitlen``. This dict is dynamically
+    constructed during ``_calc_size``.
+    """
     _int_offsets: dict[str, int]
+    _int_bitfields: dict[str, tuple[int, int]]
 
     def __init__(self, view: memoryview | None = None) -> None:
         if not hasattr(self, '_fields_'):
@@ -1095,12 +1173,15 @@ class CStruct(PwnType):
         super().__init__(view)
 
         self._int_offsets = getattr(self, f'_offsets{context.bits}_')
+        self._int_bitfields = getattr(self, f'_bitfields{context.bits}_')
         self._components = OrderedDict()
         for field in self._fields_:
             field_t = field[1]
             off = self._int_offsets[field[0]]
+            if isinstance(field_t, tuple):  # bitfield
+                field_t = field_t[0]
             if isinstance(field_t, BaseCType):
-                self._components[field[0]] = PwnType._calc_size(field[1])
+                self._components[field[0]] = PwnType._calc_size(field_t)
             else:
                 size = PwnType._calc_size(field_t)
                 assert issubclass(field_t, PwnType)
@@ -1109,12 +1190,46 @@ class CStruct(PwnType):
                 else:
                     self._components[field[0]] = field_t(self._view[off : off + size])
 
+    def _get_int(self, field: str) -> int:
+        """
+        A specific getter for accessing BaseCType field in CStruct to support bitfield
+        and general number.
+
+        Arguments:
+            field: The field name in the struct. The field name must be checked that
+                   it's a member in the struct.
+
+        Returns:
+            The result read from underlying memory view.
+        """
+        bit_pair = self._int_bitfields.get(field)
+        off = self._int_offsets[field]
+        size = self._components[field]
+        raw_val = unpack(bytes(self._view[off : off + size]), size * 8)
+        if not bit_pair:
+            return raw_val
+        bitstart, bitlen = bit_pair
+        raw_val >>= bitstart
+        return raw_val & ((1 << bitlen) - 1)
+
     def __setattr__(self, name: str, value: Any, /) -> None:
         if '_components' not in self.__dict__ or name not in self._components:
             object.__setattr__(self, name, value)
             return
         rhs = self._components[name]
         if isinstance(rhs, int):
+            if isinstance(value, int) and (bit_pair := self._int_bitfields.get(name)):
+                bitstart, bitlen = bit_pair
+                if value < 0:
+                    # need positive value to make following logic work
+                    value += 1 << bitlen
+                if value.bit_length() > bitlen or value < 0:
+                    raise ValueError(f'value can not fit in bitfield {name}')
+                off = self._int_offsets[name]
+                old = unpack(bytes(self._view[off : off + rhs]), rhs * 8)
+                mask = ((1 << bitlen) - 1) << bitstart
+                value = (value << bitstart) | (old & ~mask)
+
             if not self._set_int_from(self._int_offsets[name], rhs, value):
                 raise ValueError(f"Can't set {_type(self)}.{name} with {_type(value)}")
         else:  # isinstance(rhs, PwnType)
@@ -1126,9 +1241,8 @@ class CStruct(PwnType):
         if '_components' not in self.__dict__ or name not in self._components:
             raise AttributeError(f"'{_type(self)}' object has no attribute '{name}'")
         rhs = self._components[name]
-        off = self._int_offsets[name]
         if isinstance(rhs, int):
-            return unpack(bytes(self._view[off : off + rhs]), rhs * 8)
+            return self._get_int(name)
         return self._components[name]  # PwnType
 
     @overload

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -1,4 +1,4 @@
-"""
+r"""
 A generic module to construct C data types with pure Python. Downstream data types may
 consider combine basic types in ``ctypes`` and ``CArray``, ``CStruct`` and ``CUnion``
 in this module to implement basically all C types.
@@ -10,6 +10,128 @@ This module provides some features that ``ctypes`` can not:
    for 32-bit types but on 64-bit Python.
 4. Directly return ``int`` on basic types.
 5. Print composite types in a pwner-friendly form.
+
+Examples:
+    >>> from pwnlib.util.c_primitives import *
+    >>> from ctypes import *
+    >>> from enum import IntEnum, IntFlag
+    >>> context.clear(arch='amd64')
+    >>> class Token(IntEnum):
+    ...     NONE = 0
+    ...     READ = 1
+    ...     WRITE = 2
+    ...
+    >>> class Perm(IntFlag):
+    ...     R = 1
+    ...     W = 2
+    ...     X = 4
+    ...
+    >>> class CToken(CEnum):
+    ...     _size_type_ = c_uint
+    ...     _enum_ = Token
+    ...
+    >>> class CPerm(CFlag):
+    ...     _size_type_ = c_ubyte
+    ...     _flag_ = Perm
+    ...
+    >>> class Name(CCharArray):
+    ...     _count_ = 8
+    ...
+    >>> class Raw(CCharArray):
+    ...     _count_ = 24
+    ...
+    >>> class Scores(CArray):
+    ...     _type_ = c_ushort
+    ...     _count_ = 3
+    ...
+    >>> Tokens = mk_anonymous_carray(CToken, 2)
+    >>> class AutoHeader(CStruct):
+    ...     _fields_ = [
+    ...         ('tag', c_char),
+    ...         ('perm', CPerm),
+    ...         ('cursor', c_void_p),
+    ...         ('kind', CToken),
+    ...         ('name', Name),
+    ...     ]
+    ...
+    >>> class ManualPair(CStruct):
+    ...     _fields_ = [
+    ...         ('lo', c_ushort, 0, 0),
+    ...         ('target', c_void_p, 2, 2),
+    ...         ('tail', c_uint, 10, 10),
+    ...     ]
+    ...
+    >>> class Payload(CUnion):
+    ...     _fields_ = [
+    ...         ('raw', Raw),
+    ...         ('scores', Scores),
+    ...         ('pair', ManualPair),
+    ...     ]
+    ...
+    >>> class Packet(CStruct):
+    ...     _fields_ = [
+    ...         ('header', AutoHeader),
+    ...         ('payload', Payload),
+    ...         ('tokens', Tokens),
+    ...         ('perm', CPerm),
+    ...         ('handler', c_void_p),
+    ...     ]
+    ...
+    >>> pkt = Packet()
+    >>> pkt.payload.pair.offsetof('tail')
+    10
+    >>> len(pkt.payload)
+    24
+    >>> len(pkt)
+    80
+    >>> pkt.header.tag = ord('M')
+    >>> pkt.header.perm = Perm.R
+    >>> pkt.header.cursor = 0x1122334455667788
+    >>> pkt.header.kind = Token.READ + 0xaa00
+    >>> pkt.header.name = b'payload!'
+    >>> pkt.payload.pair.lo = 0xbeef
+    >>> pkt.payload.pair.target = 0x4041424344454647
+    >>> pkt.payload.pair.tail = 0x21444150
+    >>> pkt.tokens[0] = Token.READ
+    >>> pkt.tokens[1] = 0x99
+    >>> pkt.perm = Perm.W | Perm.X
+    >>> pkt.handler = 0x7f0643fa3f60
+    >>> pkt.header[12:20] = b'PWN!\x02'
+    >>> pkt[0x30:0x38] = b'/bin/sh'
+    >>> pkt
+    {
+      +0x0  header = {
+        +0x0  tag = 0x4d,
+        +0x1  perm = 0x1 <Perm.R: 1>,
+        +0x8  cursor = 0x214e575055667788,
+        +0x10 kind = 0x2 <Token.WRITE: 2>,
+        +0x14 name = <70 61 79 6c 6f 61 64 21  |payload!|>,
+      },
+      +0x20 payload = {
+        raw = <
+          ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00  |..GFEDCBA@PAD!..|
+          2f 62 69 6e 2f 73 68 00                          |/bin/sh.|
+        >,
+        scores = [
+          0xbeef,
+          0x4647,
+          0x4445,
+        ],
+        pair = {
+          +0x0 lo = 0xbeef,
+          +0x2 target = 0x4041424344454647,
+          +0xa tail = 0x21444150,
+        },
+      },
+      +0x38 tokens = [
+        0x1 <Token.READ: 1>,
+        0x99,
+      ],
+      +0x40 perm = 0x6 <Perm.W|X: 6>,
+      +0x48 handler = 0x7f0643fa3f60,
+    }
+    >>> print(pkt)
+    {{0x4d, 0x1 <Perm.R>, 0x214e575055667788, 0x2 <Token.WRITE>, <70 61 79 6c 6f 61 64 21>}, {<ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00 2f 62 69 6e 2f 73 68 00>, [0xbeef, 0x4647, 0x4445], {0xbeef, 0x4041424344454647, 0x21444150}}, [0x1 <Token.READ>, 0x99], 0x6 <Perm.W|X>, 0x7f0643fa3f60}
 """
 
 from __future__ import annotations
@@ -73,7 +195,8 @@ def _verbose_separator(s: TextIOBase, v: bool) -> None:
 
 def _remove_non_verbose_tail(s: TextIOBase, v: bool) -> None:
     if not v:
-        s.truncate(s.tell() - 2)
+        s.seek(s.tell() - 2)
+        s.truncate()
 
 
 class PwnType:
@@ -331,6 +454,8 @@ class PwnType:
         return bytes(self._view)
 
     def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, (str, bytes, bytearray)):
+            return self._view == _need_bytes(value)
         if not isinstance(value, PwnType) or type(self) is not type(value):
             return False
         return self._view == value._view
@@ -407,10 +532,41 @@ class PwnType:
 
 
 class CArray(PwnType, Generic[ArrayItemT]):
-    """
+    r"""
     A generic array to implement statments like ``int arr[3];`` in C. An array can be
     accessed with ``int`` subscript. ``slice`` is used to access underlying memory not
     objects.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> class Int4(CArray):
+        ...     _type_ = c_int
+        ...     _count_ = 4
+        ...
+        >>> buf = bytearray(32)
+        >>> arr = Int4(memoryview(buf))
+        >>> arr[0] = 0x13371337
+        >>> arr[5:9] = b'\xde\xad\xbe\xef'
+        >>> buf[:20]
+        bytearray(b'7\x137\x13\x00\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+        >>> bytes(arr)[:len(arr)]
+        b'7\x137\x13\x00\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00'
+        >>> len(arr)
+        16
+        >>> arr
+        [
+          0x13371337,
+          0xbeadde00,
+          0xef,
+          0x0,
+        ]
+        >>> print(arr)
+        [0x13371337, 0xbeadde00, 0xef, 0x0]
+        >>> arr[2:6]
+        b'7\x13\x00\xde'
+        >>> arr[1]
+        3199065600
     """
 
     _type_: CType
@@ -532,9 +688,68 @@ class CCharArray(CArray[int]):
 
 
 class CStruct(PwnType):
-    """
+    r"""
     Base type of C structure. A structure can be accessed like member, or ``dict``.
     See examples below.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> class CString(CStruct):
+        ...     _fields_ = [
+        ...         ('size', c_uint),
+        ...         ('flag', c_char, 3, 3),
+        ...         ('string', c_char_p),
+        ...     ]
+        ...     # recommends adding type hints to enable LSP auto completion
+        ...     size: int
+        ...     flag: int
+        ...     string: int
+        ...
+        >>> context.clear(arch='amd64')
+        >>> cstr = CString()
+        >>> cstr.size = 0x12345678
+        >>> cstr.flag
+        18
+        >>> cstr.string = 0x7f9843040440
+        >>> cstr
+        {
+          +0x0 size = 0x12345678,
+          +0x3 flag = 0x12,
+          +0x8 string = 0x7f9843040440,
+        }
+        >>> bytes(cstr)
+        b'xV4\x12\x00\x00\x00\x00@\x04\x04C\x98\x7f\x00\x00'
+        >>> len(cstr)
+        16
+        >>> print(cstr)
+        {0x12345678, 0x12, 0x7f9843040440}
+        >>> cstr2 = CString(memoryview(b'xV4\x12\x00\x00\x00\x00@\x04\x04C\x98\x7f\x00\x00'))
+        >>> cstr == cstr2
+        True
+        >>> cstr == b'xV4\x12\x00\x00\x00\x00@\x04\x04C\x98\x7f\x00\x00'
+        True
+        >>> cstr['flag'] = 0xab
+        >>> cstr[3:4]
+        b'\xab'
+        >>> hex(cstr['size'])
+        '0xab345678'
+        >>> cstr.str
+        Traceback (most recent call last):
+        ...
+        AttributeError: 'CString' object has no attribute 'str'
+        >>> cstr['str']
+        Traceback (most recent call last):
+        ...
+        AttributeError: 'CString' object has no attribute 'str'
+        >>> cstr.offsetof('flag')
+        3
+        >>> cstr.offsetof('length')
+        Traceback (most recent call last):
+        ...
+        ValueError: 'length' is not exist in 'CString'
+        >>> cstr.struntil('string')
+        b'xV4\xab\x00\x00\x00\x00'
     """
 
     _fields_: list[tuple[str, CType] | tuple[str, CType, int, int]]
@@ -673,9 +888,57 @@ class CStruct(PwnType):
 
 
 class CUnion(PwnType):
-    """
+    r"""
     Base type of C union. Like struct, you can access members with dot or like
     ``dict``. See examples below.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> class XU(CUnion):
+        ...     _fields_ = [
+        ...         ('a', c_uint),
+        ...         ('b', c_char),
+        ...         ('c', c_longlong),
+        ...     ]
+        ...
+        >>> xu = XU()
+        >>> xu.c = 0x123456789abcdef0
+        >>> xu['b']
+        240
+        >>> xu.b = 0
+        >>> xu.a
+        2596068864
+        >>> xu
+        {
+          a = 0x9abcde00,
+          b = 0x0,
+          c = 0x123456789abcde00,
+        }
+        >>> print(xu)
+        {0x9abcde00, 0x0, 0x123456789abcde00}
+        >>> bytes(xu)
+        b'\x00\xde\xbc\x9axV4\x12'
+        >>> xu[:]
+        b'\x00\xde\xbc\x9axV4\x12'
+        >>> len(xu)
+        8
+        >>> xu[:1] = b'123'
+        Traceback (most recent call last):
+        ...
+        ValueError: Filling bytes larger than sliced memory
+        >>> xu[0] = b'123'
+        Traceback (most recent call last):
+        ...
+        ValueError: Can not access struct with 'int' subscript
+        >>> xu[-99:] = b'123'
+        Traceback (most recent call last):
+        ...
+        ValueError: Illegal index on memoryview
+        >>> xu.b = 9999
+        Traceback (most recent call last):
+        ...
+        ValueError: pack(): number does not fit within word_size [0, 9999, 256]
     """
 
     _fields_: list[tuple[str, CType]]
@@ -764,6 +1027,31 @@ class CUnion(PwnType):
 class CEnum(PwnType):
     """
     Base type of a C enum. This can be used to beautify struct output.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> from enum import IntEnum
+        >>> class XEnum(IntEnum):
+        ...     X1 = 1
+        ...     X2 = 2
+        ...
+        >>> class X(CEnum):
+        ...     _size_type_ = c_int
+        ...     _enum_ = XEnum
+        ...
+        >>> Xarr = mk_anonymous_carray(X, 1)
+        >>> e = Xarr()
+        >>> e[0] = 1
+        >>> e[0]
+        0x1 <XEnum.X1: 1>
+        >>> print(e[0])
+        0x1 <XEnum.X1>
+        >>> e[0] = 233
+        >>> e[0]
+        0xe9
+        >>> int(e[0])
+        233
     """
 
     _size_type_: CType
@@ -793,7 +1081,7 @@ class CEnum(PwnType):
             return
         raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
-    def copy_from(self, value: Any) -> type[Any] | None:
+    def _copy_from(self, value: Any) -> type[Any] | None:
         typ = super()._copy_from(value)
         if typ is None:
             return typ
@@ -829,12 +1117,35 @@ class CEnum(PwnType):
 
 class CFlag(PwnType):
     """
-    Base type of a C enum. This can be used to beautify struct output.
+    Base type of a C flag. This can be used to beautify struct output.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> from enum import IntFlag
+        >>> class XFlag(IntFlag):
+        ...     X1 = 1
+        ...     X2 = 2
+        ...
+        >>> class X(CFlag):
+        ...     _size_type_ = c_int
+        ...     _flag_ = XFlag
+        ...
+        >>> Xarr = mk_anonymous_carray(X, 1)
+        >>> f = Xarr()
+        >>> f[0] = 1
+        >>> f[0]
+        0x1 <XFlag.X1: 1>
+        >>> f[0] = XFlag.X1 | XFlag.X2
+        >>> print(f[0])
+        0x3 <XFlag.X1|X2>
+        >>> int(f[0])
+        3
     """
 
     _size_type_: CType
     """
-    Defines how many bytes this enum takes.
+    Defines how many bytes this flag takes.
     """
     _flag_: type[IntFlag]
     """
@@ -859,7 +1170,7 @@ class CFlag(PwnType):
             return
         raise ValueError(f"'{_type(key)}' is not supported to access '{_type(self)}'")
 
-    def copy_from(self, value: Any) -> type[Any] | None:
+    def _copy_from(self, value: Any) -> type[Any] | None:
         typ = super()._copy_from(value)
         if typ is None:
             return typ
@@ -892,6 +1203,15 @@ def mk_anonymous_carray(
 ) -> type[CArray[CompCValue]]:
     """
     Factory function to generate an anonymous ``CArray``.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> mk_anonymous_carray(c_int, 2)()
+        [
+          0x0,
+          0x0,
+        ]
     """
     fields: dict[str, Any] = {'_type_': elem_type, '_count_': count}
     if align:
@@ -902,6 +1222,12 @@ def mk_anonymous_carray(
 def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
     """
     Factory function to generate an anonymous ``CCharArray``.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> mk_anonymous_cchararray(5)(memoryview(b'hello'))
+        <68 65 6c 6c 6f  |hello|>
     """
     fields: dict[str, Any] = {'_type_': c_char, '_count_': count}
     if align:
@@ -914,6 +1240,14 @@ def mk_anonymous_cstruct(
 ) -> type[CStruct]:
     """
     Factory function to generate an anonymous ``CStruct``.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> mk_anonymous_cstruct([('aaa', c_int)])()
+        {
+          +0x0 aaa = 0x0,
+        }
     """
     return type('', (CStruct,), {'_fields_': fields})
 
@@ -921,5 +1255,14 @@ def mk_anonymous_cstruct(
 def mk_anonymous_cunion(fields: list[tuple[str, CType]]) -> type[CUnion]:
     """
     Factory function to generate an anonymous ``CUnion``.
+
+    Examples:
+        >>> from pwnlib.util.c_primitives import *
+        >>> from ctypes import *
+        >>> mk_anonymous_cunion([('x', c_int), ('y', c_char)])()
+        {
+          x = 0x0,
+          y = 0x0,
+        }
     """
     return type('', (CUnion,), {'_fields_': fields})

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -237,6 +237,11 @@ class PwnType:
     buffer to construct a ``memoryview`` object) so later variables can be read
     directly on memory. In this case, setting underlying memory buffer can affect
     variable value, helping pwners write exploits painlessly.
+
+    Arguments:
+        view: Pass an existing memory view so that variables will be placed on that
+              region of memory later, or ``None`` to allocate a new region of memory
+              to place variables.
     """
 
     _32_size_cache_: int
@@ -491,6 +496,20 @@ class PwnType:
         return self._view == value._view
 
     def _normalize_slice(self, s: slice) -> slice:
+        """
+        Normalize ``start`` and ``stop`` in the slice and reject ``step`` if not
+        ``None`` so that the slice can be passed to access the underlying memory view.
+
+        Arguments:
+            s: A ``slice`` from user's code.
+
+        Returns:
+            A ``slice`` which fits in ``[0, self._len)``.
+
+        Raises:
+            ValueError: ``step`` is not ``None`` in user's slice.
+            IndexError: Index in slice is illegal against underlying memory view.
+        """
         if s.step is not None:
             raise ValueError(f'Slice step is not supported')
         start = s.start
@@ -508,24 +527,48 @@ class PwnType:
         elif stop > self._len:
             stop = self._len
         if start < 0 or stop < 0:
-            raise ValueError(f'Illegal index on memoryview')
+            raise IndexError(f'Illegal index on memoryview')
         if start >= stop:
-            raise ValueError(f'Illegal access range on memoryview')
+            raise IndexError(f'Illegal access range on memoryview')
         return slice(start, stop, None)
 
     def _get_slice(self, subscript: Any) -> bytes | None:
         """
         A helper method to allow user to get object's underlying memory with ``slice``.
+
+        Arguments:
+            subscript: The key within ``[]`` when user tries to access ``PwnType``
+                       instance.
+
+        Returns:
+            A ``bytes`` object if user is accessing ``PwnType`` with ``slice``, or else
+            the ``None``.
+
+        Raises:
+            IndexError: See :func:`pwnlib.util.c_primitives._normalize_slice`.
+            ValueError: See :func:`pwnlib.util.c_primitives._normalize_slice`.
         """
         if isinstance(subscript, slice):
-            s = self._normalize_slice(subscript)
-            return bytes(self._view[s.start:s.stop])
+            return bytes(self._view[self._normalize_slice(subscript)])
         return None
 
     def _set_slice(self, subscript: Any, value: Any) -> bool:
         """
         A helper method to allow user to set object's underlying memory with ``slice``
-        and a buffer with the same size as the object.
+        and a buffer.
+
+        Arguments:
+            subscript: The key within ``[]`` when user tries to access ``PwnType``
+                       instance.
+
+        Returns:
+            Whether the underlying memory view is set with ``value`` successfully.
+
+        Raises:
+            IndexError: See :func:`pwnlib.util.c_primitives._normalize_slice`.
+            ValueError: See :func:`pwnlib.util.c_primitives._normalize_slice`. Setting
+                        memory view with ``value`` which is incompatible with ``bytes``,
+                        or ``value`` is larger than memory view.
         """
         if isinstance(subscript, slice):
             s = self._normalize_slice(subscript)
@@ -535,7 +578,7 @@ class PwnType:
             data = _need_bytes(value)
             if len(data) > s.stop - s.start:
                 raise ValueError(f'Filling bytes larger than sliced memory')
-            self._view[s.start:s.stop] = data.ljust(s.stop - s.start, b'\x00')
+            self._view[s] = data.ljust(s.stop - s.start, b'\x00')
             return True
         return False
 
@@ -667,7 +710,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
     _count_: int
     """
     The count of elements in array. This value can be ``0`` if and only if the array is
-    constructed with a ``memoryview``, and the length of that memoryview is not ``0``.
+    constructed with a ``memoryview``, and the length of that memoryview is not 0.
     An internal count will be calculated in that case so user still have bound
     restrictions when accessing elements.
     """

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -325,10 +325,10 @@ class BaseCType(Enum):
             case BaseCType.void_p:
                 return context.bytes
             case BaseCType.wchar_t:
-                return 4 if context.os == 'linux' else 2  # Windows use UTF-16
+                return 2 if context.os == 'windows' else 4  # Windows use UTF-16
             case BaseCType.long_double:
                 if context.arch == 'i386' and context.os == 'linux':
-                    return 3
+                    return 12
                 return context.bytes * 2
             case BaseCType.long:
                 if context.os == 'linux':
@@ -456,7 +456,7 @@ class PwnType:
         align_attr = f'_{context.bits}_align_cache_'
         if hasattr(typ, align_attr):
             return getattr(typ, align_attr)
-        if issubclass(typ, (CStruct, CUnion)):
+        if issubclass(typ, CStruct):
             if all(len(field) == 4 for field in typ._fields_):
                 # this is a packed struct
                 align = 1
@@ -465,6 +465,8 @@ class PwnType:
                     PwnType._calc_align(f[1][0] if isinstance(f[1], tuple) else f[1])
                     for f in typ._fields_
                 )
+        elif issubclass(typ, CUnion):
+            align = max(PwnType._calc_align(f[1]) for f in typ._fields_)
         elif issubclass(typ, CArray):
             if hasattr(typ, '_align_'):  # here _align_ is type-range
                 align = typ._align_
@@ -546,8 +548,7 @@ class PwnType:
             setattr(typ, bitfield_attr, bitfields)
             setattr(typ, offset_table_attr, offsets)
             align = PwnType._calc_align(typ)
-            struct_len = ((struct_len + align - 1) // align) * align
-            size_cache = struct_len
+            size_cache = ((struct_len + align - 1) // align) * align
         elif issubclass(typ, CArray):
             if typ._count_ == 0:
                 return 0
@@ -556,7 +557,9 @@ class PwnType:
             else:
                 size_cache = PwnType._calc_size(typ._type_) * typ._count_
         elif issubclass(typ, CUnion):
-            size_cache = max(PwnType._calc_size(field[1]) for field in typ._fields_)
+            max_size = max(PwnType._calc_size(field[1]) for field in typ._fields_)
+            align = PwnType._calc_align(typ)
+            size_cache = ((max_size + align - 1) // align) * align
         elif issubclass(typ, CEnum):
             size_cache = PwnType._calc_size(typ._size_type_)
         else:
@@ -1429,6 +1432,8 @@ class CUnion(PwnType):
         >>> xu[:]
         b'\x00\xde\xbc\x9axV4\x12'
         >>> len(xu)
+        8
+        >>> len(mk_anonymous_cunion([('a', mk_anonymous_cchararray(5)), ('b', BaseCType.int)])())
         8
         >>> xu[:1] = b'123'
         Traceback (most recent call last):

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -1217,7 +1217,7 @@ def mk_anonymous_carray(
     return type(f'AnonymousCArray[{_type(elem_type)}]', (CArray,), fields)
 
 
-def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
+def mk_anonymous_cchararray(count: int) -> type[CCharArray]:
     """
     Factory function to generate an anonymous ``CCharArray``.
 
@@ -1228,8 +1228,6 @@ def mk_anonymous_cchararray(count: int, align: int = 0) -> type[CCharArray]:
         <68 65 6c 6c 6f  |hello|>
     """
     fields: dict[str, Any] = {'_type_': c_char, '_count_': count}
-    if align:
-        fields['_align_'] = align
     return type('AnonymousCCharArray', (CCharArray,), fields)
 
 

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -85,13 +85,13 @@ Examples:
     24
     >>> len(pkt)
     80
-    >>> pkt.header.tag = ord('M')
+    >>> pkt.header.tag = b'M'
     >>> pkt.header.perm = Perm.R
     >>> pkt.header.cursor = 0x1122334455667788
     >>> pkt.header.kind = Token.READ + 0xaa00
     >>> pkt.header.name = b'payload!'
-    >>> pkt.payload.pair.lo = 0xbeef
-    >>> pkt.payload.pair.target = 0x4041424344454647
+    >>> pkt.payload[:2] = b'\xef\xbe'
+    >>> pkt.payload['pair'].target = 0x4041424344454647
     >>> pkt.payload.pair.tail = 0x21444150
     >>> pkt.tokens[0] = Token.READ
     >>> pkt.tokens[1] = 0x99
@@ -133,6 +133,14 @@ Examples:
     }
     >>> print(pkt)
     {{0x4d, 0x1 <Perm.R>, 0x214e575055667788, 0x2 <Token.WRITE>, <70 61 79 6c 6f 61 64 21>}, {<ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00 2f 62 69 6e 2f 73 68 00>, [0xbeef, 0x4647, 0x4445], {0xbeef, 0x4041424344454647, 0x21444150}}, [0x1 <Token.READ>, 0x99], 0x4 <Perm.X>, 0x7f0643fa3f60}
+    >>> pkt.header = b' ' * 0x100
+    Traceback (most recent call last):
+    ...
+    ValueError: Setting bytes larger than AutoHeader
+    >>> newraw = Raw()
+    >>> pkt.payload.raw = newraw
+    >>> print(pkt.payload.raw)
+    <00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
 """
 
 from __future__ import annotations
@@ -178,6 +186,23 @@ VAR_TYPES: list[BaseCType] = [
 
 
 def _type(o: Any) -> str:
+    """
+    A helper function to get a simplified type name of an object.
+
+    Arguments:
+        o: An ``object`` or a ``type``. If ``o`` is ``object``, cast it to ``type``
+        first.
+
+    Returns:
+        The simplified type name of ``o``.
+
+    Examples:
+        >>> from pwnlib.util import c_primitives
+        >>> c_primitives._type('')
+        'str'
+        >>> c_primitives._type(str)
+        'str'
+    """
     if isinstance(o, type):
         return o.__name__
     return type(o).__name__
@@ -549,6 +574,8 @@ class CArray(PwnType, Generic[ArrayItemT]):
     objects.
 
     Examples:
+        A named array with 4 ints:
+
         >>> from pwnlib.util.c_primitives import *
         >>> from ctypes import *
         >>> class Int4(CArray):
@@ -557,7 +584,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
         ...
         >>> buf = bytearray(32)
         >>> arr = Int4(memoryview(buf))
-        >>> arr[0] = 0x13371337
+        >>> arr[-4] = 0x13371337
         >>> arr[5:9] = b'\xde\xad\xbe\xef'
         >>> buf[:20]
         bytearray(b'7\x137\x13\x00\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -572,12 +599,65 @@ class CArray(PwnType, Generic[ArrayItemT]):
           0xef,
           0x0,
         ]
-        >>> print(arr)
-        [0x13371337, 0xbeadde00, 0xef, 0x0]
+        >>> for e in arr:
+        ...     print(e)
+        322376503
+        3199065600
+        239
+        0
         >>> arr[2:6]
         b'7\x13\x00\xde'
         >>> arr[1]
         3199065600
+        >>> arr[1] == arr[-3]
+        True
+
+        An anonymous array with 2 composite type elements and 8 as alignment:
+
+        >>> anon_struct = mk_anonymous_cstruct([('k', c_char), ('v', c_ushort)])
+        >>> anon_cls = mk_anonymous_carray(anon_struct, 2, 8)
+        >>> anon = anon_cls()
+        >>> len(anon)
+        16
+        >>> anon[0] = None
+        Traceback (most recent call last):
+        ...
+        ValueError: Can't set AnonymousCStruct with NoneType
+        >>> anon[0] = b'KVPR'
+        >>> print(next(iter(anon)))
+        {0x4b, 0x5250}
+        >>> class DictLen(CStruct):
+        ...     _fields_ = [
+        ...         ('dict', anon_cls),
+        ...         ('capacity', c_int),
+        ...     ]
+        ...
+        >>> DictLen().offsetof('capacity')
+        16
+        >>> len(DictLen())
+        24
+
+        Array length can be 0, but the only way to use it is via ``CStruct``.
+
+        >>> from pwnlib.util.packing import p64
+        >>> class Chunk(CStruct):
+        ...     _fields_ = [
+        ...         ('prev_size', c_ulong),
+        ...         ('size', c_long),
+        ...         ('chunk', mk_anonymous_cchararray(0)),
+        ...     ]
+        ...
+        >>> context.clear(arch='amd64')
+        >>> buf = p64(0) + p64(0x21) + b''.ljust(0x10, b'A') + p64(0x20)
+        >>> Chunk(memoryview(buf))
+        {
+          +0x0  prev_size = 0x0,
+          +0x8  size = 0x21,
+          +0x10 chunk = <
+            41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41  |AAAAAAAAAAAAAAAA|
+            20 00 00 00 00 00 00 00                          | .......|
+          >,
+        }
     """
 
     _type_: CType
@@ -1068,6 +1148,9 @@ class CEnum(PwnType):
         0xe9
         >>> int(e[0])
         233
+        >>> e[0][:1] = b'\x02'
+        >>> e[0] == 2 and e[0] == X(b'\x02\x00\x00\x00')
+        True
     """
 
     _size_type_: CType
@@ -1157,6 +1240,10 @@ class CFlag(CEnum):
         0x2 <XFlag.X2>
         >>> int(f[0])
         2
+        >>> f[0] == 2
+        True
+        >>> f[0][:1].hex()
+        '02'
     """
 
     _size_type_: CType

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -94,7 +94,7 @@ Examples:
     >>> pkt.payload.pair.tail = 0x21444150
     >>> pkt.tokens[0] = Token.READ
     >>> pkt.tokens[1] = 0x99
-    >>> pkt.perm = Perm.W | Perm.X
+    >>> pkt.perm = Perm.X
     >>> pkt.handler = 0x7f0643fa3f60
     >>> pkt.header[12:20] = b'PWN!\x02'
     >>> pkt[0x30:0x38] = b'/bin/sh'
@@ -127,11 +127,11 @@ Examples:
         0x1 <Token.READ: 1>,
         0x99,
       ],
-      +0x40 perm = 0x6 <Perm.W|X: 6>,
+      +0x40 perm = 0x4 <Perm.X: 4>,
       +0x48 handler = 0x7f0643fa3f60,
     }
     >>> print(pkt)
-    {{0x4d, 0x1 <Perm.R>, 0x214e575055667788, 0x2 <Token.WRITE>, <70 61 79 6c 6f 61 64 21>}, {<ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00 2f 62 69 6e 2f 73 68 00>, [0xbeef, 0x4647, 0x4445], {0xbeef, 0x4041424344454647, 0x21444150}}, [0x1 <Token.READ>, 0x99], 0x6 <Perm.W|X>, 0x7f0643fa3f60}
+    {{0x4d, 0x1 <Perm.R>, 0x214e575055667788, 0x2 <Token.WRITE>, <70 61 79 6c 6f 61 64 21>}, {<ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00 2f 62 69 6e 2f 73 68 00>, [0xbeef, 0x4647, 0x4445], {0xbeef, 0x4041424344454647, 0x21444150}}, [0x1 <Token.READ>, 0x99], 0x4 <Perm.X>, 0x7f0643fa3f60}
 """
 
 from __future__ import annotations
@@ -1136,11 +1136,11 @@ class CFlag(PwnType):
         >>> f[0] = 1
         >>> f[0]
         0x1 <XFlag.X1: 1>
-        >>> f[0] = XFlag.X1 | XFlag.X2
+        >>> f[0] = XFlag.X2
         >>> print(f[0])
-        0x3 <XFlag.X1|X2>
+        0x2 <XFlag.X2>
         >>> int(f[0])
-        3
+        2
     """
 
     _size_type_: CType

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -30,7 +30,6 @@ Examples:
         };
 
         typedef char Name[8];
-        typedef char Raw[24];
         typedef unsigned short Scores[3];
 
         struct AutoHeader {
@@ -45,10 +44,11 @@ Examples:
             unsigned short lo;
             void *target;
             unsigned int tail;
+            unsigned int extra;
         };
 
         union Payload {
-            Raw raw;
+            char raw[0];
             Scores scores;
             struct ManualPair pair;
         };
@@ -85,9 +85,6 @@ Examples:
     >>> class Name(CCharArray):
     ...     _count_ = 8
     ...
-    >>> class Raw(CCharArray):
-    ...     _count_ = 24
-    ...
     >>> class Scores(CArray):
     ...     _type_ = BaseCType.ushort
     ...     _count_ = 3
@@ -107,11 +104,12 @@ Examples:
     ...         ('lo', BaseCType.ushort, 0, 0),
     ...         ('target', BaseCType.void_p, 2, 2),
     ...         ('tail', BaseCType.uint, 10, 10),
+    ...         ('extra', BaseCType.uint, 14, 14),
     ...     ]
     ...
     >>> class Payload(CUnion):
     ...     _fields_ = [
-    ...         ('raw', Raw),
+    ...         ('raw', mk_anonymous_cchararray(0)),
     ...         ('scores', Scores),
     ...         ('pair', ManualPair),
     ...     ]
@@ -129,9 +127,9 @@ Examples:
     >>> pkt.payload.pair.offsetof('tail')
     10
     >>> len(pkt.payload)
-    24
+    18
     >>> len(pkt)
-    80
+    72
     >>> pkt.header.tag = b'M'
     >>> pkt.header.perm = Perm.R
     >>> pkt.header.cursor = 0x1122334455667788
@@ -145,7 +143,6 @@ Examples:
     >>> pkt.perm = Perm.X
     >>> pkt.handler = 0x7f0643fa3f60
     >>> pkt.header[12:20] = b'PWN!\x02'
-    >>> pkt[0x30:0x38] = b'/bin/sh'
     >>> pkt
     {
       +0x0  header = {
@@ -158,7 +155,7 @@ Examples:
       +0x20 payload = {
         raw = <
           ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00  |..GFEDCBA@PAD!..|
-          2f 62 69 6e 2f 73 68 00                          |/bin/sh.|
+          00 00                                            |..|
         >,
         scores = [
           0xbeef,
@@ -169,25 +166,26 @@ Examples:
           +0x0 lo = 0xbeef,
           +0x2 target = 0x4041424344454647,
           +0xa tail = 0x21444150,
+          +0xe extra = 0x0,
         },
       },
-      +0x38 tokens = [
+      +0x34 tokens = [
         0x1 <Token.READ: 1>,
         0x99,
       ],
-      +0x40 perm = 0x4 <Perm.X: 4>,
-      +0x48 handler = 0x7f0643fa3f60,
+      +0x3c perm = 0x4 <Perm.X: 4>,
+      +0x40 handler = 0x7f0643fa3f60,
     }
     >>> print(pkt)
-    {{0x4d, 0x1 <Perm.R>, 0x214e575055667788, 0x2 <Token.WRITE>, <70 61 79 6c 6f 61 64 21>}, {<ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00 2f 62 69 6e 2f 73 68 00>, [0xbeef, 0x4647, 0x4445], {0xbeef, 0x4041424344454647, 0x21444150}}, [0x1 <Token.READ>, 0x99], 0x4 <Perm.X>, 0x7f0643fa3f60}
+    {{0x4d, 0x1 <Perm.R>, 0x214e575055667788, 0x2 <Token.WRITE>, <70 61 79 6c 6f 61 64 21>}, {<ef be 47 46 45 44 43 42 41 40 50 41 44 21 00 00 00 00>, [0xbeef, 0x4647, 0x4445], {0xbeef, 0x4041424344454647, 0x21444150, 0x0}}, [0x1 <Token.READ>, 0x99], 0x4 <Perm.X>, 0x7f0643fa3f60}
     >>> pkt.header = b' ' * 0x100
     Traceback (most recent call last):
     ...
     ValueError: Setting bytes larger than AutoHeader
-    >>> newraw = Raw()
-    >>> pkt.payload['raw'] = newraw
+    >>> newscore = Scores()
+    >>> pkt.payload['scores'] = newscore
     >>> print(pkt.payload.raw)
-    <00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
+    <00 00 00 00 00 00 43 42 41 40 50 41 44 21 00 00 00 00>
 """
 
 from __future__ import annotations
@@ -256,14 +254,18 @@ class BaseCType(Enum):
     x86_64, ``c_longlong is c_long``, which means we have no way to distinguish it to
     calculate correct size when crossing architecture. This enum implement functions
     to provide correct type size and alignment on each platform in a hacky way.
+
+    The basic data types are gathered by looking up keywords and including ``stdint.h``
+    and ``stddef.h``.
     """
 
     char = 0
     byte = 1
     schar = 2
     uchar = 3
-    int8_t = 4
-    uint8_t = 5
+    bool = 4
+    int8_t = 5
+    uint8_t = 6
 
     short = 0x10
     word = 0x11
@@ -300,7 +302,8 @@ class BaseCType(Enum):
     @staticmethod
     def sizeof(e: BaseCType) -> builtins.int:
         """
-        Returns ``sizeof(type)``.
+        Returns ``sizeof(type)``. Some special sizes are confirmed via ``zig cc``
+        cross compiler.
 
         Arguments:
             e: One of ``BaseCType`` enums.
@@ -336,7 +339,8 @@ class BaseCType(Enum):
     @staticmethod
     def alignof(e: BaseCType) -> builtins.int:
         """
-        Returns ``alignof(type)``.
+        Returns ``alignof(type)``. Some special alignments are confirmed via ``zig cc``
+        cross compiler.
 
         Arguments:
             e: One of ``BaseCType`` enums.
@@ -358,7 +362,7 @@ class PwnType:
 
     All variables, including basic C types, are not stored with value directly. Instead,
     the component offset and size is stored, and the actual value is fetched via memory.
-    Every composite type stores a ``memoryview`` object on initialization (or create a
+    Every composite type stores a ``memoryview`` object on initialization (or creates a
     buffer to construct a ``memoryview`` object) so later variables can be read
     directly on memory. In this case, setting underlying memory buffer can affect
     variable value, helping pwners write exploits painlessly.
@@ -764,6 +768,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
         A named array with 4 ints:
 
         >>> from pwnlib.util.c_primitives import *
+        >>> context.clear(arch='i386')
         >>> class Int4(CArray):
         ...     _type_ = BaseCType.int
         ...     _count_ = 4
@@ -844,6 +849,18 @@ class CArray(PwnType, Generic[ArrayItemT]):
             20 00 00 00 00 00 00 00                          | .......|
           >,
         }
+
+        Initialize a 0-size array with ``None`` or 0-size ``memoryview`` is invalid.
+
+        >>> vararr = mk_anonymous_carray(BaseCType.int, 0)
+        >>> vararr()
+        Traceback (most recent call last):
+        ...
+        BufferError: Allocating zero-length array
+        >>> vararr(memoryview(b''))
+        Traceback (most recent call last):
+        ...
+        BufferError: Zero-length array has no writable memory
     """
 
     _type_: CType
@@ -1248,6 +1265,8 @@ class CUnion(PwnType):
             else:
                 size = PwnType._calc_size(field_t)
                 assert issubclass(field_t, PwnType)
+                if issubclass(field_t, CArray) and size == 0:
+                    size = self._len
                 self._components[field[0]] = field_t(self._view[:size])
 
     def __getattr__(self, name: str) -> CompCValue:

--- a/pwnlib/util/c_primitives.py
+++ b/pwnlib/util/c_primitives.py
@@ -1,7 +1,7 @@
 r"""
 A generic module to construct C data types with pure Python. Downstream data types may
-consider combine basic types in ``ctypes`` and ``CArray``, ``CStruct`` and ``CUnion``
-in this module to implement basically all C types.
+combine basic types in ``BaseCType`` and ``CArray``, ``CStruct`` and ``CUnion`` in
+this module to implement basically all C types.
 
 This module provides some features that ``ctypes`` can not:
 
@@ -62,7 +62,6 @@ Examples:
         };
 
     >>> from pwnlib.util.c_primitives import *
-    >>> from ctypes import *
     >>> from enum import IntEnum, IntFlag
     >>> context.clear(arch='amd64')
     >>> class Token(IntEnum):
@@ -76,11 +75,11 @@ Examples:
     ...     X = 4
     ...
     >>> class CToken(CEnum):
-    ...     _size_type_ = c_uint
+    ...     _size_type_ = BaseCType.uint
     ...     _disp_type_ = Token
     ...
     >>> class CPerm(CFlag):
-    ...     _size_type_ = c_ubyte
+    ...     _size_type_ = BaseCType.uchar
     ...     _disp_type_ = Perm
     ...
     >>> class Name(CCharArray):
@@ -90,24 +89,24 @@ Examples:
     ...     _count_ = 24
     ...
     >>> class Scores(CArray):
-    ...     _type_ = c_ushort
+    ...     _type_ = BaseCType.ushort
     ...     _count_ = 3
     ...
     >>> Tokens = mk_anonymous_carray(CToken, 2)
     >>> class AutoHeader(CStruct):
     ...     _fields_ = [
-    ...         ('tag', c_char),
+    ...         ('tag', BaseCType.char),
     ...         ('perm', CPerm),
-    ...         ('cursor', c_void_p),
+    ...         ('cursor', BaseCType.void_p),
     ...         ('kind', CToken),
     ...         ('name', Name),
     ...     ]
     ...
     >>> class ManualPair(CStruct):
     ...     _fields_ = [
-    ...         ('lo', c_ushort, 0, 0),
-    ...         ('target', c_void_p, 2, 2),
-    ...         ('tail', c_uint, 10, 10),
+    ...         ('lo', BaseCType.ushort, 0, 0),
+    ...         ('target', BaseCType.void_p, 2, 2),
+    ...         ('tail', BaseCType.uint, 10, 10),
     ...     ]
     ...
     >>> class Payload(CUnion):
@@ -123,7 +122,7 @@ Examples:
     ...         ('payload', Payload),
     ...         ('tokens', Tokens),
     ...         ('perm', CPerm),
-    ...         ('handler', c_void_p),
+    ...         ('handler', BaseCType.void_p),
     ...     ]
     ...
     >>> pkt = Packet()
@@ -193,44 +192,21 @@ Examples:
 
 from __future__ import annotations
 
+import builtins
 from collections import OrderedDict
 from collections.abc import Iterator
-from ctypes import (
-    _SimpleCData,
-    c_char,
-    c_char_p,
-    c_long,
-    c_size_t,
-    c_ssize_t,
-    c_ulong,
-    c_void_p,
-    c_wchar_p,
-    sizeof,
-)
 from enum import Enum, Flag, IntEnum, IntFlag
 from io import StringIO, TextIOBase
-from typing import Any, Generic, TypeAlias, TypeVar, cast, overload
+from typing import Any, Generic, TypeAlias, TypeVar, overload
 
 from pwnlib.context import context
 from pwnlib.util.packing import _need_bytes, pack, unpack
 
-BaseCType: TypeAlias = type[_SimpleCData]
 CompCType: TypeAlias = type['PwnType']
-CType: TypeAlias = BaseCType | CompCType
+CType: TypeAlias = 'BaseCType | CompCType'
 CompCValue: TypeAlias = 'int | PwnType'
 BytesLike: TypeAlias = str | bytes | bytearray
 ArrayItemT = TypeVar('ArrayItemT', bound='CompCValue')
-
-CTYPE_BASE = cast(BaseCType, c_long.__base__)
-VAR_TYPES: list[BaseCType] = [
-    c_void_p,
-    c_char_p,
-    c_wchar_p,
-    c_size_t,
-    c_ssize_t,
-    c_ulong,
-    c_long,
-]
 
 
 def _type(o: Any) -> str:
@@ -272,6 +248,107 @@ def _remove_non_verbose_tail(s: TextIOBase, v: bool) -> None:
     if not v:
         s.seek(s.tell() - 2)
         s.truncate()
+
+
+class BaseCType(Enum):
+    """
+    Basic C types presented in enum. Types from ``ctypes`` is not reliable because on
+    x86_64, ``c_longlong is c_long``, which means we have no way to distinguish it to
+    calculate correct size when crossing architecture. This enum implement functions
+    to provide correct type size and alignment on each platform in a hacky way.
+    """
+
+    char = 0
+    byte = 1
+    schar = 2
+    uchar = 3
+    int8_t = 4
+    uint8_t = 5
+
+    short = 0x10
+    word = 0x11
+    ushort = 0x12
+    int16_t = 0x13
+    uint16_t = 0x14
+
+    int = 0x20
+    dword = 0x21
+    uint = 0x22
+    int32_t = 0x23
+    uint32_t = 0x24
+    float = 0x25
+
+    long = 0x30
+    ulong = 0x31
+
+    void_p = 0x40
+    size_t = 0x41
+    ssize_t = 0x42
+    ptrdiff_t = 0x43
+
+    longlong = 0x50
+    qword = 0x51
+    ulonglong = 0x52
+    int64_t = 0x53
+    uint64_t = 0x54
+    double = 0x55
+
+    wchar_t = 0x60
+
+    long_double = 0x70
+
+    @staticmethod
+    def sizeof(e: BaseCType) -> builtins.int:
+        """
+        Returns ``sizeof(type)``.
+
+        Arguments:
+            e: One of ``BaseCType`` enums.
+
+        Returns:
+            The C-level size of ``e``.
+        """
+        enum_type = BaseCType(e.value & 0xF0)
+        match enum_type:
+            case BaseCType.char:
+                return 1
+            case BaseCType.short:
+                return 2
+            case BaseCType.int:
+                return 4
+            case BaseCType.longlong:
+                return 8
+            case BaseCType.void_p:
+                return context.bytes
+            case BaseCType.wchar_t:
+                return 4 if context.os == 'linux' else 2  # Windows use UTF-16
+            case BaseCType.long_double:
+                if context.arch == 'i386' and context.os == 'linux':
+                    return 3
+                return context.bytes * 2
+            case BaseCType.long:
+                if context.os == 'linux':
+                    return context.bytes
+                return 4  # Windows
+            case _:
+                raise NotImplementedError
+
+    @staticmethod
+    def alignof(e: BaseCType) -> builtins.int:
+        """
+        Returns ``alignof(type)``.
+
+        Arguments:
+            e: One of ``BaseCType`` enums.
+
+        Returns:
+            The C-level alignment requirement of ``e``.
+        """
+        if context.arch == 'i386' and context.os == 'linux':
+            return min(4, BaseCType.sizeof(e))
+        if e is BaseCType.long_double and context.arch == 's390x':
+            return 8
+        return BaseCType.sizeof(e)
 
 
 class PwnType:
@@ -355,8 +432,8 @@ class PwnType:
         align is basically equal to the size of the type. As for composite types, the
         align is the max align in members.
         """
-        if issubclass(typ, CTYPE_BASE):
-            return PwnType._calc_size(typ)
+        if isinstance(typ, BaseCType):
+            return BaseCType.alignof(typ)
         align_attr = f'_{context.bits}_align_cache_'
         if hasattr(typ, align_attr):
             return getattr(typ, align_attr)
@@ -385,10 +462,10 @@ class PwnType:
         set all struct member offsets, it is considered that the struct is packed, or
         else the struct size will align up. (The default not-packed bahavior.)
         """
+        if isinstance(typ, BaseCType):
+            return BaseCType.sizeof(typ)
         if not isinstance(typ, type):
             typ = type(typ)
-        if issubclass(typ, CTYPE_BASE):
-            return context.bytes if typ in VAR_TYPES else sizeof(typ)
         cache_attr = f'_{context.bits}_size_cache_'
         if hasattr(typ, cache_attr):
             return getattr(typ, cache_attr)
@@ -687,9 +764,8 @@ class CArray(PwnType, Generic[ArrayItemT]):
         A named array with 4 ints:
 
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
         >>> class Int4(CArray):
-        ...     _type_ = c_int
+        ...     _type_ = BaseCType.int
         ...     _count_ = 4
         ...
         >>> buf = bytearray(32)
@@ -724,7 +800,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
 
         An anonymous array with 2 composite type elements and 8 as alignment:
 
-        >>> anon_struct = mk_anonymous_cstruct([('k', c_char), ('v', c_ushort)])
+        >>> anon_struct = mk_anonymous_cstruct([('k', BaseCType.char), ('v', BaseCType.ushort)])
         >>> anon_cls = mk_anonymous_carray(anon_struct, 2, 8)
         >>> anon = anon_cls()
         >>> len(anon)
@@ -739,7 +815,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
         >>> class DictLen(CStruct):
         ...     _fields_ = [
         ...         ('dict', anon_cls),
-        ...         ('capacity', c_int),
+        ...         ('capacity', BaseCType.int),
         ...     ]
         ...
         >>> DictLen().offsetof('capacity')
@@ -752,8 +828,8 @@ class CArray(PwnType, Generic[ArrayItemT]):
         >>> from pwnlib.util.packing import p64
         >>> class Chunk(CStruct):
         ...     _fields_ = [
-        ...         ('prev_size', c_ulong),
-        ...         ('size', c_long),
+        ...         ('prev_size', BaseCType.ulong),
+        ...         ('size', BaseCType.long),
         ...         ('chunk', mk_anonymous_cchararray(0)),
         ...     ]
         ...
@@ -808,7 +884,7 @@ class CArray(PwnType, Generic[ArrayItemT]):
             self._len = len(self._view)
             self._int_count = self._len // self._align_
 
-        if issubclass(self._type_, CTYPE_BASE):
+        if isinstance(self._type_, BaseCType):
             self._components = None
         else:
             step = self._align_
@@ -905,7 +981,7 @@ class CCharArray(CArray[int]):
     hexdump of elements.
     """
 
-    _type_ = c_char
+    _type_ = BaseCType.char
 
 
 class CStruct(PwnType):
@@ -915,12 +991,11 @@ class CStruct(PwnType):
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
         >>> class CString(CStruct):
         ...     _fields_ = [
-        ...         ('size', c_uint),
-        ...         ('flag', c_char, 3, 3),
-        ...         ('string', c_char_p),
+        ...         ('size', BaseCType.uint),
+        ...         ('flag', BaseCType.char, 3, 3),
+        ...         ('string', BaseCType.void_p),
         ...     ]
         ...     # recommends adding type hints to enable LSP auto completion
         ...     size: int
@@ -1001,7 +1076,7 @@ class CStruct(PwnType):
         for field in self._fields_:
             field_t = field[1]
             off = self._int_offsets[field[0]]
-            if issubclass(field_t, CTYPE_BASE):
+            if isinstance(field_t, BaseCType):
                 self._components[field[0]] = PwnType._calc_size(field[1])
             else:
                 size = PwnType._calc_size(field_t)
@@ -1107,12 +1182,11 @@ class CUnion(PwnType):
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
         >>> class XU(CUnion):
         ...     _fields_ = [
-        ...         ('a', c_uint),
-        ...         ('b', c_char),
-        ...         ('c', c_longlong),
+        ...         ('a', BaseCType.uint),
+        ...         ('b', BaseCType.char),
+        ...         ('c', BaseCType.longlong),
         ...     ]
         ...
         >>> xu = XU()
@@ -1169,7 +1243,7 @@ class CUnion(PwnType):
         self._components = OrderedDict()
         for field in self._fields_:
             field_t = field[1]
-            if issubclass(field_t, CTYPE_BASE):
+            if isinstance(field_t, BaseCType):
                 self._components[field[0]] = PwnType._calc_size(field_t)
             else:
                 size = PwnType._calc_size(field_t)
@@ -1236,14 +1310,13 @@ class CEnum(PwnType):
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
         >>> from enum import IntEnum
         >>> class XEnum(IntEnum):
         ...     X1 = 1
         ...     X2 = 2
         ...
         >>> class X(CEnum):
-        ...     _size_type_ = c_int
+        ...     _size_type_ = BaseCType.int
         ...     _disp_type_ = XEnum
         ...
         >>> Xarr = mk_anonymous_carray(X, 1)
@@ -1329,14 +1402,13 @@ class CFlag(CEnum):
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
         >>> from enum import IntFlag
         >>> class XFlag(IntFlag):
         ...     X1 = 1
         ...     X2 = 2
         ...
         >>> class X(CFlag):
-        ...     _size_type_ = c_int
+        ...     _size_type_ = BaseCType.int
         ...     _disp_type_ = XFlag
         ...
         >>> Xarr = mk_anonymous_carray(X, 1)
@@ -1387,8 +1459,7 @@ def mk_anonymous_carray(
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
-        >>> mk_anonymous_carray(c_int, 2)()
+        >>> mk_anonymous_carray(BaseCType.int, 2)()
         [
           0x0,
           0x0,
@@ -1406,11 +1477,10 @@ def mk_anonymous_cchararray(count: int) -> type[CCharArray]:
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
         >>> mk_anonymous_cchararray(5)(memoryview(b'hello'))
         <68 65 6c 6c 6f  |hello|>
     """
-    fields: dict[str, Any] = {'_type_': c_char, '_count_': count}
+    fields: dict[str, Any] = {'_type_': BaseCType.char, '_count_': count}
     return type('AnonymousCCharArray', (CCharArray,), fields)
 
 
@@ -1422,8 +1492,7 @@ def mk_anonymous_cstruct(
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
-        >>> mk_anonymous_cstruct([('aaa', c_int)])()
+        >>> mk_anonymous_cstruct([('aaa', BaseCType.int)])()
         {
           +0x0 aaa = 0x0,
         }
@@ -1437,8 +1506,7 @@ def mk_anonymous_cunion(fields: list[tuple[str, CType]]) -> type[CUnion]:
 
     Examples:
         >>> from pwnlib.util.c_primitives import *
-        >>> from ctypes import *
-        >>> mk_anonymous_cunion([('x', c_int), ('y', c_char)])()
+        >>> mk_anonymous_cunion([('x', BaseCType.int), ('y', BaseCType.char)])()
         {
           x = 0x0,
           y = 0x0,


### PR DESCRIPTION
This patch is a part of #2442 (though it will be superseded later). The new module `c_primitives` allow developer to create composite C data types painlessly. Multiple features will be enabled once the base class is inherited. The only thing to do is fill out fields, and then add some type hints.

Please point out my doc string spelling error if you spot any incorrect word.
