### PR TITLE
fix(ssh): preserve ANSI escape codes in interactive mode (closes #2703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The table below shows which release corresponds to each branch, and what date th
 | [2.2.0](#220)    |          | Jan 5, 2015
 
 ## 5.0.0 (`dev`)
-
+- [#2747][2747] fix(ssh): preserve ANSI escape codes in interactive mode (closes #2703)
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
 - [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
 - [#2725][2725] feat(libcdb): add extra_mirrors arg + PWNLIB_EXTRA_LIBC_MIRRORS env to download_libraries
@@ -138,6 +138,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2730][2730] Fix atexception handlers in term mode
 - [#2733][2733] loongarch64: fix incorrect mov assembly template
 
+[2747]: https://github.com/Gallopsled/pwntools/pull/2747
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
 [2638]: https://github.com/Gallopsled/pwntools/pull/2638

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -232,9 +232,8 @@ class ssh_channel(sock):
                     elif cur == b'\a':
                         # Ugly hack until term unstands bell characters
                         continue
-                    stdout = sys.stdout
-                    if not term.term_mode:
-                        stdout = getattr(stdout, 'buffer', stdout)
+
+                    stdout = getattr(sys.stdout, 'buffer', sys.stdout)
                     stdout.write(cur)
                     stdout.flush()
                 except EOFError:


### PR DESCRIPTION
When using `ssh.interactive()`, ANSI escape codes are displayed literally 
(e.g., `\x1b[31m`) instead of being interpreted as colors.

In `ssh_channel.interactive()`, the condition to use the binary stdout buffer 
was inverted:
- When `term_mode=True` (terminal mode), it uses `sys.stdout`
- When `term_mode=False`, it uses `sys.stdout.buffer`

`sys.stdout` escapes ANSI escape codes, preventing the terminal from 
interpreting them correctly. This change always uses `sys.stdout.buffer` 
to preserve the escape sequences.

Fixes #2703