### PR TITLE
fix: Fix DeprecationWarning when setting ssl=True in remote()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2730][2730] Fix atexception handlers in term mode
 - [#2733][2733] loongarch64: fix incorrect mov assembly template
 - [#2746][2746] elf: point people at libc_start_main_return when they look up __libc_start_main_ret
+- [#2750][2750] fix: Fix DeprecationWarning when setting ssl=True in remote()
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -201,6 +202,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2739]: https://github.com/Gallopsled/pwntools/pull/2739
 [2740]: https://github.com/Gallopsled/pwntools/pull/2740
 [2746]: https://github.com/Gallopsled/pwntools/pull/2746
+[2750]: https://github.com/Gallopsled/pwntools/pull/2750
 
 ## 4.15.1
 

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -95,7 +95,7 @@ class remote(sock):
                 ssl_args = ssl_args or {}
                 if "server_hostname" in ssl_args and sni:
                     log.error("sni and server_hostname cannot be set at the same time")
-                ssl_context = ssl_context or _ssl.SSLContext(_ssl.PROTOCOL_TLSv1_2)
+                ssl_context = ssl_context or _ssl.SSLContext(_ssl.PROTOCOL_TLS_CLIENT)
                 if isinstance(sni, str):
                     ssl_args["server_hostname"] = sni
                 elif sni:

--- a/pwnlib/tubes/remote.py
+++ b/pwnlib/tubes/remote.py
@@ -57,6 +57,17 @@ class remote(sock):
         >>> r = remote.fromsocket(s) #doctest: +SKIP
         >>> r.recvn(4) #doctest: +SKIP
         b'HTTP'
+        
+        To disable certificate verification, pass in a custom ssl_context:
+
+        >>> import ssl
+        >>> ssl_context = ssl.create_default_context()
+        >>> ssl_context.check_hostname = False
+        >>> ssl_context.verify_mode = ssl.CERT_NONE
+        >>> r = remote('self-signed.badssl.com', 443, ssl=True, ssl_context=ssl_context)
+        >>> r.send(b"GET / HTTP/1.1\r\nHost: self-signed.badssl.com\r\n\r\n")
+        >>> r.recvn(4)
+        b'HTTP'
     """
 
     def __init__(self, host, port,
@@ -95,7 +106,7 @@ class remote(sock):
                 ssl_args = ssl_args or {}
                 if "server_hostname" in ssl_args and sni:
                     log.error("sni and server_hostname cannot be set at the same time")
-                ssl_context = ssl_context or _ssl.SSLContext(_ssl.PROTOCOL_TLS_CLIENT)
+                ssl_context = ssl_context or _ssl.create_default_context()
                 if isinstance(sni, str):
                     ssl_args["server_hostname"] = sni
                 elif sni:


### PR DESCRIPTION
The current code initializes SSLContext with ssl.PROTOCOL_TLSv1_2, which has been deprecated since Python 3.6

This should be the correct fix, according to the documentation (https://docs.python.org/3/library/ssl.html#ssl.SSLContext)

New PR against the dev branch, following the maintainer notes left in #2748 

---

# Pwntools Pull Request

Thanks for contributing to Pwntools!  Take a moment to look at [`CONTRIBUTING.md`][contributing] to make sure you're familiar with Pwntools development.

Please provide a high-level explanation of what this pull request is for.

## Testing

Pull Requests that introduce new code should try to add doctests for that code.  See [`TESTING.md`][testing] for more information.

## Target Branch

Depending on what the PR is for, it needs to target a different branch.

You can always [change the branch][change] after you create the PR if it's against the wrong branch.

| Branch   | Type of PR                                                       |
| -------- | ---------------------------------------------------------------- |
| `dev`    | New features, and enhancements
| `dev`    | Documentation fixes and new tests
| `stable` | Bug fixes that affect the current `stable` branch
| `beta`   | Bug fixes that affect the current `beta` branch, but not `stable`
| `dev`    | Bug fixes for code that has never been released

[contributing]: https://github.com/Gallopsled/pwntools/blob/dev/CONTRIBUTING.md
[testing]: https://github.com/Gallopsled/pwntools/blob/dev/TESTING.md
[change]: https://github.blog/news-insights/product-news/change-the-base-branch-of-a-pull-request/

## Changelog

After creating your Pull Request, please add and push a commit that updates the changelog for the appropriate branch.  
You can look at the existing changelog for examples of how to do this.
