### PR TITLE
Support paginated libc.rip API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2746][2746] elf: point people at libc_start_main_return when they look up __libc_start_main_ret
 - [#2734][2734] ROP: Add labels to reference addresses relative to your chain
 - [#2735][2735] Add support for debugging with x64dbg on Windows
+- [#2767][2767] Support paginated libc.rip API requests to include all search results
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -213,6 +214,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2735]: https://github.com/Gallopsled/pwntools/pull/2735
 [2753]: https://github.com/Gallopsled/pwntools/pull/2753
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
+[2767]: https://github.com/Gallopsled/pwntools/pull/2767
 
 ## 4.15.1
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -116,17 +116,32 @@ def query_libc_rip(params):
     import requests
 
     url = f"{LIBC_RIP_URL}/api/find"
-    try:
-        log.debug("Querying libc.rip at %s with parameters: %s", url, params)
-        result = requests.post(url, json=params, timeout=20)
-        result.raise_for_status()
-        if result.status_code != 200:
-            log.debug("Error: %s", result.text)
+    # Handle pagination transparently and fetch all results
+    offset = 0
+    count = 1
+    results = []
+    while offset < count:
+        try:
+            pagination_params = {'offset': offset, 'limit': 100}
+            log.debug("Querying libc.rip at %s (pagination %s) with parameters: %s", url, pagination_params, params)
+            result = requests.post(url, params=pagination_params, json=params, timeout=20)
+            result.raise_for_status()
+            if result.status_code != 200:
+                log.debug("Error: %s", result.text)
+                return None
+            imm_results = result.json()
+            # non-paginated result. old libc-database API?
+            if not isinstance(imm_results, dict):
+                return imm_results
+            results.extend(imm_results.get('results', []))
+            count = imm_results.get('total', 0)
+            offset += imm_results['count']
+            if not imm_results['has_more']:
+                break
+        except requests.RequestException as e:
+            log.warn_once("Failed to fetch libc info from libc.rip: %s", e)
             return None
-        return result.json()
-    except requests.RequestException as e:
-        log.warn_once("Failed to fetch libc info from libc.rip: %s", e)
-        return None
+    return results
 
 # https://libc.rip/
 def provider_libc_rip(search_target, search_type):


### PR DESCRIPTION
libc.rip used to truncate the result set but supports pagination now. Fetch all results reliably now by requesting all pages.

Fixes #2651