### PR TITLE
fix(packing): dd() raises TypeError on a bytearray destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,10 +134,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2694][2694] fix: pad bytes fields to correct field size in FileStructure
 - [#2701][2701] Fix `adb._build_date()` crash on devices with non-standard locale date strings
 - [#2721][2721] Allow running with Unicorn 2.1.[34] but throw when emulating MIPS
+- [#2772][2772] fix(packing): `dd()` no longer crashes on a `bytearray` destination
 
 [2694]: https://github.com/Gallopsled/pwntools/pull/2694
 [2701]: https://github.com/Gallopsled/pwntools/pull/2701
 [2721]: https://github.com/Gallopsled/pwntools/pull/2721
+[2772]: https://github.com/Gallopsled/pwntools/pull/2772
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/util/packing.py
+++ b/pwnlib/util/packing.py
@@ -988,6 +988,11 @@ def dd(dst, src, count = 0, skip = 0, seek = 0, truncate = False):
         ('H', 'e', 'l', 'l', 'o', b'?')
         >>> dd(list('Hello!'), (63,), skip = 5)
         ['H', 'e', 'l', 'l', 'o', b'?']
+        >>> buf = bytearray(b'Hello!')
+        >>> dd(buf, b'?', skip = 5)
+        bytearray(b'Hello?')
+        >>> buf
+        bytearray(b'Hello?')
         >>> _ = open('/tmp/foo', 'w').write('A' * 10)
         >>> dd(open('/tmp/foo'), open('/dev/zero'), skip = 3, count = 4).read()
         'AAA\\x00\\x00\\x00\\x00AAA'
@@ -1105,7 +1110,12 @@ def dd(dst, src, count = 0, skip = 0, seek = 0, truncate = False):
         dst = real_dst
 
     elif isinstance(dst, (list, bytearray)):
-        dst[skip : skip + len(src)] = list(map(p8, bytearray(src)))
+        # A bytearray slice takes a byte string, while a list slice takes the
+        # single-byte bytes objects that p8() returns.
+        if isinstance(dst, bytearray):
+            dst[skip : skip + len(src)] = src
+        else:
+            dst[skip : skip + len(src)] = list(map(p8, bytearray(src)))
         if truncate:
             while len(dst) > truncate:
                 dst.pop()


### PR DESCRIPTION
`dd()` lists `bytearray` among its supported destination types, and has an explicit `isinstance(dst, ..., bytearray)` branch for it, but every `bytearray` destination raises `TypeError` on 4.15.0.

```py
>>> from pwn import *
>>> dd(bytearray(b'Hello!'), b'?', skip=5)
Traceback (most recent call last):
  ...
    dst[skip : skip + len(src)] = list(map(p8, bytearray(src)))
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'bytes' object cannot be interpreted as an integer
```

The cause is the shared `list`/`bytearray` branch at https://github.com/Gallopsled/pwntools/blob/7e5e79d00f357e54e7240d54f57e2ceeccafddda/pwnlib/util/packing.py#L1107-L1108, which fills both destination types with `list(map(p8, bytearray(src)))`. `p8()` returns a length-1 `bytes` object, which is exactly what a `list` destination is documented to hold, as the neighbouring `dd(list('Hello!'), (63,), skip = 5)` doctest shows. A `bytearray` slice assignment needs an iterable of `int`, so it rejects those `bytes` objects. The other four destination types all work: `list`, `tuple`, `bytes` and `str` return `['H', 'e', 'l', 'l', 'o', b'?']`, `('H', 'e', 'l', 'l', 'o', b'?')`, `b'Hello?'` and `'Hello?'` respectively.

The fix assigns the byte string `src` directly when the destination is a `bytearray`. Every `src` branch above the destination dispatch, at packing.py:1039-1089, has already reduced `src` to a byte string, so the slice assignment is always valid, and this makes a `bytearray` destination agree with the `bytes` and `str` destinations, which already copy `src` verbatim. `dd(bytearray(b'Hello!'), b'?', skip=5)` now returns `bytearray(b'Hello?')` and updates the caller's buffer in place, which is what the "If `dst` is a mutable type it will be updated" contract in the docstring promises.

## Testing

The new doctest in the `dd()` docstring covers both the returned value and the in-place update. Run the way CI runs it, on the touched module only:

```
$ PWNLIB_NOTERM=1 python -bb -m sphinx -b doctest docs/source docs/build/doctest docs/source/util/packing.rst
71 tests in 1 items.
71 passed and 0 failed.
Test passed.
```

Reverting only the one-line code change and keeping the new doctest gives `69 passed and 2 failed`, with `TypeError: 'bytes' object cannot be interpreted as an integer` on `dd(buf, b'?', skip = 5)` and `bytearray(b'Hello!')` instead of `bytearray(b'Hello?')` on the follow-up check, so the doctest is a real regression test rather than a restatement of the new behaviour.

`flake8 . --count --select=E9,F63,F7,E71 --show-source --statistics --exclude=android-?dk` reports `0`, and `pylint --exit-zero --errors-only pwnlib/util/packing.py -f parseable` produces output identical to `stable` at 7e5e79d, so the PyLint job sees no new errors. Ran on macOS 15 with Python 3.11.9 and Sphinx 8.2.3.

## Target Branch

This targets `stable` because the crash is present in the released 4.15.0 and in `beta` and `dev` as well, which the PR template maps to a `stable` bug fix.
