### PR TITLE
docs(args): clarify reserved args (DEBUG/NOASLR) map to context, not args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2753][2753] docs(args): clarify reserved args (DEBUG/NOASLR) map to context, not args
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
 - [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
 - [#2725][2725] feat(libcdb): add extra_mirrors arg + PWNLIB_EXTRA_LIBC_MIRRORS env to download_libraries
@@ -209,6 +210,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2746]: https://github.com/Gallopsled/pwntools/pull/2746
 [2734]: https://github.com/Gallopsled/pwntools/pull/2734
 [2735]: https://github.com/Gallopsled/pwntools/pull/2735
+[2753]: https://github.com/Gallopsled/pwntools/pull/2753
 
 ## 4.15.1
 

--- a/pwnlib/args.py
+++ b/pwnlib/args.py
@@ -17,7 +17,10 @@ The easiest example is to enable more verbose debugging.  Just set ``DEBUG``.
 These arguments are automatically extracted, regardless of their name, and
 exposed via :mod:`pwnlib.args.args`, which is exposed as the global variable
 :data:`args`.  Arguments which ``pwntools`` reserves internally are not exposed
-this way.
+this way.  These reserved arguments (such as ``DEBUG`` and ``NOASLR``) instead
+adjust :data:`pwnlib.context.context`, so their effect is read from ``context``
+(e.g. ``context.log_level``, ``context.aslr``) rather than from ``args`` --
+``args.NOASLR`` is always the empty string.
 
 .. code-block:: bash
 

--- a/pwnlib/data/templates/pwnup.mako
+++ b/pwnlib/data/templates/pwnup.mako
@@ -53,9 +53,12 @@ exe = ${binary_repr}
 %endif
 
 %if not quiet:
-# Many built-in settings can be controlled on the command-line and show up
-# in "args".  For example, to dump all data sent/received, and disable ASLR
-# for all created processes...
+# Many built-in settings can be controlled on the command-line.  Reserved
+# "magic arguments" such as DEBUG and NOASLR adjust pwntools' behavior via
+# "context" (e.g. context.log_level, context.aslr) and are NOT stored in
+# "args"; other arguments (HOST, PORT, EXE, ...) show up in "args".  For
+# example, to dump all data sent/received, and disable ASLR for all created
+# processes...
 # ./exploit.py DEBUG NOASLR
 %if host or port or user:
 # ./exploit.py GDB HOST=example.com PORT=4141 EXE=/tmp/executable


### PR DESCRIPTION
## Summary

As reported in #2564, users try to check `args.NOASLR` and find it is always empty. The root cause is a documentation gap: reserved "magic arguments" like `DEBUG` and `NOASLR` are consumed as hooks in `pwnlib/args.py` that adjust `context` (`context.log_level`, `context.aslr`). They are never stored in the `args` dict, so `args.NOASLR` always evaluates to the empty string.

The generated `pwnup` exploit template — the first thing most users see — reinforced the wrong mental model by commenting that these settings "show up in args". This PR corrects that comment and adds a matching clarification to the `pwnlib.args` module docstring.

Fixes #2564

## Changes

- `pwnlib/data/templates/pwnup.mako`: reword the command-line-arguments comment so it distinguishes reserved arguments (DEBUG/NOASLR → `context`) from arguments that actually appear in `args` (HOST, PORT, EXE, ...).
- `pwnlib/args.py`: extend the module docstring to state that reserved arguments adjust `context` and that their effect is read from `context` (e.g. `context.aslr`), not `args`.