### PR TITLE
patched safeeval _const_codes outdated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2609][2609] Fix log level of child remotes of `server` tube
 - [#2612][2612] Fix lookup of binutils for `mipsel` architecture
 - [#2624][2624] Fix regression: gdbserver can't handle command-line argument containing whitespace
+- [#2744][2744] Fix Python 3.14+ breaks ssh process tubes because of new bytecode
 
 [2508]: https://github.com/Gallopsled/pwntools/pull/2508
 [2471]: https://github.com/Gallopsled/pwntools/pull/2471
@@ -202,6 +203,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2609]: https://github.com/Gallopsled/pwntools/pull/2609
 [2612]: https://github.com/Gallopsled/pwntools/pull/2612
 [2624]: https://github.com/Gallopsled/pwntools/pull/2624
+[2744]: https://github.com/Gallopsled/pwntools/pull/2745
 
 ## 4.14.1
 

--- a/pwnlib/util/safeeval.py
+++ b/pwnlib/util/safeeval.py
@@ -6,7 +6,7 @@ _const_codes = [
     'BUILD_CONST_KEY_MAP', 'BUILD_STRING',
     'LOAD_CONST','RETURN_VALUE','STORE_SUBSCR', 'STORE_MAP',
     'LIST_TO_TUPLE', 'LIST_EXTEND', 'SET_UPDATE', 'DICT_UPDATE', 'DICT_MERGE',
-    'COPY', 'RESUME', 'RETURN_CONST'
+    'COPY', 'RESUME', 'RETURN_CONST', 'LOAD_SMALL_INT'
     ]
 
 _expr_codes = _const_codes + [


### PR DESCRIPTION
Fix Python 3.14+ breaks ssh process tubes because of new bytecode
Issue : https://github.com/Gallopsled/pwntools/issues/2744