### PR TITLE
Fix libcdb CI cache not forwarding URI path

### DIFF
--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -117,6 +117,7 @@ def query_libc_rip(params):
 
     url = f"{LIBC_RIP_URL}/api/find"
     try:
+        log.debug("Querying libc.rip at %s with parameters: %s", url, params)
         result = requests.post(url, json=params, timeout=20)
         result.raise_for_status()
         if result.status_code != 200:

--- a/travis/libcdb_nginx_cache.conf
+++ b/travis/libcdb_nginx_cache.conf
@@ -27,7 +27,7 @@ http {
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://$upstream_host/;
+            proxy_pass https://$upstream_host$request_uri;
         }
     }
 
@@ -44,7 +44,7 @@ http {
             proxy_cache_key $scheme://$host$uri$is_args$query_string$request_body;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://$upstream_host/;
+            proxy_pass https://$upstream_host$request_uri;
         }
     }
 
@@ -59,7 +59,7 @@ http {
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass http://$upstream_host/;
+            proxy_pass http://$upstream_host$request_uri;
         }
     }
 
@@ -76,7 +76,7 @@ http {
             proxy_cache_valid 200 404 12w;
             proxy_ignore_headers Cache-Control Set-Cookie;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://$upstream_host/;
+            proxy_pass https://$upstream_host$request_uri;
         }
     }
 
@@ -92,7 +92,7 @@ http {
             proxy_cache_key $scheme://$host$uri$is_args$query_string;
             proxy_cache_valid 200 404 12w;
             proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504 http_429;
-            proxy_pass https://$upstream_host/;
+            proxy_pass https://$upstream_host$request_uri;
         }
     }
 }


### PR DESCRIPTION
The nginx docs say that you have to specify the $request_uri manually when a variable is used in the `proxy_pass` value. Since we just put `/` at the end, all requests were rewritten to `/` instead of the intended e.g. `/api/find` endpoints.

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass

This broke in #2718 but didn't manifest right away since the responses were still cached in CI. Now after the cache expired the fetch failed.
