### PR TITLE
fix: Fix DeprecationWarning when setting ssl=True in remote()

### DIFF
--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -98,7 +98,7 @@ class remote(sock):
                 ssl_args = ssl_args or {}
                 if "server_hostname" in ssl_args and sni:
                     log.error("sni and server_hostname cannot be set at the same time")
-                ssl_context = ssl_context or _ssl.SSLContext(_ssl.PROTOCOL_TLSv1_2)
+                ssl_context = ssl_context or _ssl.SSLContext(_ssl.PROTOCOL_TLS_CLIENT)
                 if isinstance(sni, str):
                     ssl_args["server_hostname"] = sni
                 elif sni:


### PR DESCRIPTION
The current code initializes SSLContext with `ssl.PROTOCOL_TLSv1_2`, which has been deprecated since Python 3.6

This should be the correct fix, according to the documentation (https://docs.python.org/3/library/ssl.html#ssl.SSLContext)

A possible issue is breakage on Python versions older than 3.6, but that shouldn't be a problem according to the README (which lists Python 3.10+)

--- 
# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.blog/news-insights/product-news/change-the-base-branch-of-a-pull-request/

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
