### PR TITLE
fix(ssh): don't parse a unix socket path as a (host, port) pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2765][2765] fix(ssh): don't parse a unix socket path as a `(host, port)` pair
 - [#2762][2762] fix(srop): correct amd64 SigreturnFrame `uc_sigmask` offset
 - [#2753][2753] docs(args): clarify reserved args (DEBUG/NOASLR) map to context, not args
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
@@ -212,6 +213,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2734]: https://github.com/Gallopsled/pwntools/pull/2734
 [2735]: https://github.com/Gallopsled/pwntools/pull/2735
 [2753]: https://github.com/Gallopsled/pwntools/pull/2753
+[2765]: https://github.com/Gallopsled/pwntools/pull/2765
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
 
 ## 4.15.1

--- a/docs/source/tubes/ssh.rst
+++ b/docs/source/tubes/ssh.rst
@@ -27,3 +27,5 @@
 
    .. autoclass:: pwnlib.tubes.ssh.ssh_listener()
       :show-inheritance:
+
+   .. autofunction:: pwnlib.tubes.ssh._sockname_to_endpoint

--- a/pwnlib/tubes/ssh.py
+++ b/pwnlib/tubes/ssh.py
@@ -33,6 +33,50 @@ h = logging.StreamHandler(open(os.devnull,'w+'))
 h.setFormatter(logging.Formatter())
 paramiko_log.addHandler(h)
 
+
+def _sockname_to_endpoint(sockname):
+    """Split the result of ``socket.getsockname()`` into a ``(host, port)`` pair.
+
+    ``AF_INET``/``AF_INET6`` sockets report their address as a tuple, but
+    ``AF_UNIX`` sockets report a bare filesystem path instead: a ``str``
+    (``bytes`` for Linux's abstract namespace), and ``''`` when the socket is
+    unbound.  Indexing that path as though it were a tuple silently yields
+    single characters, or raises ``IndexError`` for the unbound case, so a
+    Unix socket reports its path as the host and ``None`` as the port.
+
+    Arguments:
+        sockname: Return value of :meth:`socket.socket.getsockname`.
+
+    Returns:
+        A ``(host, port)`` tuple.  ``port`` is ``None`` for ``AF_UNIX``.
+
+    Examples:
+
+        An ordinary TCP socket reports a host and a port.
+
+        >>> pwnlib.tubes.ssh._sockname_to_endpoint(('127.0.0.1', 1337))
+        ('127.0.0.1', 1337)
+
+        ``AF_INET6`` reports two extra fields, which are discarded.
+
+        >>> pwnlib.tubes.ssh._sockname_to_endpoint(('::1', 1337, 0, 0))
+        ('::1', 1337)
+
+        A Unix socket has a path rather than a host and port.
+
+        >>> pwnlib.tubes.ssh._sockname_to_endpoint('/tmp/example.sock')
+        ('/tmp/example.sock', None)
+
+        An unbound Unix socket reports an empty path.
+
+        >>> pwnlib.tubes.ssh._sockname_to_endpoint('')
+        ('', None)
+    """
+    if isinstance(sockname, tuple):
+        return sockname[0], sockname[1]
+    return sockname, None
+
+
 class ssh_channel(sock):
 
     #: Parent :class:`ssh` object
@@ -484,8 +528,7 @@ class ssh_connecter(sock):
                     curr = curr.get_transport().sock
 
                 sockname = curr.getsockname()
-                self.lhost = sockname[0]
-                self.lport = sockname[1]
+                self.lhost, self.lport = _sockname_to_endpoint(sockname)
             except Exception as e:
                 self.exception("Could not find base-level Socket object.")
                 raise e


### PR DESCRIPTION
Fixes #1988.

`ssh_connecter` walks down through the proxy layers to the base socket and then indexes `getsockname()` as an `(host, port)` tuple. For an `AF_UNIX` socket that's a plain path string instead, so it breaks in two ways:

```python
>>> import socket, tempfile, os
>>> s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
>>> s.getsockname()          # unbound
''
>>> s.getsockname()[0]
IndexError: string index out of range

>>> s.bind('/tmp/example.sock')
>>> s.getsockname()
'/tmp/example.sock'
>>> s.getsockname()[0], s.getsockname()[1]
('/', 't')
```

The `IndexError` is the one in the report — and it gets swallowed by the surrounding `except Exception` and re-raised as `"Could not find base-level Socket object."`, which is misleading since the socket was found just fine.

The **named** case is the one I think is worse and it isn't in the report; I only spotted it poking at `getsockname()` directly. There's no exception at all, you just quietly end up with `lhost='/'` and `lport='t'` — a one-character string where an `int` is expected.

@peace-maker you'd asked on the issue for a test case that demonstrates it. The doctest added here is that, minus the SSH server: the path from `proxy_sock` to the crash is just `getsockname()` returning a `str`, so I pulled the parsing into `_sockname_to_endpoint()` and tested it directly against the real return values. Everything else in `ssh_connecter.__init__` needs a live SSH connection, and since pwntools tests through doctests there was no way to cover this otherwise.

Unix sockets now report the path as `lhost` and `None` as `lport`.

## What I checked
- `tubes/ssh` doctests go **168 → 172 tests, 12 → 16 passing**; the 156 failures are unchanged and all pre-existing (they want the `example.pwnme` fixture, which I don't have locally on macOS).
- I had to add one `autofunction` line to `docs/source/tubes/ssh.rst` — that file's `automodule` has no `:members:`, so module-level functions never get rendered and sphinx doesn't collect their doctests. I checked this by diffing the test counts before/after; without that line the count stayed at 168 and my test silently wasn't running.
- `flake8 --select=E9,F63,F7,E71` clean, `mypy | mypy-baseline filter` → `new: 0`, `vermin -t=3.10-` still reports 3.6.
- Left `remote.py` / `listen.py` alone — they do the same `[:2]` indexing but always construct their own `AF_INET`/`AF_INET6` sockets, so they can't reach this.

## Branch
Against `dev`. The same three lines are identical on `stable` and `beta` (both at 462-464), so this is backportable if you want it — happy to open those PRs, just didn't want to assume.

Related: #1787 is the other half of the `proxy_sock` report. That one's about an `AuthenticationException` with a *TCP* proxy socket and someone commented they couldn't reproduce it on current `dev`, so I've deliberately left it alone rather than lump them together.