### PR TITLE
fix(srop): correct amd64 SigreturnFrame uc_sigmask offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2762][2762] fix(srop): correct amd64 SigreturnFrame `uc_sigmask` offset
 - [#2753][2753] docs(args): clarify reserved args (DEBUG/NOASLR) map to context, not args
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
 - [#2739][2739] shellcraft: migrate lazy importer to find_spec for Python 3.12+
@@ -211,6 +212,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2734]: https://github.com/Gallopsled/pwntools/pull/2734
 [2735]: https://github.com/Gallopsled/pwntools/pull/2735
 [2753]: https://github.com/Gallopsled/pwntools/pull/2753
+[2762]: https://github.com/Gallopsled/pwntools/pull/2762
 
 ## 4.15.1
 

--- a/pwnlib/rop/srop.py
+++ b/pwnlib/rop/srop.py
@@ -181,7 +181,7 @@ registers = {
                   80: 'r13', 88: 'r14', 96: 'r15', 104: 'rdi', 112: 'rsi', 120: 'rbp', 128: 'rbx',
                   136: 'rdx', 144: 'rax', 152: 'rcx', 160: 'rsp', 168: 'rip', 176: 'eflags',
                   184: 'csgsfs', 192: 'err', 200: 'trapno', 208: 'oldmask', 216: 'cr2',
-                  224: '&fpstate', 232: '__reserved', 240: 'sigmask'},
+                  224: '&fpstate', 232: '__reserved', 296: 'sigmask'},
 # Reference : http://lxr.free-electrons.com/source/arch/arm/include/uapi/asm/sigcontext.h#L15
         'arm' : {0: 'uc_flags', 4: 'uc_link', 8: 'uc_stack.ss_sp', 12: 'uc_stack.ss_flags',
                  16: 'uc_stack.ss_size', 20: 'trap_no', 24: 'error_code', 28: 'oldmask', 32: 'r0',
@@ -266,15 +266,15 @@ class SigreturnFrame(dict):
         >>> context.clear(arch='amd64')
         >>> s = SigreturnFrame()
         >>> unpack_many(bytes(s))
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 51, 0, 0, 0, 0, 0, 0, 0]
-        >>> assert len(s) == 248
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        >>> assert len(s) == 304
         >>> s.rax = 0xa
         >>> s.rdi = 0x00601000
         >>> s.rsi = 0x1000
         >>> s.rdx = 0x7
-        >>> assert len(bytes(s)) == 248
+        >>> assert len(bytes(s)) == 304
         >>> unpack_many(bytes(s))
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6295552, 4096, 0, 0, 7, 10, 0, 0, 0, 0, 51, 0, 0, 0, 0, 0, 0, 0]
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6295552, 4096, 0, 0, 7, 10, 0, 0, 0, 0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
         Crafting a SigreturnFrame that calls mprotect on i386
 


### PR DESCRIPTION
The amd64 `SigreturnFrame` placed `uc_sigmask` at offset 240, which is 56 bytes too early.

In the amd64 signal frame, `uc_sigmask` follows `uc_mcontext` (a `struct sigcontext`), which ends with `__reserved[8]` — an array of eight `__u64`, i.e. 64 bytes, starting at offset 232. The old map treated `__reserved` as a single 8-byte field and put `sigmask` at 232 + 8 = 240, landing in the middle of the reserved area. The array is 64 bytes, so `uc_sigmask` actually belongs at 232 + 64 = 296. This also grows the frame from 248 to 304 bytes. The layout matches `struct sigcontext` / `struct ucontext` in arch/x86/include/uapi/asm/sigcontext.h.

Only amd64 is affected — i386 has no such reserved array (its frame is unchanged) and the other architectures use different structures. The amd64 doctest in the `SigreturnFrame` docstring is updated to reflect the 304-byte frame.

Fixes #2439.
