### PR TITLE
Disable debuginfod doctests in libcdb.unstrip_libc on stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,10 +134,12 @@ The table below shows which release corresponds to each branch, and what date th
 - [#2694][2694] fix: pad bytes fields to correct field size in FileStructure
 - [#2701][2701] Fix `adb._build_date()` crash on devices with non-standard locale date strings
 - [#2721][2721] Allow running with Unicorn 2.1.[34] but throw when emulating MIPS
+- [#2773][2773] Disable debuginfod doctests in libcdb.unstrip_libc
 
 [2694]: https://github.com/Gallopsled/pwntools/pull/2694
 [2701]: https://github.com/Gallopsled/pwntools/pull/2701
 [2721]: https://github.com/Gallopsled/pwntools/pull/2721
+[2773]: https://github.com/Gallopsled/pwntools/pull/2773
 
 ## 4.15.0 (`stable`)
 

--- a/pwnlib/libcdb.py
+++ b/pwnlib/libcdb.py
@@ -354,15 +354,15 @@ def unstrip_libc(filename):
         >>> libc = ELF(filename)
         >>> 'main_arena' in libc.symbols
         False
-        >>> unstrip_libc(filename)
+        >>> unstrip_libc(filename) # doctest: +SKIP
         True
         >>> libc = ELF(filename)
-        >>> hex(libc.symbols.main_arena)
+        >>> hex(libc.symbols.main_arena) # doctest: +SKIP
         '0x219c80'
         >>> unstrip_libc(pwnlib.data.elf.get('test-x86'))
         False
         >>> filename = search_by_build_id('d1704d25fbbb72fa95d517b883131828c0883fe9', unstrip=True)
-        >>> 'main_arena' in ELF(filename).symbols
+        >>> 'main_arena' in ELF(filename).symbols # doctest: +SKIP
         True
     """
     if not which('eu-unstrip'):


### PR DESCRIPTION
This is a cherry-pick of 86cafce19694ccccf01070c362af191179d4f1ad, "Disable debuginfod tests in libcdb.unstrip_libc", from `dev` onto `stable`, with the original author kept on the commit. It marks the three `unstrip_libc` doctest examples that assert the result of a successful debuginfod download with `# doctest: +SKIP` and changes nothing else.

On `stable` those three examples fail on every run. On #2772 the Python 2.7 job reports `unstrip_libc(filename)` returning `False`, `hex(libc.symbols.main_arena)` raising `AttributeError: main_arena` and `'main_arena' in ELF(filename).symbols` returning `False`, and the libcdb document ends at `40 passed and 3 failed`. `dev` has carried this change since July and its `test` matrix is green, most recently run 33740432895 on 2026-09-03 passing on Python 3.10 through 3.14.

## Testing

The changed lines are identical to the `dev` commit and the cherry-pick applied without conflicts. The libcdb document cannot run outside Linux, since `provider_local_system` parses `/bin/sh` as an ELF, so the evidence is CI. With this change, run 34017324597 reports `libcdb: 40 passed and 0 failed` on the Python 2.7 job.

The rest of that run shows what this change does not cover. The 2.7 job still fails 15 gdb examples, 4 elf/corefile examples and the `s.ibt` check in tubes/ssh, none of which failed on #2772's run of the same branch, which in turn failed 2 useragents examples that pass here, so those move between runs. The 3.10 and 3.12 jobs were cancelled by fail-fast after the watchdog in docs/source/conf.py fired inside a libcdb example that downloads through the debuginfod proxy cache, `unstrip_libc(pwnlib.data.elf.get('test-x86'))` on 3.10 and `search_by_build_id('d1704d25fbbb72fa95d517b883131828c0883fe9', unstrip=True)` on 3.12. Those two examples are not skipped on `dev` either, where the cache answers them. This change removes the three deterministic failures and leaves the timeouts, which are a cache and server matter.

## Target Branch

`stable`. `dev` already has the change, so nothing needs to flow forward.

## Changelog

The entry under 4.15.1 is in the second commit, since the changelog check requires one for any change under `pwnlib/`.
