### PR TITLE
Added the homebrew workaround in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The table below shows which release corresponds to each branch, and what date th
 
 ## 5.0.0 (`dev`)
 
+- [#2768][2768] docs: Added the homebrew workaround in documentation needed for macOS users
 - [#2762][2762] fix(srop): correct amd64 SigreturnFrame `uc_sigmask` offset
 - [#2753][2753] docs(args): clarify reserved args (DEBUG/NOASLR) map to context, not args
 - [#2740][2740] setup: install docs to FHS-compliant share/doc/pwntools
@@ -219,6 +220,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
 [2767]: https://github.com/Gallopsled/pwntools/pull/2767
 [2726]: https://github.com/Gallopsled/pwntools/pull/2726
+[2768]: https://github.com/Gallopsled/pwntools/pull/2768
 
 ## 4.15.1
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,6 +17,11 @@ following system libraries installed.
 
 
 Note: For Mac OS X you will need to have cmake ``brew install cmake`` and pkg-config ``brew install pkg-config`` installed.
+Note: The pwntools/pwntools Homebrew tap is undergoing migration, hence for Mac OS you will have to set ``HOMEBREW_DEVELOPER="true"`` before installing the dependencies. The exact workaround is as follows. The actual resolution of the tap migration is still pending.
+
+.. code-block:: bash
+
+    HOMEBREW_DEVELOPER=true brew install pwntools
 
 Released Version
 -----------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,7 +17,10 @@ following system libraries installed.
 
 
 Note: For Mac OS X you will need to have cmake ``brew install cmake`` and pkg-config ``brew install pkg-config`` installed.
-Note: The pwntools/pwntools Homebrew tap is undergoing migration, hence for Mac OS you will have to set ``HOMEBREW_DEVELOPER="true"`` before installing the dependencies. The exact workaround is as follows. The actual resolution of the tap migration is still pending.
+Note: The pwntools/pwntools Homebrew tap is currently (August 2026) undergoing migration.
+If you encounter issues on Mac OS, try setting ``HOMEBREW_DEVELOPER="true"`` before installing the dependencies.
+The exact workaround is as follows. The actual resolution of the tap migration is still pending.
+If everything goes well, you can omit this variable.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Addresses #2672 

The pwntools/pwntools Homebrew tap is currently undergoing migration, causing installation failures on macOS. This PR documents the temporary `HOMEBREW_DEVELOPER=true` workaround in the installation docs.
Note: I don't have Mac access myself (as mentioned in earlier discussions as well)  the workaround is based on the documented Homebrew behaviour discussed in issue #2672 . Mac end-to-end verification from a university contact is pending approximately 3 weeks. @peace-maker  flagged they also lack Mac access, so merging pending verification is fine if preferred.
Changes are also backed by the discussions on the homebrew repo itself at [this discussion](https://github.com/orgs/Homebrew/discussions/6351)

No new code introduced docs change only.