### PR TITLE
fix(context): bits/endian stop following arch after a second switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2764][2764] fix(context): bits/endian stop following arch after a second switch
 - [#2762][2762] fix(srop): correct amd64 SigreturnFrame `uc_sigmask` offset
 - [#2753][2753] docs(args): clarify reserved args (DEBUG/NOASLR) map to context, not args
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
@@ -212,6 +213,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2734]: https://github.com/Gallopsled/pwntools/pull/2734
 [2735]: https://github.com/Gallopsled/pwntools/pull/2735
 [2753]: https://github.com/Gallopsled/pwntools/pull/2753
+[2764]: https://github.com/Gallopsled/pwntools/pull/2764
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
 
 ## 4.15.1

--- a/pwnlib/context/__init__.py
+++ b/pwnlib/context/__init__.py
@@ -155,7 +155,11 @@ def _validator(validator):
     of the classes here.
 
     This expects that the object has a ._tls property which
-    is of type _DictStack.
+    is of type _DictStack, and a ._tls_explicit property of
+    the same type used to track which attributes were set
+    directly by a user versus implicitly (e.g. ``bits`` and
+    ``endian`` being derived from ``arch``). See the ``arch``
+    setter for where this distinction is used.
     """
 
     name = validator.__name__
@@ -166,9 +170,11 @@ def _validator(validator):
 
     def fset(self, val):
         self._tls[name] = validator(self, val)
+        self._tls_explicit[name] = True
 
     def fdel(self):
         self._tls._current.pop(name,None)
+        self._tls_explicit._current.pop(name,None)
 
     return property(fget, fset, fdel, doc)
 
@@ -333,7 +339,7 @@ class ContextType:
     # Setting any properties on a ContextType object will throw an
     # exception.
     #
-    __slots__ = '_tls',
+    __slots__ = '_tls', '_tls_explicit'
 
     #: Default values for :class:`pwnlib.context.ContextType`
     defaults: dict[str, object] = {
@@ -460,6 +466,12 @@ class ContextType:
         All keyword arguments are passed to :func:`update`.
         """
         self._tls = _Tls_DictStack(_defaultdict(self.defaults))
+        # Tracks which attribute names were set directly by a user (via the
+        # property setters, i.e. going through _validator's fset) as opposed
+        # to being derived as a side effect of another attribute (e.g. `bits`
+        # and `endian` being filled in from `arch`'s defaults). Only
+        # directly-set values should survive a later change to `arch`/`os`.
+        self._tls_explicit = _Tls_DictStack(_defaultdict({}))
         self.update(**kwargs)
 
 
@@ -553,11 +565,13 @@ class ContextType:
         class LocalContext:
             def __enter__(a):
                 self._tls.push()
+                self._tls_explicit.push()
                 self.update(**{k:v for k,v in kwargs.items() if v is not None})
                 return self
 
             def __exit__(a, *b, **c):
                 self._tls.pop()
+                self._tls_explicit.pop()
 
             def __call__(self, function, *a, **kw):
                 @functools.wraps(function)
@@ -699,6 +713,7 @@ class ContextType:
             True
         """
         self._tls._current.clear()
+        self._tls_explicit._current.clear()
 
         if a or kw:
             self.update(*a, **kw)
@@ -781,6 +796,20 @@ class ContextType:
             >>> context.arch = 'powerpc64'
             >>> vars(context) == {'arch': 'powerpc64', 'bits': 64, 'endian': 'big'}
             True
+
+            Switching :attr:`arch` back and forth keeps applying each
+            new architecture's defaults for :attr:`bits`, as long as
+            :attr:`bits` was never expressly set by the user (i.e. the
+            value in place is only there because of a *previous*
+            :attr:`arch` assignment, not a real user choice)
+
+            >>> context.clear()
+            >>> context.arch = 'amd64'
+            >>> context.bits == 64
+            True
+            >>> context.arch = 'i386'
+            >>> context.bits == 32
+            True
         """
         # Lowercase
         arch = arch.lower()
@@ -811,7 +840,12 @@ class ContextType:
             raise AttributeError('AttributeError: arch (%r) must be one of %r' % (arch, sorted(self.architectures)))
 
         for k,v in defaults.items():
-            if k not in self._tls:
+            # Only keep the existing value if the user set it directly
+            # (e.g. via `context.bits = ...`) rather than it having been
+            # filled in by a *previous* `arch` assignment - otherwise
+            # switching arch back and forth can leave stale, invalid
+            # combinations in place (see #2498).
+            if k not in self._tls_explicit:
                 self._tls[k] = v
 
         return arch


### PR DESCRIPTION
Fixes #2498.

Repro from the issue: set `arch` to `amd64` then back to `i386`, and `bits` stays at 64 — assembling anything after that blows up with `Invalid arch/bits combination: i386/64`. The `arch` setter's cascade check (`if k not in self._tls`) can't tell "user explicitly set bits" apart from "bits only has a value because a *previous* arch assignment put it there".

Went with the fix @peace-maker sketched out in the issue thread: track which attributes were set directly by the user (a new `_tls_explicit` dict-stack, mirroring `_tls`) and only skip the `arch`→`bits`/`endian` cascade for those. Also had to add `_tls_explicit` to `__slots__`, since `ContextType` doesn't allow arbitrary attributes.

## What I checked
- `context.local()`, `context.clear()`, and `Thread` context inheritance all push/pop/reset this new tracking in lockstep with the existing `_tls` — manually reproduced all three scenarios, since none of pwntools' existing doctests exercise them together with a second `arch` switch.
- Added a doctest matching the issue's exact repro, right next to the existing bits/arch examples in the `arch` setter's docstring.
- Ran the full `context.rst` doctest suite before and after my change — same 8 pre-existing failures both times (all environmental: my local macOS box is missing the cross-arch binutils packages CI installs, and macOS's `/bin/bash` isn't an ELF file — `TESTING.md` already says Ubuntu is the expected environment for this).
- `mypy | mypy-baseline filter` — 0 new issues.

## One thing worth flagging
`os`'s setter has the exact same cascade bug for its own defaults (e.g. `newline`) — same root cause, just never got reported. Left it alone since the issue didn't ask for it and I didn't want to grow this PR unasked; happy to open a separate issue/PR for it if you'd rather have it fixed too.

## Branch
Opened against `dev` since that's where I developed and tested this. I confirmed the identical cascade bug also exists on `stable`/`beta` (same code there) — let me know if you'd like this backported and I'll open that PR too, since `dev` has diverged enough from `stable` (type hints, Python 2 compat removed) that I didn't want to guess at a port without it being reviewed first.

Changelog commit to follow once this has a PR number, per CONTRIBUTING.md.