### PR TITLE
Use compression.zstd (PEP-784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2735][2735] Add support for debugging with x64dbg on Windows
 - [#2767][2767] Support paginated libc.rip API requests to include all search results
 - [#2726][2726] feat(libcdb): use local debuginfod client cache before hitting servers
+- [#2769][2769] Use standard library (PEP-784) for Zstandard decompression
 
 [2675]: https://github.com/Gallopsled/pwntools/pull/2675
 [2652]: https://github.com/Gallopsled/pwntools/pull/2652
@@ -219,6 +220,7 @@ The table below shows which release corresponds to each branch, and what date th
 [2762]: https://github.com/Gallopsled/pwntools/pull/2762
 [2767]: https://github.com/Gallopsled/pwntools/pull/2767
 [2726]: https://github.com/Gallopsled/pwntools/pull/2726
+[2769]: https://github.com/Gallopsled/pwntools/pull/2769
 
 ## 4.15.1
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -510,17 +510,12 @@ def unstrip_libc(filename):
     return True
 
 def _extract_tarfile(cache_dir, data_filename, tarball):
-    from io import BytesIO
-    import tarfile
-    # Handle zstandard compression, since tarfile only supports gz, bz2, and xz.
-    if data_filename.endswith('.zst') or data_filename.endswith('.zstd'):
-        import zstandard
-        dctx = zstandard.ZstdDecompressor()
-        decompressed_tar = BytesIO()
-        dctx.copy_stream(tarball, decompressed_tar)
-        decompressed_tar.seek(0)
-        tarball.close()
-        tarball = decompressed_tar
+    import sys
+    if sys.version_info >= (3, 14):
+        import tarfile
+    else:
+        # for zstandard support in tarfile
+        from backports.zstd import tarfile
 
     with tarfile.open(fileobj=tarball) as tar_file:
         # Find the library folder in the archive (e.g. /lib/x86_64-linux-gnu/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "rpyc",
     "colored_traceback",
     "unix-ar",
-    "zstandard",
+    "backports.zstd>=1.0.0 ; python_version<'3.14'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Python 3.14 introduces support for Zstandard in the standard library via the [`compression.zstd`](https://docs.python.org/3.14/library/compression.zstd.html) module ([PEP-784](https://peps.python.org/pep-0784/)).

Moreover, it brings support for Zstandard into `tarfile`, removing the need for manual handling in the codebase.

Changes in this PR:
 - Remove custom code to handle `.zst` and `.zstd` file extensions via the `zstandard` library before passing the resulting fileobject to `tarfile` module.
 - Remove the `zstdandard` dependency in favor of the native support in Python 3.14+. For older Python versions, the [backport](https://github.com/Rogdham/backports.zstd) is used.

As a bonus, this also avoids loading the whole decompressed tar file into memory (which is done by current implementation).

I have tested this PR by manually importing and calling the `_extract_tarfile` function.

_Full disclosure: I'm the author and maintainer of `backports.zstd`, and the maintainer of `pyzstd` (which code was used as a base for the integration into Python). I also helped with PEP-784 and its integration into CPython. I have made PRs similar to this one in many repositories already._